### PR TITLE
feat: Add singly circular linked list with head/tail invariant

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ fmt:
 	find . \( -name "*.c" -o -name "*.h" \) -not -path "*/build/*" | xargs clang-format -i
 
 clean:
-	$(RM) $(TARGET)$(EXE) test_circ_queue$(EXE) test_bst$(EXE) test_search$(EXE) test_hash_func$(EXE) test_sll$(EXE) test_dll$(EXE) test_array$(EXE) test_stack$(EXE) test_tbt$(EXE) test_priority_queue$(EXE)
+	$(RM) $(TARGET)$(EXE) test_circ_queue$(EXE) test_bst$(EXE) test_search$(EXE) test_hash_func$(EXE) test_sll$(EXE) test_dll$(EXE) test_array$(EXE) test_stack$(EXE) test_tbt$(EXE) test_priority_queue$(EXE) test_scll$(EXE)
 
 valgrind:
 	for t in $(TEST_BINS); do \
@@ -103,12 +103,17 @@ TBT_TEST_SRC = \
 	src/utils/safe_input_int.c \
 	src/data_structures/tbt.c \
 	tests/test_tbt.c
-  
+
 PRIORITY_QUEUE_SRC = \
 	src/data_structures/array.c \
 	src/utils/safe_input_int.c \
 	src/data_structures/priority_queue.c \
-	tests/test_priority_queue.c 
+	tests/test_priority_queue.c
+
+SCLL_TEST_SRC = \
+	src/data_structures/scll.c \
+	src/utils/safe_input_int.c \
+	tests/test_scll.c
 
 test_tbt:
 	$(CC) $(CFLAGS) $(TBT_TEST_SRC) -o test_tbt$(EXE)
@@ -150,8 +155,12 @@ test_priority_queue:
 	$(CC) $(CFLAGS) $(PRIORITY_QUEUE_SRC) -o test_priority_queue$(EXE)
 	./test_priority_queue$(EXE)
 
+test_scll:
+	$(CC) $(CFLAGS) $(SCLL_TEST_SRC) -o test_scll$(EXE)
+	./test_scll$(EXE)
 
-TEST_BINS=test_circ_queue test_bst test_search test_hash_func test_sll test_dll test_array test_stack test_tbt test_priority_queue
+
+TEST_BINS=test_circ_queue test_bst test_search test_hash_func test_sll test_dll test_array test_stack test_tbt test_priority_queue test_scll
 test: $(TEST_BINS)
 
 .PHONY: $(TARGET) $(TEST_BINS)

--- a/src/data_structures/data_structures.h
+++ b/src/data_structures/data_structures.h
@@ -123,4 +123,32 @@ void destroy_pq(priority_queue* pq);
 void display_heap(priority_queue* pq);
 void priority_queue_demo(void);
 
+// For singly circular linked list
+// Invariant: when non-empty, tail->next == head (the ring closes back onto head);
+// when empty, head == tail == NULL and length == 0. head and tail are both tracked and
+// length is cached so getLength is O(1) and positional inserts need no counting pass.
+typedef struct scll_Node
+{
+    int data;
+    struct scll_Node* next;
+} scll_Node;
+typedef struct scll
+{
+    scll_Node* head;
+    scll_Node* tail;
+    int length;
+} scll;
+void scll_init(scll* list);
+int scll_insertAtBeginning(scll* list, int value);
+int scll_insertAtEnd(scll* list, int value);
+int scll_insertAtPosition(scll* list, int value, int position);
+int scll_deleteAtBeginning(scll* list);
+int scll_deleteAtEnd(scll* list);
+int scll_deleteByValue(scll* list, int value);
+int scll_deleteAtPosition(scll* list, int position);
+int scll_search(const scll* list, int key);
+int scll_getLength(const scll* list);
+void scll_printlist(const scll* list);
+void scll_destroy(scll* list);
+void scll_Demo(void);
 #endif

