### PR TITLE
fix: initialize rollnos struct to prevent circular queue early exit crash

### DIFF
--- a/src/data_structures/circular_queue.c
+++ b/src/data_structures/circular_queue.c
@@ -14,7 +14,7 @@ void circular_queue_Demo(void)
 
     while (1)
     {
-        circular_queue rollnos;
+        circular_queue rollnos = {0};
         int queue_capacity_value;
         int queue_capacity_status =
             safe_input_int(&queue_capacity_value,


### PR DESCRIPTION
***

# Description
This PR resolves a critical memory safety bug in the circular queue demo. 

In `circular_queue_Demo()`, the `rollnos` struct was declared on the stack but not initialized. If a user requested an early exit by entering `-1` for the capacity on the first prompt, the program would call `destroy_circ_queue(&rollnos)` before `init_circ_queue()` was ever executed. Since `rollnos` was uninitialized, the program would attempt to free garbage memory addresses from the stack, resulting in an immediate memory abort/crash.

## Changes Made
- Initialized `circular_queue rollnos` to zero at declaration (`circular_queue rollnos = {0};`) to ensure its internal array pointer starts as `NULL`, which is safe to destroy/free.

## Verification
- Compiled and executed the test suite on macOS (`make test`) and verified that the circular queue tests pass.
- Manually verified that entering `-1` on the initial capacity prompt now exits the circular queue demo cleanly without crashing.

Closes #69 