### PR TITLE
feat: Add simple (linear) queue for comparison with circular queue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ fmt:
 	find . \( -name "*.c" -o -name "*.h" \) -not -path "*/build/*" | xargs clang-format -i
 
 clean:
-	$(RM) $(TARGET)$(EXE) test_circ_queue$(EXE) test_bst$(EXE) test_search$(EXE) test_hash_func$(EXE) test_sll$(EXE) test_dll$(EXE) test_array$(EXE) test_stack$(EXE) test_tbt$(EXE) test_priority_queue$(EXE) test_scll$(EXE)
+	$(RM) $(TARGET)$(EXE) test_circ_queue$(EXE) test_bst$(EXE) test_search$(EXE) test_hash_func$(EXE) test_sll$(EXE) test_dll$(EXE) test_array$(EXE) test_stack$(EXE) test_tbt$(EXE) test_priority_queue$(EXE) test_scll$(EXE) test_simple_queue$(EXE)
 
 valgrind:
 	for t in $(TEST_BINS); do \
@@ -115,6 +115,11 @@ SCLL_TEST_SRC = \
 	src/utils/safe_input_int.c \
 	tests/test_scll.c
 
+SIMPLE_QUEUE_TEST_SRC = \
+	src/data_structures/simple_queue.c \
+	src/utils/safe_input_int.c \
+	tests/test_simple_queue.c
+
 test_tbt:
 	$(CC) $(CFLAGS) $(TBT_TEST_SRC) -o test_tbt$(EXE)
 	./test_tbt$(EXE)
@@ -159,8 +164,12 @@ test_scll:
 	$(CC) $(CFLAGS) $(SCLL_TEST_SRC) -o test_scll$(EXE)
 	./test_scll$(EXE)
 
+test_simple_queue:
+	$(CC) $(CFLAGS) $(SIMPLE_QUEUE_TEST_SRC) -o test_simple_queue$(EXE)
+	./test_simple_queue$(EXE)
 
-TEST_BINS=test_circ_queue test_bst test_search test_hash_func test_sll test_dll test_array test_stack test_tbt test_priority_queue test_scll
+
+TEST_BINS=test_circ_queue test_bst test_search test_hash_func test_sll test_dll test_array test_stack test_tbt test_priority_queue test_scll test_simple_queue
 test: $(TEST_BINS)
 
 .PHONY: $(TARGET) $(TEST_BINS)

--- a/src/data_structures/data_structures.h
+++ b/src/data_structures/data_structures.h
@@ -169,4 +169,24 @@ int scll_getLength(const scll* list);
 void scll_printlist(const scll* list);
 void scll_destroy(scll* list);
 void scll_Demo(void);
+
+// For simple (linear) queue
+// A fixed-capacity array queue WITHOUT wrap-around. front and rear are array indices (both -1
+// when empty) and rear only ever advances. Once rear reaches N-1 the queue reports full even
+// if dequeues freed slots at the front - that freed space is never reused. This "false
+// overflow" is the limitation the circular queue (above) solves by wrapping front/rear modulo
+// N; the two live side-by-side for comparison.
+typedef struct simple_queue
+{
+    int front;
+    int rear;
+    int N;
+    int* arr;
+} simple_queue;
+int init_simple_queue(int N, simple_queue* queue_ptr);
+void destroy_simple_queue(simple_queue* queue_ptr);
+int enqueue_simple(simple_queue* queue_ptr, int value);
+int dequeue_simple(simple_queue* queue_ptr);
+void display_simple_queue(const simple_queue* queue_ptr);
+void simple_queue_Demo(void);
 #endif

--- a/src/data_structures/data_structures_demo.c
+++ b/src/data_structures/data_structures_demo.c
@@ -39,8 +39,9 @@ void data_structures_demo(void)
                         "\nenter 2 for doubly linked list demo"
                         "\nenter 3 for arrays demo"
                         "\nenter 4 for priority queue (binary heap implementation with array) demo"
+                        "\nenter 5 for simple (linear) queue demo"
                         "\nenter choice : ",
