### PR TITLE
feat: Add double hashing collision resolution to hashing module

### DIFF
--- a/src/hashing/double_hashing.c
+++ b/src/hashing/double_hashing.c
@@ -1,0 +1,133 @@
+#include "data_structures.h"
+#include "hash.h"
+#include <safe_input.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <string.h>
+
+// secondary hash: the probe step size for double hashing. 1 + (value % (length - 1))
+// always lands in [1, length - 1], so the step is never 0 (which would stall probing)
+// and it depends on the key -- the defining property of double hashing. local helper,
+// not meant to be used as an API in other modules.
+static int second_hash(int value, int length_of_array)
+{
+    if (length_of_array <= 1)
+    {
+        return 1; // single-slot table: step value is irrelevant, just stay non-zero
+    }
+    return 1 + (value % (length_of_array - 1));
+}
+
+void double_hashing_demo(void)
+{
+    while (1)
+    {
+        int value;
+        int length_of_array;
+
+        int length_arr_status = safe_input_int(
+            &length_of_array, "\n\nenter length of the array (between 1 and 1000):- ", 1, 1000);
+
+        if (length_arr_status == INPUT_EXIT_SIGNAL)
+        {
+            printf("\nExiting double_hashing demo");
+            return;
+        }
+        if (length_arr_status == 0)
+        {
+            continue;
+        }
+
+        int arr[length_of_array];
+
+        memset(arr, 0, sizeof(arr)); // empty slot is represented by 0
+
+        // ---------- insertion phase ----------
+        while (1)
+        {
+            int value_status = safe_input_int(
+                &value, "\nenter a value between 1 and 1000 (enter '-1' to search elements):- ", 1,
+                1000);
+
+            if (value_status == INPUT_EXIT_SIGNAL)
+            {
+                break;
+            }
+            if (value_status == 0)
+            {
+                continue;
+            }
+
+            int h1 = hash_function(value, length_of_array); // primary hash
+            int h2 = second_hash(value, length_of_array);   // step size, never 0
+            bool inserted = false;
+
+            for (int i = 0; i < length_of_array; i++)
+            {
+                int probe_location = (h1 + i * h2) % length_of_array;
+
+                if (!arr[probe_location])
+                {
+                    arr[probe_location] = value;
+                    print_array(arr, length_of_array);
+                    inserted = true;
+                    break;
+                }
+            }
+
+            if (!inserted)
+            {
+                printf("\nhash table full or double hashing probe failed, old table destroyed, new "
+                       "table created\n");
+                break;
+            }
+        }
+
+        // ---------- search phase (follows the same double-hash probe chain) ----------
+        while (1)
+        {
+            int search_val;
+            int search_status = safe_input_int(
+                &search_val, "\nenter a value to search in the hash table (enter '-1' to exit):- ",
+                1, 1000);
+
+            if (search_status == INPUT_EXIT_SIGNAL)
+            {
+                printf("\nExiting double_hashing demo.....\n");
+                return;
+            }
+            if (search_status == 0)
+            {
+                continue;
+            }
+
+            int h1 = hash_function(search_val, length_of_array);
+            int h2 = second_hash(search_val, length_of_array);
+            int found_index = -1;
+
+            for (int i = 0; i < length_of_array; i++)
+            {
+                int probe_location = (h1 + i * h2) % length_of_array;
+
+                if (arr[probe_location] == search_val)
+                {
+                    found_index = probe_location;
+                    break;
+                }
+                if (!arr[probe_location]) // empty slot: value cannot be further down the chain
+                {
+                    break;
+                }
+            }
+
+            if (found_index != -1)
+            {
+                printf("\nValue %d found in the hash table at index %d.", search_val, found_index);
+            }
+            else
+            {
+                printf("\nValue %d not found in the hash table.", search_val);
+            }
+        }
+    }
+}

--- a/src/hashing/hash.h
+++ b/src/hashing/hash.h
@@ -6,6 +6,7 @@ void hashing_algorithms_demo(void);
 int hash_function(int value, int length_of_array);
 void separate_chaining_demo(void);
 void quadratic_probing_demo(void);
+void double_hashing_demo(void);
 
 static const unsigned char PRIMES[] = {
     0, 0, 1, 1, 1, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 0, 0, 1, 0, 1, 0, 0, 0, 1, 0, 1, 0, 0, 0, 1, 0, 1,

--- a/src/hashing/hashing_algorithms_demo.c
+++ b/src/hashing/hashing_algorithms_demo.c
@@ -7,9 +7,11 @@ void hashing_algorithms_demo(void)
     while (1)
     {
         int hash_algo_choice;
-        int hash_algo_status =
-            safe_input_int(&hash_algo_choice,
-                           "\n\nenter 1 for linear probing, 2 for separate chaining, and 3 for quadratic probing :- ", 1, 3);
+        int hash_algo_status = safe_input_int(&hash_algo_choice,
+                                              "\n\nenter 1 for linear probing, 2 for separate "
+                                              "chaining, 3 for quadratic probing, and 4 for double "
+                                              "hashing :- ",
+                                              1, 4);
 
         if (hash_algo_status == INPUT_EXIT_SIGNAL)
         {
@@ -30,9 +32,13 @@ void hashing_algorithms_demo(void)
             case 2:
                 separate_chaining_demo();
                 break;
-                
+
             case 3:
                 quadratic_probing_demo();
+                break;
+
+            case 4:
+                double_hashing_demo();
                 break;
         }
     }


### PR DESCRIPTION
Adds double hashing as a 4th collision-resolution strategy, alongside linear probing, separate chaining, and quadratic probing.

## Approach
- Primary hash reuses the existing hash_function(value, length) as h1.
- Secondary hash h2(key) = 1 + key % (length - 1), always in [1, length-1] so it is never 0 and depends on the key (the defining property of double hashing).
- Probe sequence: index = (h1 + i * h2) % length; insert at the first free slot, report table full if the whole table is probed.
- Search follows the same probe chain and stops at the value or the first empty slot — a real hashed lookup, not a linear scan (hashing is for fast lookups).

## Conventions
- Array-based demo style matching linear/quadratic probing, per your guidance (local int arr[length], 0 = empty slot, values 1-1000, input via safe_input_int).
- Wired into the hashing menu as option 4.
- No Makefile change needed (src/hashing/*.c is globbed).

## Verification (local)
- Clean build under -Wall -Wextra -Werror -std=c11
- make test: full suite green
- Demo verified: colliding keys are placed via double-hash probing and found again by search; a non-inserted key reports not found.

Closes #60