--- a/src/data_structures/data_structures_demo.c
+++ b/src/data_structures/data_structures_demo.c
@@ -76,8 +76,12 @@ void data_structures_demo(void)
                 while (1)
                 {
                     int circular_variant_choice = 0;
-                    int circular_variant_status = safe_input_int(
-                        &circular_variant_choice, "enter 1 for circular queue demo : ", 1, 1);
+                    int circular_variant_status =
+                        safe_input_int(&circular_variant_choice,
+                                       "\nenter 1 for circular queue demo"
+                                       "\nenter 2 for singly circular linked list demo"
+                                       "\nenter choice : ",
+                                       1, 2);
                     if (circular_variant_status == 0)
                         continue;
                     if (circular_variant_status == INPUT_EXIT_SIGNAL)
@@ -86,7 +90,10 @@ void data_structures_demo(void)
                     {
                         circular_queue_Demo();
                     }
-                    break;
+                    if (circular_variant_choice == 2)
+                    {
+                        scll_Demo();
+                    }
                 }
 
                 break;

--- a/src/data_structures/scll.c
+++ b/src/data_structures/scll.c
@@ -1,0 +1,653 @@
+#include "data_structures.h"
+#include "safe_input.h"
+#include <stdio.h>
+#include <stdlib.h>
+
+// Singly circular linked list. See data_structures.h for the head/tail/length invariant.
+//
+// A note on traversal: because the list is circular there is no NULL terminator to stop on.
+// Every traversal here therefore walks at most `length` nodes, using the idiom
+//     cur = head; do { ...; cur = cur->next; } while (cur != head);
+// which visits each node exactly once and is guaranteed to terminate (it stops the moment it
+// arrives back at head). This is what prevents the infinite loops a circular list invites.
+
+// Allocates a node holding `value`. Returns NULL on malloc failure. The caller is responsible
+// for linking it into the ring (next is left as NULL on purpose).
+static scll_Node* scll_create_node(int value)
+{
+    scll_Node* node = malloc(sizeof(scll_Node));
+    if (node == NULL)
+    {
+        return NULL;
+    }
+    node->data = value;
+    node->next = NULL;
+    return node;
+}
+
+void scll_init(scll* list)
+{
+    list->head = NULL;
+    list->tail = NULL;
+    list->length = 0;
+}
+
+int scll_insertAtBeginning(scll* list, int value)
+{
+    scll_Node* node = scll_create_node(value);
+    if (node == NULL)
+    {
+        return -1;
+    }
+
+    if (list->head == NULL)
+    {
+        // First node: it must point to itself so that tail->next == head holds.
+        node->next = node;
+        list->head = node;
+        list->tail = node;
+    }
+    else
+    {
+        // New node becomes the head; tail keeps closing the ring onto the new head.
+        node->next = list->head;
+        list->head = node;
+        list->tail->next = list->head;
+    }
+
+    list->length++;
+    return 1;
+}
+
+int scll_insertAtEnd(scll* list, int value)
+{
+    scll_Node* node = scll_create_node(value);
+    if (node == NULL)
+    {
+        return -1;
+    }
+
+    if (list->head == NULL)
+    {
+        node->next = node;
+        list->head = node;
+        list->tail = node;
+    }
+    else
+    {
+        // Link after the current tail and close the ring back onto head. O(1) thanks to tail.
+        node->next = list->head;
+        list->tail->next = node;
+        list->tail = node;
+    }
+
+    list->length++;
+    return 1;
+}
+
+int scll_insertAtPosition(scll* list, int value, int position)
+{
+    // Valid insert positions are 0..length (length == append at the end).
+    if (position < 0 || position > list->length)
+    {
+        return -2;
+    }
+
+    if (position == 0)
+    {
+        return scll_insertAtBeginning(list, value);
+    }
+    if (position == list->length)
+    {
+        return scll_insertAtEnd(list, value);
+    }
+
+    // Interior insert: walk to the node just before the target position.
+    scll_Node* node = scll_create_node(value);
+    if (node == NULL)
+    {
+        return -1;
+    }
+
+    scll_Node* prev = list->head;
+    for (int i = 0; i < position - 1; i++)
+    {
+        prev = prev->next;
+    }
+
+    node->next = prev->next;
+    prev->next = node;
+    // head and tail are untouched here (position is strictly interior), invariant preserved.
+
+    list->length++;
+    return 1;
+}
+
+int scll_deleteAtBeginning(scll* list)
+{
+    if (list->head == NULL)
+    {
+        return -1;
+    }
+
+    scll_Node* old_head = list->head;
+
+    if (list->head == list->tail)
+    {
+        // Single node deletes down to the empty list.
+        free(old_head);
+        list->head = NULL;
+        list->tail = NULL;
+    }
+    else
+    {
+        list->head = old_head->next;
+        list->tail->next = list->head; // keep the ring closed onto the new head
+        free(old_head);
+    }
+
+    list->length--;
+    return 1;
+}
+
+int scll_deleteAtEnd(scll* list)
+{
+    if (list->head == NULL)
+    {
+        return -1;
+    }
+
+    if (list->head == list->tail)
+    {
+        free(list->tail);
+        list->head = NULL;
+        list->tail = NULL;
+    }
+    else
+    {
+        // Singly linked: we must walk from head to find the node before the tail.
+        scll_Node* prev = list->head;
+        while (prev->next != list->tail)
+        {
+            prev = prev->next;
+        }
+        free(list->tail);
+        list->tail = prev;
+        list->tail->next = list->head; // re-close the ring
+    }
+
+    list->length--;
+    return 1;
+}
+
+int scll_deleteByValue(scll* list, int value)
+{
+    if (list->head == NULL)
+    {
+        return -2;
+    }
+
+    // Deleting the head value is delegated so the head/tail bookkeeping stays in one place.
+    if (list->head->data == value)
+    {
+        return scll_deleteAtBeginning(list);
+    }
+
+    // Search for the predecessor of the node holding `value`, bounded by one full lap.
+    scll_Node* prev = list->head;
+    while (prev->next != list->head)
+    {
+        if (prev->next->data == value)
+        {
+            scll_Node* target = prev->next;
+            prev->next = target->next;
+            if (target == list->tail)
+            {
+                list->tail = prev; // removed the tail: prev becomes the new tail
+            }
+            free(target);
+            list->length--;
+            return 1;
+        }
+        prev = prev->next;
+    }
+
+    return -1; // value not present
+}
+
+int scll_deleteAtPosition(scll* list, int position)
+{
+    if (list->head == NULL)
+    {
+        return -1;
+    }
+    // Valid delete positions are 0..length-1.
+    if (position < 0 || position >= list->length)
+    {
+        return -2;
+    }
+
+    if (position == 0)
+    {
+        return scll_deleteAtBeginning(list);
+    }
+
+    // Walk to the predecessor of the target node.
+    scll_Node* prev = list->head;
+    for (int i = 0; i < position - 1; i++)
+    {
+        prev = prev->next;
+    }
+
+    scll_Node* target = prev->next;
+    prev->next = target->next;
+    if (target == list->tail)
+    {
+        list->tail = prev; // deleting the last node updates tail
+    }
+    free(target);
+
+    list->length--;
+    return 1;
+}
+
+int scll_search(const scll* list, int key)
+{
+    if (list->head == NULL)
+    {
+        return -1;
+    }
+
+    int index = 0;
+    const scll_Node* cur = list->head;
+    do
+    {
+        if (cur->data == key)
+        {
+            return index;
+        }
+        cur = cur->next;
+        index++;
+    } while (cur != list->head);
+
+    return -1;
+}
+
+int scll_getLength(const scll* list)
+{
+    return list->length;
+}
+
+void scll_printlist(const scll* list)
+{
+    printf("HEAD->");
+    if (list->head == NULL)
+    {
+        printf("(empty)");
+        return;
+    }
+
+    const scll_Node* cur = list->head;
+    do
+    {
+        printf("%d->", cur->data);
+        cur = cur->next;
+    } while (cur != list->head);
+
+    printf("(back to HEAD)");
+}
+
+void scll_destroy(scll* list)
+{
+    if (list->head == NULL)
+    {
+        return;
+    }
+
+    // Break the ring first so the walk has a NULL terminator and we never revisit a freed node.
+    list->tail->next = NULL;
+    scll_Node* cur = list->head;
+    while (cur != NULL)
+    {
+        scll_Node* upcoming = cur->next;
+        free(cur);
+        cur = upcoming;
+    }
+
+    list->head = NULL;
+    list->tail = NULL;
+    list->length = 0;
+}
+
+void scll_Demo(void)
+{
+    scll list;
+    scll_init(&list);
+
+    int scll_element_count;
+    int scll_length_status;
+
+start_scll:
+    scll_length_status = safe_input_int(
+        &scll_element_count,
+        "enter how many elements you want to insert, (between 1 and 100), enter '-1' to exit :- ",
+        1, 100);
+
+    if (scll_length_status == INPUT_EXIT_SIGNAL)
+    {
+        printf("\nExiting scll demo\n");
+        scll_destroy(&list);
+        return;
+    }
+
+    if (scll_length_status == 0)
+    {
+        goto start_scll;
+    }
+
+    while (scll_element_count > 0)
+    {
+        int scll_position_choice;
+        int scll_position_status;
+
+    scll_position_selection:
+        scll_position_status = safe_input_int(&scll_position_choice,
+                                              "\nenter '0' for inserting at beginning"
+                                              "\nenter '1' for inserting at end"
+                                              "\nenter '2' for inserting at specific position"
+                                              "\nenter '-1' to exit :- ",
+                                              0, 2);
+
+        if (scll_position_status == INPUT_EXIT_SIGNAL)
+        {
+            printf("\nExiting scll demo\n");
+            scll_destroy(&list);
+            return;
+        }
+
+        if (scll_position_status == 0)
+        {
+            goto scll_position_selection;
+        }
+
+        if (scll_position_choice == 1)
+        {
+            int scll_end_status;
+            int scll_end_value;
+        scll_enter_end_value:
+            scll_end_status = safe_input_int(&scll_end_value,
+                                             "enter the no. you want to insert at end, (between 1 "
+                                             "and 100), enter '-1' to exit :- ",
+                                             1, 100);
+
+            if (scll_end_status == INPUT_EXIT_SIGNAL)
+            {
+                printf("\nExiting scll demo\n");
+                scll_destroy(&list);
+                return;
+            }
+
+            if (scll_end_status == 0)
+            {
+                goto scll_enter_end_value;
+            }
+
+            int status = scll_insertAtEnd(&list, scll_end_value);
+            if (status == -1)
+            {
+                printf("\nmalloc allocation failure. try again\n");
+                goto scll_enter_end_value;
+            }
+            printf("\n");
+            scll_printlist(&list);
+        }
+        else if (scll_position_choice == 0)
+        {
+            int scll_start_status;
+            int scll_start_value;
+
+        scll_enter_start_value:
+            scll_start_status = safe_input_int(&scll_start_value,
+                                               "enter the no. you want to insert at beginning, "
+                                               "(between 1 and 100), enter '-1' to exit :- ",
+                                               1, 100);
+
+            if (scll_start_status == INPUT_EXIT_SIGNAL)
+            {
+                printf("\nExiting scll demo\n");
+                scll_destroy(&list);
+                return;
+            }
+
+            if (scll_start_status == 0)
+            {
+                goto scll_enter_start_value;
+            }
+            int status = scll_insertAtBeginning(&list, scll_start_value);
+            if (status == -1)
+            {
+                printf("\nmalloc allocation failure. try again\n");
+                goto scll_enter_start_value;
+            }
+            printf("\n");
+            scll_printlist(&list);
+        }
+        else if (scll_position_choice == 2)
+        {
+            int scll_pos_status;
+            int scll_pos_value;
+            int scll_pos_index;
+            char scll_pos_prompt[128];
+
+        scll_enter_pos_value:
+            scll_pos_status = safe_input_int(&scll_pos_value,
+                                             "enter the no. you want to insert, (between 1 "
+                                             "and 100), enter '-1' to exit :- ",
+                                             1, 100);
+
+            if (scll_pos_status == INPUT_EXIT_SIGNAL)
+            {
+                printf("\nExiting scll demo\n");
+                scll_destroy(&list);
+                return;
+            }
+
+            if (scll_pos_status == 0)
+            {
+                goto scll_enter_pos_value;
+            }
+
+        scll_enter_pos_index:
+            snprintf(scll_pos_prompt, sizeof(scll_pos_prompt),
+                     "enter the position (0 to %d), enter '-1' to exit :- ", scll_getLength(&list));
+            scll_pos_status =
+                safe_input_int(&scll_pos_index, scll_pos_prompt, 0, scll_getLength(&list));
+
+            if (scll_pos_status == INPUT_EXIT_SIGNAL)
+            {
+                printf("\nExiting scll demo\n");
+                scll_destroy(&list);
+                return;
+            }
+
+            if (scll_pos_status == 0)
+            {
+                goto scll_enter_pos_index;
+            }
+
+            int status = scll_insertAtPosition(&list, scll_pos_value, scll_pos_index);
+            if (status == -1)
+            {
+                printf("\nmalloc allocation failure. try again\n");
+                goto scll_enter_pos_value;
+            }
+            else if (status == -2)
+            {
+                printf("\ninvalid position. try again\n");
+                goto scll_enter_pos_index;
+            }
+            printf("\n");
+            scll_printlist(&list);
+        }
+
+        scll_element_count--;
+    }
+
+    // searching elements in scll
+    while (1)
+    {
+        int scll_search_status;
+        int scll_search_value;
+        scll_search_status = safe_input_int(
+            &scll_search_value,
+            "\nenter the element to be searched, (between 1 and 100), enter '-1' to exit :- ", 1,
+            100);
+        if (scll_search_status == INPUT_EXIT_SIGNAL)
+        {
+            break;
+        }
+        if (scll_search_status == 0)
+        {
+            continue;
+        }
+
+        int index = scll_search(&list, scll_search_value);
+        printf("\nelement found at index :- %d", index);
+    }
+
+    // deleting elements in scll
+    while (1)
+    {
+        int scll_delete_choice;
+        int scll_delete_status;
+
+    scll_delete_selection:
+        scll_delete_status = safe_input_int(&scll_delete_choice,
+                                            "\nenter '0' to delete at beginning"
+                                            "\nenter '1' to delete at end"
+                                            "\nenter '2' to delete by value"
+                                            "\nenter '3' to delete at position"
+                                            "\nenter '-1' to exit :- ",
+                                            0, 3);
+
+        if (scll_delete_status == INPUT_EXIT_SIGNAL)
+        {
+            printf("\nExiting scll demo\n");
+            scll_destroy(&list);
+            return;
+        }
+        if (scll_delete_status == 0)
+        {
+            goto scll_delete_selection;
+        }
+
+        if (scll_delete_choice == 0)
+        {
+            int status = scll_deleteAtBeginning(&list);
+            if (status == -1)
+            {
+                printf("\nList is empty\n");
+            }
+            else
+            {
+                printf("\nscll after deletion - ");
+                scll_printlist(&list);
+            }
+        }
+        else if (scll_delete_choice == 1)
+        {
+            int status = scll_deleteAtEnd(&list);
+            if (status == -1)
+            {
+                printf("\nList is empty\n");
+            }
+            else
+            {
+                printf("\nscll after deletion - ");
+                scll_printlist(&list);
+            }
+        }
+        else if (scll_delete_choice == 2)
+        {
+            int scll_delete_value;
+            scll_delete_status = safe_input_int(
+                &scll_delete_value,
+                "\nenter the element to be deleted, (between 1 and 100), enter '-1' to exit :- ", 1,
+                100);
+
+            if (scll_delete_status == INPUT_EXIT_SIGNAL)
+            {
+                printf("\nExiting scll demo\n");
+                scll_destroy(&list);
+                return;
+            }
+            if (scll_delete_status == 0)
+            {
+                continue;
+            }
+
+            int status = scll_deleteByValue(&list, scll_delete_value);
+            if (status == -2)
+            {
+                printf("\nList is empty\n");
+            }
+            else if (status == -1)
+            {
+                printf("\nvalue not found\n");
+            }
+            else
+            {
+                printf("\nscll after deletion - ");
+                scll_printlist(&list);
+            }
+        }
+        else if (scll_delete_choice == 3)
+        {
+            int scll_pos_delete_status;
+            int scll_pos_delete_index;
+            char scll_pos_delete_prompt[128];
+
+            if (scll_getLength(&list) == 0)
+            {
+                printf("\nList is empty\n");
+                continue;
+            }
+
+        scll_delete_pos_input:
+            snprintf(scll_pos_delete_prompt, sizeof(scll_pos_delete_prompt),
+                     "enter the position to delete (0 to %d), enter '-1' to exit :- ",
+                     scll_getLength(&list) - 1);
+            scll_pos_delete_status = safe_input_int(&scll_pos_delete_index, scll_pos_delete_prompt,
+                                                    0, scll_getLength(&list) - 1);
+
+            if (scll_pos_delete_status == INPUT_EXIT_SIGNAL)
+            {
+                printf("\nExiting scll demo\n");
+                scll_destroy(&list);
+                return;
+            }
+
+            if (scll_pos_delete_status == 0)
+            {
+                goto scll_delete_pos_input;
+            }
+
+            int status = scll_deleteAtPosition(&list, scll_pos_delete_index);
+            if (status == -1)
+            {
+                printf("\nList is empty\n");
+            }
+            else if (status == -2)
+            {
+                printf("\nInvalid position\n");
+            }
+            else
+            {
+                printf("\nscll after deletion - ");
+                scll_printlist(&list);
+            }
+        }
+    }
+
+    scll_destroy(&list);
+}