-                        1, 4);
+                        1, 5);
 
                     if (linear_ds_status == INPUT_EXIT_SIGNAL)
                         break;
@@ -66,6 +67,11 @@ void data_structures_demo(void)
                     if (linear_ds_choice == 4)
                     {
                         priority_queue_demo();
+                        continue;
+                    }
+                    if (linear_ds_choice == 5)
+                    {
+                        simple_queue_Demo();
                         continue;
                     }
                 }

--- a/src/data_structures/simple_queue.c
+++ b/src/data_structures/simple_queue.c
@@ -1,0 +1,176 @@
+#include "data_structures.h"
+#include "safe_input.h"
+#include <stdio.h>
+#include <stdlib.h>
+
+// init function returns 0 on bad capacity / malloc failure and 1 on correct initialization
+
+// enqueue_simple returns 1 on successful operation and -1 on failure due to a full queue
+
+// dequeue_simple returns -1 when the queue is empty and the dequeued value on success
+
+// This is a LINEAR queue: front and rear are plain array indices (both -1 when empty) and
+// rear only ever advances. It does NOT wrap around, so once rear reaches the last slot the
+// queue is reported full even if dequeues have freed slots at the front - that freed space
+// is never reused. This "false overflow" is exactly the limitation the circular queue avoids
+// by wrapping front/rear modulo N; the two implementations sit side-by-side for comparison.
+
+void simple_queue_Demo(void)
+{
+
+    while (1)
+    {
+        simple_queue q;
+        int queue_capacity_value;
+        int queue_capacity_status =
+            safe_input_int(&queue_capacity_value,
+                           "\n\nenter capacity number (N) of simple (linear) queue, (between 1 and "
+                           "100), enter -1 to exit:- ",
+                           1, 100);
+
+        if (queue_capacity_status == INPUT_EXIT_SIGNAL)
+        {
+            printf("\nExiting simple queue demo\n");
+            return;
+        }
+        if (queue_capacity_status == 0)
+        {
+            continue;
+        }
+        if (!init_simple_queue(queue_capacity_value, &q))
+        {
+            printf("\nmalloc allocation failure");
+            return;
+        }
+
+        printf("\nNote: this is a LINEAR queue. rear only moves forward, so once it reaches the\n"
+               "last slot the queue reports full even if dequeues freed slots at the front (the\n"
+               "freed space is NOT reused). Compare this with the circular queue, which wraps\n"
+               "around to reuse freed slots.\n");
+
+        // loop of enqueue and dequeue (interleaved enqueue and dequeue)
+
+        while (1)
+        {
+            int simple_queue_choice;
+            int simple_queue_status =
+                safe_input_int(&simple_queue_choice,
+                               "\n\nenter 1 for enqueue, 2 for dequeue and -1 for exit:- ", 1, 2);
+
+            if (simple_queue_status == INPUT_EXIT_SIGNAL)
+            {
+                printf("\nExiting simple queue demo\n");
+                destroy_simple_queue(&q);
+                return;
+            }
+
+            if (simple_queue_status == 0)
+            { // invalid input, (chars or number+chars) loopback to start
+                continue;
+            }
+
+            if (simple_queue_choice == 1)
+            {
+                int enqueue_val;
+                int enqueue_val_status = safe_input_int(
+                    &enqueue_val,
+                    "\nEnter value to enqueue (between 1 and 100), enter -1 to exit:- ", 1, 100);
+
+                if (enqueue_val_status == INPUT_EXIT_SIGNAL)
+                {
+                    printf("\nExiting simple queue demo\n");
+                    destroy_simple_queue(&q);
+                    return;
+                }
+
+                if (enqueue_val_status == 0)
+                { // invalid input, (chars or number+chars) loopback to start
+                    continue;
+                }
+
+                if (enqueue_simple(&q, enqueue_val) == -1)
+                {
+                    printf("\nQueue is full (linear overflow - freed front slots cannot be "
+                           "reused)\n");
+                }
+
+                display_simple_queue(&q);
+            }
+
+            else if (simple_queue_choice == 2)
+            {
+                int removed = dequeue_simple(&q);
+
+                if (removed == -1)
+                {
+                    printf("\nQueue is empty\n");
+                }
+                else
+                {
+                    printf("\nDequeued element: %d\n", removed);
+                }
+
+                display_simple_queue(&q);
+            }
+        }
+    }
+}
+
+int init_simple_queue(int N, simple_queue* queue_ptr)
+{
+    if (N < 1)
+        return 0;
+    queue_ptr->arr = malloc(sizeof(int) * N);
+    if (queue_ptr->arr == NULL)
+        return 0;
+    queue_ptr->N = N;
+    queue_ptr->front = -1;
+    queue_ptr->rear = -1;
+    return 1;
+}
+
+void destroy_simple_queue(simple_queue* queue_ptr)
+{
+    if (queue_ptr->arr == NULL)
+        return;
+    free(queue_ptr->arr);
+    queue_ptr->arr = NULL;
+    queue_ptr->front = -1;
+    queue_ptr->rear = -1;
+    queue_ptr->N = 0;
+}
+
+int enqueue_simple(simple_queue* queue_ptr, int value)
+{ // rear never moves backward, so a slot freed by dequeue at the front is not reclaimed
+    if (queue_ptr->rear == queue_ptr->N - 1)
+        return -1;
+    if (queue_ptr->front == -1)
+        queue_ptr->front = 0;
+    queue_ptr->rear++;
+    queue_ptr->arr[queue_ptr->rear] = value;
+    return 1;
+}
+
+int dequeue_simple(simple_queue* queue_ptr)
+{
+    if (queue_ptr->front == -1 || queue_ptr->front > queue_ptr->rear)
+        return -1;
+    int front_value = queue_ptr->arr[queue_ptr->front];
+    queue_ptr->front++;
+    return front_value;
+}
+
+void display_simple_queue(const simple_queue* queue_ptr)
+{
+    if (queue_ptr->front == -1 || queue_ptr->front > queue_ptr->rear)
+    {
+        printf("\nQueue (front -> rear): [empty]\n");
+        return;
+    }
+    printf("\nQueue (front -> rear): ");
+    for (int i = queue_ptr->front; i <= queue_ptr->rear; i++)
+    {
+        printf("%d -> ", queue_ptr->arr[i]);
+    }
+    printf("END\n");
+}

