### PR TITLE
docs: add header comment for data structures index

### DIFF
--- a/src/data_structures/data_structures.h
+++ b/src/data_structures/data_structures.h
@@ -1,5 +1,22 @@
 #ifndef DATA_STRUCTURES_H
 #define DATA_STRUCTURES_H
+/*
+ * DATA STRUCTURES INDEX
+ *
+ * This header aggregates all data structures used in the project.
+ * The data structures appear in the following order:
+ *
+ * 1. Arrays
+ * 2. Binary Search Tree (BST)
+ * 3. Circular Queue
+ * 4. Doubly Linked List
+ * 5. Singly Linked List
+ * 6. Threaded Binary Tree (TBT)
+ * 7. Priority Queue
+ *
+ * Refer to the corresponding section below for structure
+ * definitions and function declarations.
+ */
 #define HEAP_CAPACITY 100
 #include <stdbool.h>
 #include <stddef.h>


### PR DESCRIPTION
Adds a documentation index at the top of `data_structures.h` listing all included data structures in the order they appear in the file.

Closes #40