### PR TITLE
feat: add Double-Ended Queue (Deque) data structure and tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ fmt:
 	find . \( -name "*.c" -o -name "*.h" \) -not -path "*/build/*" | xargs clang-format -i
 
 clean:
-	$(RM) $(TARGET)$(EXE) test_circ_queue$(EXE) test_bst$(EXE) test_search$(EXE) test_hash_func$(EXE) test_sll$(EXE) test_dll$(EXE) test_array$(EXE) test_stack$(EXE) test_tbt$(EXE) test_priority_queue$(EXE) test_scll$(EXE) test_simple_queue$(EXE)
+	$(RM) $(TARGET)$(EXE) test_circ_queue$(EXE) test_bst$(EXE) test_search$(EXE) test_hash_func$(EXE) test_sll$(EXE) test_dll$(EXE) test_array$(EXE) test_stack$(EXE) test_tbt$(EXE) test_priority_queue$(EXE) test_scll$(EXE) test_simple_queue$(EXE) test_deque$(EXE)
 
 valgrind:
 	for t in $(TEST_BINS); do \
@@ -121,6 +121,11 @@ SIMPLE_QUEUE_TEST_SRC = \
 	src/utils/safe_input_int.c \
 	tests/test_simple_queue.c
 
+DEQUE_TEST_SRC = \
+	src/data_structures/deque.c \
+	src/utils/safe_input_int.c \
+	tests/test_deque.c
+
 test_tbt:
 	$(CC) $(CFLAGS) $(TBT_TEST_SRC) -o test_tbt$(EXE)
 	./test_tbt$(EXE)
@@ -169,8 +174,13 @@ test_simple_queue:
 	$(CC) $(CFLAGS) $(SIMPLE_QUEUE_TEST_SRC) -o test_simple_queue$(EXE)
 	./test_simple_queue$(EXE)
 
+test_deque:
+	$(CC) $(CFLAGS) $(DEQUE_TEST_SRC) -o test_deque$(EXE)
+	./test_deque$(EXE)
 
-TEST_BINS=test_circ_queue test_bst test_search test_hash_func test_sll test_dll test_array test_stack test_tbt test_priority_queue test_scll test_simple_queue
+
+TEST_BINS=test_circ_queue test_bst test_search test_hash_func test_sll test_dll test_array test_stack test_tbt test_priority_queue test_scll test_simple_queue test_deque
 test: $(TEST_BINS)
 
 .PHONY: $(TARGET) $(TEST_BINS)
+

--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ If any test fails or Valgrind detects a memory error, the CI job fails automatic
 - Singly Linked List (SLL)
 - Doubly Linked List (DLL)
 - Circular Queue (array-based)
+- Double-Ended Queue (Deque) (array-based)
 - Stack (array-based / linked-list-based as required)
 - Binary Search Tree (BST)-recursive
 - Threaded Binary Tree (TBT)

--- a/src/data_structures/data_structures.h
+++ b/src/data_structures/data_structures.h
@@ -189,4 +189,27 @@ int enqueue_simple(simple_queue* queue_ptr, int value);
 int dequeue_simple(simple_queue* queue_ptr);
 void display_simple_queue(const simple_queue* queue_ptr);
 void simple_queue_Demo(void);
+
+// For Double-Ended Queue (Deque)
+typedef struct deque
+{
+    int front;
+    int rear;
+    int N;
+    int* arr;
+} deque;
+int init_deque(int N, deque* dq);
+void destroy_deque(deque* dq);
+int deque_insert_front(deque* dq, int value);
+int deque_insert_rear(deque* dq, int value);
+int deque_delete_front(deque* dq);
+int deque_delete_rear(deque* dq);
+int deque_get_front(const deque* dq);
+int deque_get_rear(const deque* dq);
+bool deque_is_empty(const deque* dq);
+bool deque_is_full(const deque* dq);
+void display_deque(const deque* dq);
+void deque_demo(void);
+
 #endif
+

--- a/src/data_structures/data_structures_demo.c
+++ b/src/data_structures/data_structures_demo.c
@@ -86,8 +86,9 @@ void data_structures_demo(void)
                         safe_input_int(&circular_variant_choice,
                                        "\nenter 1 for circular queue demo"
                                        "\nenter 2 for singly circular linked list demo"
+                                       "\nenter 3 for double-ended queue (deque) demo"
                                        "\nenter choice : ",
-                                       1, 2);
+                                       1, 3);
                     if (circular_variant_status == 0)
                         continue;
                     if (circular_variant_status == INPUT_EXIT_SIGNAL)