--- a/tests/test_simple_queue.c
+++ b/tests/test_simple_queue.c
@@ -1,0 +1,118 @@
+#include "data_structures.h"
+#include <assert.h>
+#include <stdio.h>
+
+void test_init()
+{
+    simple_queue q;
+    assert(init_simple_queue(5, &q) == 1);
+    assert(q.N == 5);
+    assert(q.front == -1);
+    assert(q.rear == -1);
+    destroy_simple_queue(&q);
+
+    printf("Simple queue init test passed\n");
+}
+
+void test_basic_enqueue_dequeue()
+{
+    simple_queue q;
+    init_simple_queue(5, &q);
+
+    assert(enqueue_simple(&q, 30) == 1);
+    assert(enqueue_simple(&q, 20) == 1);
+
+    // FIFO: first in, first out
+    assert(dequeue_simple(&q) == 30);
+    assert(dequeue_simple(&q) == 20);
+
+    destroy_simple_queue(&q);
+
+    printf("Simple queue basic enqueue/dequeue test passed\n");
+}
+
+void test_underflow()
+{
+    simple_queue q;
+    init_simple_queue(5, &q);
+
+    assert(dequeue_simple(&q) == -1);
+
+    destroy_simple_queue(&q);
+
+    printf("Simple queue underflow test passed\n");
+}
+
+void test_overflow()
+{
+    simple_queue q;
+    init_simple_queue(3, &q);
+
+    assert(enqueue_simple(&q, 1) == 1);
+    assert(enqueue_simple(&q, 2) == 1);
+    assert(enqueue_simple(&q, 3) == 1);
+
+    // capacity reached: rear is at the last slot
+    assert(enqueue_simple(&q, 4) == -1);
+
+    destroy_simple_queue(&q);
+
+    printf("Simple queue overflow test passed\n");
+}
+
+void test_false_overflow()
+{
+    // The defining limitation of a linear queue: once rear reaches the last slot the queue
+    // is full even after the front has been dequeued. The freed slots are NOT reusable
+    // (unlike a circular queue, which wraps around). This test pins that behaviour.
+    simple_queue q;
+    init_simple_queue(3, &q);
+
+    enqueue_simple(&q, 1);
+    enqueue_simple(&q, 2);
+    enqueue_simple(&q, 3); // rear == N-1, queue full
+
+    assert(dequeue_simple(&q) == 1);
+    assert(dequeue_simple(&q) == 2); // two front slots are now free
+
+    // Only one element (3) remains in a capacity-3 queue, yet enqueue still fails:
+    // rear cannot move past N-1 and the freed front slots cannot be reclaimed.
+    assert(enqueue_simple(&q, 4) == -1);
+
+    // The remaining element is still retrievable in order, then the queue is empty.
+    assert(dequeue_simple(&q) == 3);
+    assert(dequeue_simple(&q) == -1);
+
+    destroy_simple_queue(&q);
+
+    printf("Simple queue false-overflow (linear limitation) test passed\n");
+}
+
+void test_fifo_order()
+{
+    simple_queue q;
+    init_simple_queue(4, &q);
+
+    for (int i = 1; i <= 4; i++)
+        assert(enqueue_simple(&q, i * 10) == 1);
+
+    for (int i = 1; i <= 4; i++)
+        assert(dequeue_simple(&q) == i * 10);
+
+    destroy_simple_queue(&q);
+
+    printf("Simple queue FIFO order test passed\n");
+}
+
+int main()
+{
+    test_init();
+    test_basic_enqueue_dequeue();
+    test_underflow();
+    test_overflow();
+    test_false_overflow();
+    test_fifo_order();
+
+    printf("All simple queue tests passed\n");
+    return 0;
+}


