### PR TITLE
feat: add linear search functionality to linear probing hashing demo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,6 +76,7 @@ HASH_FUNCTION_TEST_SRC = \
 	src/hashing/linear_probing.c \
 	src/utils/safe_input_int.c \
 	src/data_structures/array.c \
+	src/searching_algorithms/linear_search.c \
 	tests/test_hash_function.c
 
 SLL_TEST_SRC = \

--- a/src/hashing/linear_probing.c
+++ b/src/hashing/linear_probing.c
@@ -1,5 +1,6 @@
 #include "data_structures.h"
 #include "hash.h"
+#include "searching_algorithms.h"
 #include <safe_input.h>
 #include <stdbool.h>
 #include <stdio.h>
@@ -53,12 +54,11 @@ void linear_probing_demo(void)
         while (1)
         {
             int value_status = safe_input_int(
-                &value, "\nenter a value between 1 and 1000 (enter '-1' to exit):- ", 1, 1000);
+                &value, "\nenter a value between 1 and 1000 (enter '-1' to search elements):- ", 1, 1000);
 
             if (value_status == INPUT_EXIT_SIGNAL)
             {
-                printf("\nExiting linear_probing demo.....");
-                return;
+                break;
             }
             if (value_status == 0)
             {
@@ -95,6 +95,33 @@ void linear_probing_demo(void)
             arr[hash_location] = value; // inserting value at its hash location
 
             print_array(arr, length_of_array);
+        }
+
+        while (1)
+        {
+            int search_val;
+            int search_status = safe_input_int(
+                &search_val, "\nenter a value to search in the hash table (enter '-1' to exit):- ", 1, 1000);
+
+            if (search_status == INPUT_EXIT_SIGNAL)
+            {
+                printf("\nExiting linear_probing demo.....\n");
+                return;
+            }
+            if (search_status == 0)
+            {
+                continue;
+            }
+
+            int res = linear_search(arr, search_val, length_of_array);
+            if (res != -1)
+            {
+                printf("\nValue %d found in the hash table at index %d.", search_val, res);
+            }
+            else
+            {
+                printf("\nValue %d not found in the hash table.", search_val);
+            }
         }
     }
 }

--- a/src/searching_algorithms/searching_algorithms.h
+++ b/src/searching_algorithms/searching_algorithms.h
@@ -4,5 +4,7 @@
 int linear_search_demo(void);
 int binary_search_demo(void);
 void searching_algorithms_demo(void);
+int linear_search(int arr[], int target, int length_of_array);
+int binary_search(int arr[], int target, int length_of_array);
 
 #endif


### PR DESCRIPTION
***

# Description
This PR integrates an interactive search feature into the linear probing hashing demo (`linear_probing.c`).

Once the user finishes inserting elements into the hash table (by entering `-1`), the program transitions into an interactive search loop. It utilizes the modular `linear_search` function to look up elements within the underlying hash table array and displays their corresponding indices.

Closes #44

## Changes Made
- Included `searching_algorithms.h` in `src/hashing/linear_probing.c` and implemented the search loop.
- Declared the core `linear_search` and `binary_search` utility functions in `src/searching_algorithms/searching_algorithms.h`.
- Added the `linear_search.c` dependency to `HASH_FUNCTION_TEST_SRC` in the `Makefile` to resolve compiler linker errors.