@@ -99,6 +100,10 @@ void data_structures_demo(void)
                     if (circular_variant_choice == 2)
                     {
                         scll_Demo();
+                    }
+                    if (circular_variant_choice == 3)
+                    {
+                        deque_demo();
                     }
                 }
 

--- a/src/data_structures/deque.c
+++ b/src/data_structures/deque.c
@@ -1,0 +1,305 @@
+#include "data_structures.h"
+#include "safe_input.h"
+#include <stdio.h>
+#include <stdlib.h>
+
+int init_deque(int N, deque* dq)
+{
+    if (N < 1)
+        return 0;
+    dq->arr = malloc(sizeof(int) * N);
+    if (dq->arr == NULL)
+        return 0;
+    dq->N = N;
+    dq->front = -1;
+    dq->rear = -1;
+    return 1;
+}
+
+void destroy_deque(deque* dq)
+{
+    if (dq->arr == NULL)
+        return;
+    free(dq->arr);
+    dq->arr = NULL;
+    dq->front = -1;
+    dq->rear = -1;
+    dq->N = 0;
+}
+
+bool deque_is_empty(const deque* dq)
+{
+    return (dq->front == -1);
+}
+
+bool deque_is_full(const deque* dq)
+{
+    return ((dq->front == 0 && dq->rear == dq->N - 1) || (dq->front == dq->rear + 1));
+}
+
+int deque_insert_front(deque* dq, int value)
+{
+    if (deque_is_full(dq))
+        return -1;
+
+    if (dq->front == -1) // empty
+    {
+        dq->front = 0;
+        dq->rear = 0;
+    }
+    else if (dq->front == 0)
+    {
+        dq->front = dq->N - 1;
+    }
+    else
+    {
+        dq->front = dq->front - 1;
+    }
+
+    dq->arr[dq->front] = value;
+    return 1;
+}
+
+int deque_insert_rear(deque* dq, int value)
+{
+    if (deque_is_full(dq))
+        return -1;
+
+    if (dq->front == -1) // empty
+    {
+        dq->front = 0;
+        dq->rear = 0;
+    }
+    else if (dq->rear == dq->N - 1)
+    {
+        dq->rear = 0;
+    }
+    else
+    {
+        dq->rear = dq->rear + 1;
+    }
+
+    dq->arr[dq->rear] = value;
+    return 1;
+}
+
+int deque_delete_front(deque* dq)
+{
+    if (deque_is_empty(dq))
+        return -1;
+
+    int val = dq->arr[dq->front];
+
+    if (dq->front == dq->rear) // only one element
+    {
+        dq->front = -1;
+        dq->rear = -1;
+    }
+    else if (dq->front == dq->N - 1)
+    {
+        dq->front = 0;
+    }
+    else
+    {
+        dq->front = dq->front + 1;
+    }
+
+    return val;
+}
+
+int deque_delete_rear(deque* dq)
+{
+    if (deque_is_empty(dq))
+        return -1;
+
+    int val = dq->arr[dq->rear];
+
+    if (dq->front == dq->rear) // only one element
+    {
+        dq->front = -1;
+        dq->rear = -1;
+    }
+    else if (dq->rear == 0)
+    {
+        dq->rear = dq->N - 1;
+    }
+    else
+    {
+        dq->rear = dq->rear - 1;
+    }
+
+    return val;
+}
+
+int deque_get_front(const deque* dq)
+{
+    if (deque_is_empty(dq))
+        return -1;
+    return dq->arr[dq->front];
+}
+
+int deque_get_rear(const deque* dq)
+{
+    if (deque_is_empty(dq))
+        return -1;
+    return dq->arr[dq->rear];
+}
+
+void display_deque(const deque* dq)
+{
+    if (deque_is_empty(dq))
+    {
+        printf("\nDeque is empty\n");
+        return;
+    }
+    printf("\nDeque elements: ");
+    int i = dq->front;
+    while (1)
+    {
+        printf("%d", dq->arr[i]);
+        if (i == dq->rear)
+            break;
+        printf("<->");
+        i = (i + 1) % dq->N;
+    }
+    printf("\n");
+}
+
+void deque_demo(void)
+{
+    while (1)
+    {
+        deque dq;
+        int capacity;
+        int status = safe_input_int(&capacity,
+                                    "\n\nenter capacity number (N) of deque (between 1 and 100), "
+                                    "enter '-1' to exit:- ",
+                                    1, 100);
+
+        if (status == INPUT_EXIT_SIGNAL)
+        {
+            printf("\nExiting deque demo\n");
+            return;
+        }
+        if (status == 0)
+        {
+            continue;
+        }
+        if (!init_deque(capacity, &dq))
+        {
+            printf("\nmalloc allocation failure");
+            return;
+        }
+
+        while (1)
+        {
+            int choice;
+            int choice_status = safe_input_int(&choice,
+                                               "\n1. Insert Front"
+                                               "\n2. Insert Rear"
+                                               "\n3. Delete Front"
+                                               "\n4. Delete Rear"
+                                               "\n5. Get Front"
+                                               "\n6. Get Rear"
+                                               "\nenter choice, '-1' to exit this deque:- ",
+                                               1, 6);
+
+            if (choice_status == INPUT_EXIT_SIGNAL)
+            {
+                destroy_deque(&dq);
+                break;
+            }
+            if (choice_status == 0)
+            {
+                continue;
+            }
+
+            if (choice == 1)
+            {
+                int val;
+                int val_status = safe_input_int(&val, "\nEnter value to insert at front (1 to 100), '-1' to exit: ", 1, 100);
+                if (val_status == INPUT_EXIT_SIGNAL)
+                {
+                    destroy_deque(&dq);
+                    return;
+                }
+                if (val_status == 0)
+                    continue;
+
+                if (deque_insert_front(&dq, val) == -1)
+                {
+                    printf("\nDeque is full (overflow)\n");
+                }
+                display_deque(&dq);
+            }
+            else if (choice == 2)
+            {
+                int val;
+                int val_status = safe_input_int(&val, "\nEnter value to insert at rear (1 to 100), '-1' to exit: ", 1, 100);
+                if (val_status == INPUT_EXIT_SIGNAL)
+                {
+                    destroy_deque(&dq);
+                    return;
+                }
+                if (val_status == 0)
+                    continue;
+
+                if (deque_insert_rear(&dq, val) == -1)
+                {
+                    printf("\nDeque is full (overflow)\n");
+                }
+                display_deque(&dq);
+            }
+            else if (choice == 3)
+            {
+                int removed = deque_delete_front(&dq);
+                if (removed == -1)
+                {
+                    printf("\nDeque is empty (underflow)\n");
+                }
+                else
+                {
+                    printf("\nDeleted element from front: %d\n", removed);
+                }
+                display_deque(&dq);
+            }
+            else if (choice == 4)
+            {
+                int removed = deque_delete_rear(&dq);
+                if (removed == -1)
+                {
+                    printf("\nDeque is empty (underflow)\n");
+                }
+                else
+                {
+                    printf("\nDeleted element from rear: %d\n", removed);
+                }
+                display_deque(&dq);
+            }
+            else if (choice == 5)
+            {
+                int val = deque_get_front(&dq);
+                if (val == -1)
+                {
+                    printf("\nDeque is empty\n");
+                }
+                else
+                {
+                    printf("\nFront element: %d\n", val);
+                }
+            }
+            else if (choice == 6)
+            {
+                int val = deque_get_rear(&dq);
+                if (val == -1)
+                {
+                    printf("\nDeque is empty\n");
+                }
+                else
+                {
+                    printf("\nRear element: %d\n", val);
+                }
+            }
+        }
+    }
+}

