### PR TITLE
feat: Add heap sort to advanced sorting algorithms

### DIFF
--- a/src/advanced_sorting_algorithms/advanced_sorting.h
+++ b/src/advanced_sorting_algorithms/advanced_sorting.h
@@ -6,5 +6,7 @@ void quicksort_demo(void);
 void advanced_sorting_demo(void);
 void merge_sort(int arr[], int n);
 void merge_sort_demo(void);
+void heap_sort(int arr[], int n);
+void heap_sort_demo(void);
 
 #endif

--- a/src/advanced_sorting_algorithms/advanced_sorting_demo.c
+++ b/src/advanced_sorting_algorithms/advanced_sorting_demo.c
@@ -11,9 +11,10 @@ void advanced_sorting_demo(void)
 
         printf("\nAdvanced sorting algorithms demo\n");
 
-        sorting_algo_status =
-            safe_input_int(&sorting_algo_choice,
-                           "enter '1' for quick sort, '2' for merge sort '-1' to exit:- ", 1, 2);
+        sorting_algo_status = safe_input_int(
+            &sorting_algo_choice,
+            "enter '1' for quick sort, '2' for merge sort, '3' for heap sort '-1' to exit:- ", 1,
+            3);
 
         if (sorting_algo_status == INPUT_EXIT_SIGNAL)
         {
@@ -34,6 +35,11 @@ void advanced_sorting_demo(void)
         else if (sorting_algo_choice == 2)
         {
             merge_sort_demo();
+        }
+
+        else if (sorting_algo_choice == 3)
+        {
+            heap_sort_demo();
         }
     }
 }

--- a/src/advanced_sorting_algorithms/heap_sort.c
+++ b/src/advanced_sorting_algorithms/heap_sort.c
@@ -1,0 +1,91 @@
+#include "advanced_sorting.h"
+#include "data_structures.h" // priority_queue API (pq_init, insert, extractTop, destroy_pq)
+#include "safe_input.h"
+#include <stdio.h>
+
+/*
+ * Heap sort implemented on top of the existing priority_queue (binary heap).
+ *
+ *   Build phase: insert all n elements into a MIN-heap   -> n * O(log n)
+ *   Sort phase : extractTop n times                       -> n * O(log n)
+ *                a min-heap always yields the smallest remaining element,
+ *                so writing them back left-to-right gives ascending order.
+ *
+ * Overall: O(n log n). Not in-place (the heap keeps its own copy) and bounded
+ * by HEAP_CAPACITY because priority_queue uses a fixed-size array.
+ */
+void heap_sort(int arr[], int n)
+{
+    if (n <= 1)
+        return;
+
+    priority_queue* pq = pq_init(MIN_HEAP);
+    if (pq == NULL)
+        return;
+
+    int inserted = 0;
+    for (int i = 0; i < n; i++)
+    {
+        if (insert(pq, arr[i]) == 0) // heap full (HEAP_CAPACITY reached)
+            break;
+        inserted++;
+    }
+
+    for (int i = 0; i < inserted; i++)
+        extractTop(pq, &arr[i]); // min first -> ascending order
+
+    destroy_pq(pq);
+}
+
+void heap_sort_demo(void)
+{
+    int length_of_array;
+    while (1)
+    {
+        printf("\n\nHeap sort demo");
+        int length_status = safe_input_int(&length_of_array,
+                                           "\nenter the number of elements in the array "
+                                           "(between 1 and 100), enter '-1' to exit:- ",
+                                           1, 100);
+
+        if (length_status == 0)
+            continue; // retry on failure
+
+        if (length_status == INPUT_EXIT_SIGNAL)
+        { // user entered -1
+            printf("\nExiting heap sort demo....\n");
+            return;
+        }
+
+        int arr[length_of_array];
+
+        for (int i = 0; i < length_of_array; i++)
+        {
+
+        retry:
+            printf("\nenter the element number %d, (between 1 and 100), enter '-1' to exit:- ", i);
+            int element_status = safe_input_int(&arr[i], NULL, 1, 100);
+
+            if (element_status == INPUT_EXIT_SIGNAL)
+            {
+                printf("\nExiting heap sort demo.....\n");
+                return;
+            }
+
+            if (element_status == 0)
+            {
+                goto retry;
+            }
+        }
+
+        heap_sort(arr, length_of_array);
+
+        printf("\nThe array sorted by heap sort is:- ");
+        for (int i = 0; i < length_of_array; i++)
+        {
+            printf("%d", arr[i]);
+            if (i < length_of_array - 1)
+                printf(",");
+        }
+    }
+}


### PR DESCRIPTION
Implements heap sort on top of the existing priority_queue, per your guidance to reuse it.

## Approach
- Create a min-heap with pq_init(MIN_HEAP).
- insert() every array element (sift-up, O(log n) each).
- extractTop() n times writes elements back into the array; a min-heap always yields the smallest remaining element, so the result is ascending.
- O(n log n) overall.

## Note on the issue text
This reuses the priority queue rather than a separate in-place heapify (as you directed in chat). Consequently it is O(n) space and bounded by HEAP_CAPACITY (100), consistent with the existing merge/quick sort demos which already cap input at 100.

## Changes
- New src/advanced_sorting_algorithms/heap_sort.c (heap_sort + heap_sort_demo).
- advanced_sorting.h: declarations added.
- advanced_sorting_demo.c: wired heap sort into the menu as option 3.
- No Makefile change needed (CFLAGS already includes -Isrc/data_structures; SRCS globs the module).

## Verification (local)
- Clean build under -Wall -Wextra -Werror -std=c11
- make test: full suite green
- Demo verified: 5,3,1,4,2 -> 1,2,3,4,5
- clang-format clean

Closes #56