### PR DESCRIPTION
## What this does
Adds a **simple (linear) queue** alongside the existing circular queue, for the educational comparison discussed (issue #48). Users can now see the linear queue's limitation firsthand and contrast it with how the circular queue reuses freed slots.

## The limitation it demonstrates (false overflow)
This is a fixed-capacity array queue **without wrap-around**: `front`/`rear` are array indices (both `-1` when empty) and `rear` only ever moves forward. Once `rear` reaches the last slot, `enqueue` reports **full even if dequeues have freed slots at the front** - that freed space is never reused. That is exactly the limitation the circular queue solves by wrapping `front`/`rear` modulo `N`, so the two now read side-by-side.

## Changes
- `src/data_structures/simple_queue.c` - `init_simple_queue` / `destroy_simple_queue` / `enqueue_simple` / `dequeue_simple` / `display_simple_queue` + `simple_queue_Demo` (return-value contract mirrors the circular queue: `1`/`-1`, `0` on init failure). Function names are suffixed to avoid clashing with the circular queue's `enqueue`/`dequeue` in the shared header.
- `src/data_structures/data_structures.h` - `simple_queue` struct + declarations, in a commented section following the existing convention.
- `src/data_structures/data_structures_demo.c` - hooked `simple_queue_Demo` into the **linear data structures menu (case 1, option 5)**; the circular queue stays under the circular variants menu, so the contrast is natural.
- `tests/test_simple_queue.c` - init, FIFO order, underflow, overflow, and a dedicated **false-overflow** test that pins the linear limitation.
- `Makefile` - `test_simple_queue` target wired into `TEST_BINS` and `clean`.

## Verification (local)
- Clean build under `-Wall -Wextra -Werror -std=c11`
- `make test` - full suite green (incl. all 6 simple-queue tests)
- `make valgrind` - 0 leaks / 0 errors on `test_simple_queue`
- clang-format clean (repo `.clang-format`)

Closes #48