--- a/tests/test_deque.c
+++ b/tests/test_deque.c
@@ -1,0 +1,109 @@
+#include "data_structures.h"
+#include <assert.h>
+#include <stdio.h>
+
+void test_deque_init()
+{
+    deque dq;
+    assert(init_deque(5, &dq) == 1);
+    assert(dq.N == 5);
+    assert(dq.front == -1);
+    assert(dq.rear == -1);
+    assert(deque_is_empty(&dq) == true);
+    assert(deque_is_full(&dq) == false);
+    destroy_deque(&dq);
+
+    printf("Deque init test passed\n");
+}
+
+void test_deque_basic_ops()
+{
+    deque dq;
+    init_deque(5, &dq);
+
+    assert(deque_insert_rear(&dq, 10) == 1);
+    assert(deque_insert_rear(&dq, 20) == 1);
+    assert(deque_insert_front(&dq, 5) == 1);
+
+    assert(deque_get_front(&dq) == 5);
+    assert(deque_get_rear(&dq) == 20);
+
+    assert(deque_delete_front(&dq) == 5);
+    assert(deque_delete_rear(&dq) == 20);
+    assert(deque_delete_front(&dq) == 10);
+
+    assert(deque_is_empty(&dq) == true);
+    destroy_deque(&dq);
+
+    printf("Deque basic ops test passed\n");
+}
+
+void test_deque_underflow()
+{
+    deque dq;
+    init_deque(5, &dq);
+
+    assert(deque_delete_front(&dq) == -1);
+    assert(deque_delete_rear(&dq) == -1);
+    assert(deque_get_front(&dq) == -1);
+    assert(deque_get_rear(&dq) == -1);
+
+    destroy_deque(&dq);
+    printf("Deque underflow test passed\n");
+}
+
+void test_deque_overflow()
+{
+    deque dq;
+    init_deque(3, &dq);
+
+    assert(deque_insert_rear(&dq, 1) == 1);
+    assert(deque_insert_front(&dq, 2) == 1);
+    assert(deque_insert_rear(&dq, 3) == 1);
+    assert(deque_is_full(&dq) == true);
+
+    assert(deque_insert_front(&dq, 4) == -1);
+    assert(deque_insert_rear(&dq, 5) == -1);
+
+    destroy_deque(&dq);
+    printf("Deque overflow test passed\n");
+}
+
+void test_deque_wraparound()
+{
+    deque dq;
+    init_deque(3, &dq);
+
+    // Front: -1, Rear: -1
+    assert(deque_insert_rear(&dq, 1) == 1); // F: 0, R: 0 [1]
+    assert(deque_insert_rear(&dq, 2) == 1); // F: 0, R: 1 [1, 2]
+    assert(deque_delete_front(&dq) == 1);   // F: 1, R: 1 [2]
+
+    assert(deque_insert_front(&dq, 3) == 1); // F: 0, R: 1 [3, 2]
+    assert(deque_insert_front(&dq, 4) == 1); // F: 2, R: 1 [3, 2] (under the hood F wraps to N-1 which is 2) [4 at idx 2, 3 at idx 0, 2 at idx 1]
+    assert(deque_is_full(&dq) == true);
+
+    assert(deque_get_front(&dq) == 4);
+    assert(deque_get_rear(&dq) == 2);
+
+    assert(deque_delete_rear(&dq) == 2);   // F: 2, R: 0
+    assert(deque_delete_front(&dq) == 4);  // F: 0, R: 0
+    assert(deque_delete_front(&dq) == 3);  // F: -1, R: -1
+
+    assert(deque_is_empty(&dq) == true);
+
+    destroy_deque(&dq);
+    printf("Deque wraparound test passed\n");
+}
+
+int main()
+{
+    test_deque_init();
+    test_deque_basic_ops();
+    test_deque_underflow();
+    test_deque_overflow();
+    test_deque_wraparound();
+
+    printf("All Deque tests passed\n");
+    return 0;
+}