--- a/tests/test_scll.c
+++ b/tests/test_scll.c
@@ -1,0 +1,283 @@
+#include "data_structures.h"
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+// Independently counts the ring by walking at most one full lap. Returns the node count and,
+// via *invariant_ok, whether tail->next == head currently holds. Walking is bounded: it stops
+// when it returns to head, or after length+1 hops as a safety cap so a broken ring can never
+// loop forever inside the tests themselves.
+static int ring_count(const scll* list, int* invariant_ok)
+{
+    if (list->head == NULL)
+    {
+        *invariant_ok = (list->tail == NULL);
+        return 0;
+    }
+
+    *invariant_ok = (list->tail->next == list->head);
+
+    int count = 0;
+    const scll_Node* cur = list->head;
+    do
+    {
+        count++;
+        cur = cur->next;
+    } while (cur != list->head && count <= list->length + 1);
+
+    return count;
+}
+
+// Asserts the structural invariant after a mutation: tail->next == head, and the cached length
+// matches an independent walk of the ring.
+static void assert_invariant(const scll* list)
+{
+    int invariant_ok = 0;
+    int counted = ring_count(list, &invariant_ok);
+    assert(invariant_ok);
+    assert(counted == list->length);
+}
+
+// Copies the list into arr by walking exactly `length` nodes. The loop is bounded by the cached
+// length, which proves termination on a circular structure. Returns the number of items copied.
+static int list_to_array(const scll* list, int arr[], int max)
+{
+    int i = 0;
+    if (list->head == NULL)
+    {
+        return 0;
+    }
+    const scll_Node* cur = list->head;
+    while (i < list->length && i < max)
+    {
+        arr[i++] = cur->data;
+        cur = cur->next;
+    }
+    return i;
+}
+
+void test_insert_begin_end()
+{
+    scll list;
+    scll_init(&list);
+
+    assert(scll_insertAtEnd(&list, 10) == 1);
+    // Single node points to itself and is both head and tail.
+    assert(list.head == list.tail);
+    assert(list.head->next == list.head);
+    assert_invariant(&list);
+
+    assert(scll_insertAtEnd(&list, 20) == 1);
+    assert(scll_insertAtBeginning(&list, 5) == 1);
+    assert_invariant(&list);
+
+    int out[3];
+    int n = list_to_array(&list, out, 3);
+    assert(n == 3);
+    assert(out[0] == 5 && out[1] == 10 && out[2] == 20);
+    assert(list.head->data == 5);
+    assert(list.tail->data == 20);
+
+    scll_destroy(&list);
+    printf("scll insert begin/end tests passed\n");
+}
+
+void test_insert_at_position()
+{
+    scll list;
+    scll_init(&list);
+
+    // Insert into empty list at position 0.
+    assert(scll_insertAtPosition(&list, 10, 0) == 1);
+    // Append at the end (position == length).
+    assert(scll_insertAtPosition(&list, 30, 1) == 1);
+    // Interior insert.
+    assert(scll_insertAtPosition(&list, 20, 1) == 1);
+    assert_invariant(&list);
+
+    int out[3];
+    int n = list_to_array(&list, out, 3);
+    assert(n == 3);
+    assert(out[0] == 10 && out[1] == 20 && out[2] == 30);
+    assert(list.tail->data == 30);
+
+    // Invalid positions.
+    assert(scll_insertAtPosition(&list, 99, 10) == -2);
+    assert(scll_insertAtPosition(&list, 99, -1) == -2);
+    assert_invariant(&list);
+
+    scll_destroy(&list);
+    printf("scll insert at position tests passed\n");
+}
+
+void test_delete_begin_end()
+{
+    scll list;
+    scll_init(&list);
+    for (int v = 1; v <= 3; v++)
+    {
+        assert(scll_insertAtEnd(&list, v) == 1);
+    }
+
+    assert(scll_deleteAtBeginning(&list) == 1);
+    assert(list.head->data == 2);
+    assert_invariant(&list);
+
+    assert(scll_deleteAtEnd(&list) == 1);
+    assert(list.tail->data == 2);
+    assert(list.head == list.tail); // back down to a single node
+    assert_invariant(&list);
+
+    assert(scll_deleteAtBeginning(&list) == 1);
+    assert(list.head == NULL && list.tail == NULL && list.length == 0);
+
+    scll_destroy(&list);
+    printf("scll delete begin/end tests passed\n");
+}
+
+void test_delete_by_value()
+{
+    scll list;
+    scll_init(&list);
+    for (int v = 1; v <= 4; v++)
+    {
+        assert(scll_insertAtEnd(&list, v) == 1);
+    }
+
+    // Delete an interior value.
+    assert(scll_deleteByValue(&list, 2) == 1);
+    assert_invariant(&list);
+
+    // Delete the tail value: tail must be updated.
+    assert(scll_deleteByValue(&list, 4) == 1);
+    assert(list.tail->data == 3);
+    assert_invariant(&list);
+
+    // Delete the head value.
+    assert(scll_deleteByValue(&list, 1) == 1);
+    assert(list.head->data == 3);
+    assert_invariant(&list);
+
+    // Value not present.
+    assert(scll_deleteByValue(&list, 99) == -1);
+
+    int out[2];
+    int n = list_to_array(&list, out, 2);
+    assert(n == 1 && out[0] == 3);
+
+    scll_destroy(&list);
+    printf("scll delete by value tests passed\n");
+}
+
+void test_delete_at_position()
+{
+    scll list;
+    scll_init(&list);
+    for (int v = 1; v <= 4; v++)
+    {
+        assert(scll_insertAtEnd(&list, v) == 1);
+    }
+
+    // Delete head via position 0.
+    assert(scll_deleteAtPosition(&list, 0) == 1);
+    // Delete the new last node (position length-1) -> tail update.
+    assert(scll_deleteAtPosition(&list, list.length - 1) == 1);
+    assert(list.tail->data == 3);
+    assert_invariant(&list);
+
+    int out[2];
+    int n = list_to_array(&list, out, 2);
+    assert(n == 2 && out[0] == 2 && out[1] == 3);
+
+    // Invalid positions.
+    assert(scll_deleteAtPosition(&list, 10) == -2);
+    assert(scll_deleteAtPosition(&list, -1) == -2);
+
+    scll_destroy(&list);
+    printf("scll delete at position tests passed\n");
+}
+
+void test_search_and_length()
+{
+    scll list;
+    scll_init(&list);
+    assert(scll_getLength(&list) == 0);
+
+    int values[] = {5, 10, 15};
+    for (int i = 0; i < 3; i++)
+    {
+        assert(scll_insertAtEnd(&list, values[i]) == 1);
+    }
+    assert(scll_getLength(&list) == 3);
+
+    assert(scll_search(&list, 5) == 0);
+    assert(scll_search(&list, 15) == 2);
+    assert(scll_search(&list, 100) == -1);
+
+    scll_destroy(&list);
+    printf("scll search and length tests passed\n");
+}
+
+void test_edge_cases()
+{
+    scll list;
+    scll_init(&list);
+
+    // Operations on an empty list return the documented error codes.
+    assert(scll_deleteAtBeginning(&list) == -1);
+    assert(scll_deleteAtEnd(&list) == -1);
+    assert(scll_deleteByValue(&list, 10) == -2);
+    assert(scll_deleteAtPosition(&list, 0) == -1); // empty list -> -1 (not an invalid-position -2)
+    assert(scll_search(&list, 10) == -1);
+    assert(scll_getLength(&list) == 0);
+
+    // Single-node list: node points to itself, head == tail.
+    assert(scll_insertAtBeginning(&list, 42) == 1);
+    assert(list.head == list.tail);
+    assert(list.head->next == list.head);
+    assert(scll_search(&list, 42) == 0);
+    assert_invariant(&list);
+
+    // Delete down to empty, then reuse the same list object.
+    assert(scll_deleteAtEnd(&list) == 1);
+    assert(list.head == NULL && list.length == 0);
+    assert(scll_insertAtEnd(&list, 7) == 1);
+    assert(list.head->data == 7);
+    assert_invariant(&list);
+
+    scll_destroy(&list);
+    printf("scll edge case tests passed\n");
+}
+
+void test_destroy_is_idempotent()
+{
+    scll list;
+    scll_init(&list);
+    for (int v = 1; v <= 3; v++)
+    {
+        assert(scll_insertAtEnd(&list, v) == 1);
+    }
+
+    scll_destroy(&list);
+    assert(list.head == NULL && list.tail == NULL && list.length == 0);
+    // Destroying an already-empty list is a safe no-op.
+    scll_destroy(&list);
+    assert(list.head == NULL);
+
+    printf("scll destroy tests passed\n");
+}
+
+int main()
+{
+    test_insert_begin_end();
+    test_insert_at_position();
+    test_delete_begin_end();
+    test_delete_by_value();
+    test_delete_at_position();
+    test_search_and_length();
+    test_edge_cases();
+    test_destroy_is_idempotent();
+
+    printf("All SCLL tests passed\n");
+    return 0;
+}


### PR DESCRIPTION
Implements a singly circular linked list in src/singly_circular_linked_list/ with a wrapper struct tracking head, tail and a cached length so that tail->next == head is preserved on every insert/delete and getLength is O(1).

Operations: insert/delete at beginning, end and arbitrary position, search, getLength, safe bounded traversal (do-while against head, never NULL) and destroy. Interactive demo wired into the circular-variants menu and unit tests added under tests/.

Closes #27