### PR TITLE
fix: declare loop variables before labels in tbt.c for C11 standard compatibility

### DIFF
--- a/src/data_structures/tbt.c
+++ b/src/data_structures/tbt.c
@@ -174,8 +174,9 @@ void TBT_demo(void)
 
     for (int i = 0; i < tbt_capacity; i++)
     {
+        int val_status;
     retry_capacity:
-        int val_status = safe_input_int(
+        val_status = safe_input_int(
             &tbt_values[i],
             "\nEnter the value to insert: (between 1 and 100), enter '-1' to exit: ", 1, 100);
 
@@ -193,9 +194,9 @@ void TBT_demo(void)
 
     for (int i = 0; i < tbt_capacity; i++)
     {
-
+        int insert_status;
     retry:
-        int insert_status = insert_node_tbt(&root, tbt_values[i]);
+        insert_status = insert_node_tbt(&root, tbt_values[i]);
 
         switch (insert_status)
         {


### PR DESCRIPTION
This PR fixes a strict C11 compilation error in tbt.c caused by variable declarations (int val_status and int insert_status) immediately following their respective goto labels (retry_capacity: and retry:).

According to standard C11 constraints (and versions prior to C23), a label can only precede a statement, not a declaration. Compilers strictly enforcing this standard (such as Apple Clang on macOS and MinGW on Windows compiling with -std=c11 -Werror) treat this as a compilation failure.
Closes https://github.com/darshan2456/C_DSA_interactive_suite/issues/33