### PR DESCRIPTION
# Pull Request: Implement Double-Ended Queue (Deque)

## Related Issue
Closes #64

## Description
This PR implements a modular, array-based Double-Ended Queue (Deque) data structure with a user-interactive demo and clean unit tests.

### Changes Made:
- **Core Library API (`data_structures.h` & `deque.c`)**:
  - Defined the `deque` structural layout.
  - Implemented core operations: `init_deque()`, `destroy_deque()`, `deque_insert_front()`, `deque_insert_rear()`, `deque_delete_front()`, `deque_delete_rear()`, `deque_get_front()`, and `deque_get_rear()`.
  - Added helpers `deque_is_empty()` and `deque_is_full()`.
  - Created an interactive menu `deque_demo()` that prompts user actions through `safe_input_int()`.
- **UI Integration (`data_structures_demo.c`)**:
  - Connected the new Deque interactive CLI demo into the circular variants menu category.
- **Unit Testing (`test_deque.c`)**:
  - Added assert-based tests covering basic enqueue/dequeue, index bounds, underflow/overflow transitions, and circular wrap-around conditions.
- **Makefile**:
  - Configured compilation targets and automated the test runner under `TEST_BINS`.

## Verification & Testing
- Ran automated test suite locally:
  ```bash
  mingw32-make test_deque
