### PR TITLE
fix: change bst_traversal_choice check to bst_traversal_status in bst.c

### DIFF
--- a/src/data_structures/bst.c
+++ b/src/data_structures/bst.c
@@ -247,7 +247,7 @@ void binary_search_tree_Demo(void)
                 destroy_bst(head);
                 break;
             }
-            if (bst_traversal_choice == 0)
+            if (bst_traversal_status == 0)
             {
                 continue;
             }


### PR DESCRIPTION
***
# Description
This PR resolves a logic loop bug in the Binary Search Tree demo. In `binary_search_tree_Demo()`, the traversal selection block checked `bst_traversal_choice == 0` instead of `bst_traversal_status == 0`.

If the user inputted non-numeric characters (like letters) or a value out of the valid 1-4 range, `safe_input_int()` returned a failure status of `0`. However, since the program checked the choice variable rather than the status, it bypassed the error recovery loop and executed whatever stale or uninitialized garbage value was left inside `bst_traversal_choice` on the stack.

## Changes Made
- Modified the validation check at line 250 in `src/data_structures/bst.c` from `if (bst_traversal_choice == 0)` to `if (bst_traversal_status == 0)`.

## Verification
- Compiled and executed the BST unit tests using `make test_bst`.
- Verified that all BST tests pass successfully.
Closes https://github.com/darshan2456/C_DSA_interactive_suite/issues/35