### PR TITLE
Fix: searching algorithms time recording

### DIFF
--- a/src/searching_algorithms/binary_search.c
+++ b/src/searching_algorithms/binary_search.c
@@ -83,11 +83,12 @@ void binary_search_demo(void)
 
         start_t = clock();
         int res = binary_search(arr, target, length_of_array);
+        end_t = clock();
+        total_t = (double)(end_t - start_t) / CLOCKS_PER_SEC;
         printf("\nelement found at index %d.", res);
         if (res == -1)
             printf("\nelement not found in the given array");
-        end_t = clock();
-        total_t = (double)(end_t - start_t) / CLOCKS_PER_SEC;
+            
         printf("\ntotal CPU time taken for binary search:- %f seconds", total_t);
         printf("\n(most probably execution time would be lesser than clock resolution, resulting "
                "in 0.00)");

--- a/src/searching_algorithms/linear_search.c
+++ b/src/searching_algorithms/linear_search.c
@@ -84,11 +84,12 @@ void linear_search_demo(void)
 
         start_t = clock();
         int res = linear_search(arr, target, length_of_array);
+        end_t = clock();
+        total_t = (double)(end_t - start_t) / CLOCKS_PER_SEC;
         printf("the value found at index %d.", res);
         if (res == -1)
             printf("\nthe value is not found in the given array");
-        end_t = clock();
-        total_t = (double)(end_t - start_t) / CLOCKS_PER_SEC;
+
         printf("\ntotal CPU time taken for linear search:- %f seconds", total_t);
         printf("\n(most probably execution time would be lesser than clock resolution, resulting "
                "in 0.00)");


### PR DESCRIPTION
## Summary
Fixes #16

## Changes
- In `linear_search_demo()`, moved `end_t` and `total_t` calculation to immediately after `linear_search()` returns, before any `printf` or `if` statements
- In `binary_search_demo()`, same fix applied to `binary_search()`

## Why
`end_t` was being recorded after the `printf` and `if` statements, meaning print time was being included in the CPU time measurement. Time should only capture the actual search function execution.