### PR TITLE
feat: add AVL Tree self-balancing insertions and deletions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ fmt:
 	find . \( -name "*.c" -o -name "*.h" \) -not -path "*/build/*" | xargs clang-format -i
 
 clean:
-	$(RM) $(TARGET)$(EXE) test_circ_queue$(EXE) test_bst$(EXE) test_search$(EXE) test_hash_func$(EXE) test_sll$(EXE) test_dll$(EXE) test_array$(EXE) test_stack$(EXE) test_tbt$(EXE) test_priority_queue$(EXE) test_scll$(EXE) test_simple_queue$(EXE) test_deque$(EXE)
+	$(RM) $(TARGET)$(EXE) test_circ_queue$(EXE) test_bst$(EXE) test_search$(EXE) test_hash_func$(EXE) test_sll$(EXE) test_dll$(EXE) test_array$(EXE) test_stack$(EXE) test_tbt$(EXE) test_priority_queue$(EXE) test_scll$(EXE) test_simple_queue$(EXE) test_deque$(EXE) test_avl$(EXE)
 
 valgrind:
 	for t in $(TEST_BINS); do \
@@ -126,6 +126,11 @@ DEQUE_TEST_SRC = \
 	src/utils/safe_input_int.c \
 	tests/test_deque.c
 
+AVL_TEST_SRC = \
+	src/data_structures/avl.c \
+	src/utils/safe_input_int.c \
+	tests/test_avl.c
+
 test_tbt:
 	$(CC) $(CFLAGS) $(TBT_TEST_SRC) -o test_tbt$(EXE)
 	./test_tbt$(EXE)
@@ -178,9 +183,14 @@ test_deque:
 	$(CC) $(CFLAGS) $(DEQUE_TEST_SRC) -o test_deque$(EXE)
 	./test_deque$(EXE)
 
+test_avl:
+	$(CC) $(CFLAGS) $(AVL_TEST_SRC) -o test_avl$(EXE)
+	./test_avl$(EXE)
 
-TEST_BINS=test_circ_queue test_bst test_search test_hash_func test_sll test_dll test_array test_stack test_tbt test_priority_queue test_scll test_simple_queue test_deque
+
+TEST_BINS=test_circ_queue test_bst test_search test_hash_func test_sll test_dll test_array test_stack test_tbt test_priority_queue test_scll test_simple_queue test_deque test_avl
 test: $(TEST_BINS)
 
 .PHONY: $(TARGET) $(TEST_BINS)
+
 

--- a/src/data_structures/avl.c
+++ b/src/data_structures/avl.c
@@ -1,0 +1,367 @@
+#include "data_structures.h"
+#include "safe_input.h"
+#include <stdio.h>
+#include <stdlib.h>
+
+int avl_height(const avlNode* node)
+{
+    if (node == NULL)
+        return 0;
+    return node->height;
+}
+
+int avl_max(int a, int b)
+{
+    return (a > b) ? a : b;
+}
+
+int avl_balance_factor(const avlNode* node)
+{
+    if (node == NULL)
+        return 0;
+    return avl_height(node->left) - avl_height(node->right);
+}
+
+static avlNode* right_rotate(avlNode* y)
+{
+    avlNode* x = y->left;
+    avlNode* T2 = x->right;
+
+    x->right = y;
+    y->left = T2;
+
+    y->height = avl_max(avl_height(y->left), avl_height(y->right)) + 1;
+    x->height = avl_max(avl_height(x->left), avl_height(x->right)) + 1;
+
+    return x;
+}
+
+static avlNode* left_rotate(avlNode* x)
+{
+    avlNode* y = x->right;
+    avlNode* T2 = y->left;
+
+    y->left = x;
+    x->right = T2;
+
+    x->height = avl_max(avl_height(x->left), avl_height(x->right)) + 1;
+    y->height = avl_max(avl_height(y->left), avl_height(y->right)) + 1;
+
+    return y;
+}
+
+static avlNode* avl_insert_helper(avlNode* node, int value, int* status)
+{
+    if (node == NULL)
+    {
+        avlNode* new_node = malloc(sizeof(avlNode));
+        if (new_node == NULL)
+        {
+            *status = -1;
+            return NULL;
+        }
+        new_node->data = value;
+        new_node->height = 1;
+        new_node->left = NULL;
+        new_node->right = NULL;
+        *status = 1;
+        return new_node;
+    }
+
+    if (value == node->data)
+    {
+        *status = 0;
+        return node;
+    }
+
+    if (value < node->data)
+    {
+        node->left = avl_insert_helper(node->left, value, status);
+    }
+    else
+    {
+        node->right = avl_insert_helper(node->right, value, status);
+    }
+
+    if (*status != 1)
+        return node;
+
+    node->height = avl_max(avl_height(node->left), avl_height(node->right)) + 1;
+
+    int balance = avl_balance_factor(node);
+
+    if (balance > 1 && value < node->left->data)
+        return right_rotate(node);
+
+    if (balance < -1 && value > node->right->data)
+        return left_rotate(node);
+
+    if (balance > 1 && value > node->left->data)
+    {
+        node->left = left_rotate(node->left);
+        return right_rotate(node);
+    }
+
+    if (balance < -1 && value < node->right->data)
+    {
+        node->right = right_rotate(node->right);
+        return left_rotate(node);
+    }
+
+    return node;
+}
+
+int avl_insert(avlNode** root_ref, int value)
+{
+    int status = 0;
+    *root_ref = avl_insert_helper(*root_ref, value, &status);
+    return status;
+}
+
+static avlNode* avl_delete_helper(avlNode* root, int value, int* status)
+{
+    if (root == NULL)
+    {
+        *status = 0;
+        return NULL;
+    }
+
+    if (value < root->data)
+    {
+        root->left = avl_delete_helper(root->left, value, status);
+    }
+    else if (value > root->data)
+    {
+        root->right = avl_delete_helper(root->right, value, status);
+    }
+    else
+    {
+        *status = 1;
+        if ((root->left == NULL) || (root->right == NULL))
+        {
+            avlNode* temp = root->left ? root->left : root->right;
+
+            if (temp == NULL)
+            {
+                temp = root;
+                root = NULL;
+            }
+            else
+            {
+                *root = *temp;
+            }
+            free(temp);
+        }
+        else
+        {
+            avlNode* temp = root->right;
+            while (temp->left != NULL)
+                temp = temp->left;
+
+            root->data = temp->data;
+
+            int dummy_status;
+            root->right = avl_delete_helper(root->right, temp->data, &dummy_status);
+        }
+    }
+
+    if (root == NULL)
+        return NULL;
+
+    root->height = avl_max(avl_height(root->left), avl_height(root->right)) + 1;
+
+    int balance = avl_balance_factor(root);
+
+    if (balance > 1 && avl_balance_factor(root->left) >= 0)
+        return right_rotate(root);
+
+    if (balance > 1 && avl_balance_factor(root->left) < 0)
+    {
+        root->left = left_rotate(root->left);
+        return right_rotate(root);
+    }
+
+    if (balance < -1 && avl_balance_factor(root->right) <= 0)
+        return left_rotate(root);
+
+    if (balance < -1 && avl_balance_factor(root->right) > 0)
+    {
+        root->right = right_rotate(root->right);
+        return left_rotate(root);
+    }
+
+    return root;
+}
+
+int avl_delete(avlNode** root_ref, int value)
+{
+    int status = 0;
+    *root_ref = avl_delete_helper(*root_ref, value, &status);
+    return status;
+}
+
+void avl_inorder(const avlNode* root)
+{
+    if (root == NULL)
+        return;
+    avl_inorder(root->left);
+    printf("%d,", root->data);
+    avl_inorder(root->right);
+}
+
+void avl_preorder(const avlNode* root)
+{
+    if (root == NULL)
+        return;
+    printf("%d,", root->data);
+    avl_preorder(root->left);
+    avl_preorder(root->right);
+}
+
+void avl_postorder(const avlNode* root)
+{
+    if (root == NULL)
+        return;
+    avl_postorder(root->left);
+    avl_postorder(root->right);
+    printf("%d,", root->data);
+}
+
+void destroy_avl(avlNode* root)
+{
+    if (root == NULL)
+        return;
+    destroy_avl(root->left);
+    destroy_avl(root->right);
+    free(root);
+}
+
+void avl_demo(void)
+{
+    while (1)
+    {
+        avlNode* root = NULL;
+        int total_nodes;
+        int total_nodes_status = safe_input_int(&total_nodes,
+                                                "\n\nenter total number of nodes you want in the AVL tree, "
+                                                "(between 1 and 100), enter '-1' to exit:- ",
+                                                1, 100);
+
+        if (total_nodes_status == INPUT_EXIT_SIGNAL)
+        {
+            printf("\nExiting AVL tree demo\n");
+            destroy_avl(root);
+            return;
+        }
+        if (total_nodes_status == 0)
+        {
+            continue;
+        }
+
+        int i = 1;
+        while (total_nodes > 0)
+        {
+            int node_value;
+            printf("\nenter value of %d AVL node - ", i);
+            int node_value_status = safe_input_int(&node_value, NULL, 1, 100);
+
+            if (node_value_status == INPUT_EXIT_SIGNAL)
+            {
+                printf("\nExiting AVL tree demo\n");
+                destroy_avl(root);
+                return;
+            }
+            if (node_value_status == 0)
+            {
+                continue;
+            }
+
+            int insertion_status = avl_insert(&root, node_value);
+            if (insertion_status == 0)
+            {
+                printf("\nentered same value. only unique values please");
+                continue;
+            }
+            if (insertion_status == -1)
+            {
+                printf("\ncouldnt insert node due to malloc failure. try again\n");
+                continue;
+            }
+            i++;
+            total_nodes--;
+        }
+
+        printf("\nheight of the AVL tree is:- %d\n", avl_height(root));
+
+        while (1)
+        {
+            int traversal_choice;
+            int traversal_status = safe_input_int(&traversal_choice,
+                                                  "\nenter '1' for inorder, '2' for preorder and "
+                                                  "'3' for postorder, '4' to delete a node, '5' to check balance factor, and '-1' to exit:- ",
+                                                  1, 5);
+
+            if (traversal_status == INPUT_EXIT_SIGNAL)
+            {
+                printf("\nExiting AVL tree demo\n");
+                destroy_avl(root);
+                return;
+            }
+            if (traversal_status == 0)
+            {
+                continue;
+            }
+
+            if (traversal_choice == 1)
+            {
+                avl_inorder(root);
+                printf("\n");
+            }
+            else if (traversal_choice == 2)
+            {
+                avl_preorder(root);
+                printf("\n");
+            }
+            else if (traversal_choice == 3)
+            {
+                avl_postorder(root);
+                printf("\n");
+            }
+            else if (traversal_choice == 4)
+            {
+                int delete_value;
+                int delete_status;
+                while (1)
+                {
+                    delete_status = safe_input_int(&delete_value,
+                                                   "\nenter value to delete (between 1 and 100), enter '-1' to exit:- ",
+                                                   1, 100);
+                    if (delete_status == INPUT_EXIT_SIGNAL)
+                    {
+                        printf("\nExiting AVL tree demo\n");
+                        destroy_avl(root);
+                        return;
+                    }
+                    if (delete_status == 0)
+                        continue;
+                    break;
+                }
+                int status = avl_delete(&root, delete_value);
+                if (status == 0)
+                {
+                    printf("\nvalue not found in the tree\n");
+                }
+                else
+                {
+                    printf("\nnode deleted. updated inorder traversal: ");
+                    avl_inorder(root);
+                    printf("\n");
+                }
+            }
+            else if (traversal_choice == 5)
+            {
+                printf("\nbalance factor of root node is: %d\n", avl_balance_factor(root));
+            }
+        }
+    }
+}

--- a/src/data_structures/data_structures.h
+++ b/src/data_structures/data_structures.h
@@ -211,4 +211,22 @@ bool deque_is_full(const deque* dq);
 void display_deque(const deque* dq);
 void deque_demo(void);
 
+// For AVL Tree (Self-Balancing Binary Search Tree)
+typedef struct avlNode
+{
+    int data;
+    int height;
+    struct avlNode* left;
+    struct avlNode* right;
+} avlNode;
+int avl_insert(avlNode** root_ref, int value);
+int avl_delete(avlNode** root_ref, int value);
+int avl_height(const avlNode* node);
+int avl_balance_factor(const avlNode* node);
+void avl_inorder(const avlNode* root);
+void avl_preorder(const avlNode* root);
+void avl_postorder(const avlNode* root);
+void destroy_avl(avlNode* root);
+void avl_demo(void);
+
 #endif

--- a/src/data_structures/data_structures_demo.c
+++ b/src/data_structures/data_structures_demo.c
@@ -117,8 +117,9 @@ void data_structures_demo(void)
                         safe_input_int(&non_linear_ds_choice,
                                        "\nenter 1 for binary search tree demo"
                                        "\nenter 2 for threaded binary tree demo"
+                                       "\nenter 3 for AVL tree demo"
                                        "\nenter choice: ",
-                                       1, 2);
+                                       1, 3);
                     if (non_linear_ds_status == INPUT_EXIT_SIGNAL)
                         break;
                     if (non_linear_ds_status == 0)
@@ -130,6 +131,10 @@ void data_structures_demo(void)
                     if (non_linear_ds_choice == 2)
                     {
                         TBT_demo();
+                    }
+                    if (non_linear_ds_choice == 3)
+                    {
+                        avl_demo();
                     }
                 }
                 break;

--- a/tests/test_avl.c
+++ b/tests/test_avl.c
@@ -1,0 +1,107 @@
+#include "data_structures.h"
+#include <assert.h>
+#include <stdio.h>
+
+void test_avl_init()
+{
+    avlNode* root = NULL;
+    assert(avl_height(root) == 0);
+    assert(avl_balance_factor(root) == 0);
+
+    assert(avl_insert(&root, 10) == 1);
+    assert(avl_height(root) == 1);
+    assert(avl_balance_factor(root) == 0);
+
+    destroy_avl(root);
+    printf("AVL init test passed\n");
+}
+
+void test_avl_rotations()
+{
+    // Left-Left (LL) Case -> Right Rotation
+    avlNode* root1 = NULL;
+    avl_insert(&root1, 30);
+    avl_insert(&root1, 20);
+    avl_insert(&root1, 10);
+    assert(root1->data == 20);
+    assert(root1->left->data == 10);
+    assert(root1->right->data == 30);
+    assert(avl_height(root1) == 2);
+    destroy_avl(root1);
+
+    // Right-Right (RR) Case -> Left Rotation
+    avlNode* root2 = NULL;
+    avl_insert(&root2, 10);
+    avl_insert(&root2, 20);
+    avl_insert(&root2, 30);
+    assert(root2->data == 20);
+    assert(root2->left->data == 10);
+    assert(root2->right->data == 30);
+    assert(avl_height(root2) == 2);
+    destroy_avl(root2);
+
+    // Left-Right (LR) Case -> Left then Right Rotation
+    avlNode* root3 = NULL;
+    avl_insert(&root3, 30);
+    avl_insert(&root3, 10);
+    avl_insert(&root3, 20);
+    assert(root3->data == 20);
+    assert(root3->left->data == 10);
+    assert(root3->right->data == 30);
+    assert(avl_height(root3) == 2);
+    destroy_avl(root3);
+
+    // Right-Left (RL) Case -> Right then Left Rotation
+    avlNode* root4 = NULL;
+    avl_insert(&root4, 10);
+    avl_insert(&root4, 30);
+    avl_insert(&root4, 20);
+    assert(root4->data == 20);
+    assert(root4->left->data == 10);
+    assert(root4->right->data == 30);
+    assert(avl_height(root4) == 2);
+    destroy_avl(root4);
+
+    printf("AVL rotation tests passed\n");
+}
+
+void test_avl_deletion()
+{
+    avlNode* root = NULL;
+    avl_insert(&root, 9);
+    avl_insert(&root, 5);
+    avl_insert(&root, 10);
+    avl_insert(&root, 0);
+    avl_insert(&root, 6);
+    avl_insert(&root, 11);
+    avl_insert(&root, -1);
+    avl_insert(&root, 1);
+    avl_insert(&root, 2);
+
+    /* The constructed AVL Tree would be
+            9
+           /  \
+          1    10
+        /  \     \
+       0    5     11
+      /    / \
+     -1   2   6
+    */
+
+    // Deletion of node 10 should trigger LL rotation at root (9)
+    assert(avl_delete(&root, 10) == 1);
+    assert(avl_balance_factor(root) >= -1 && avl_balance_factor(root) <= 1);
+
+    destroy_avl(root);
+    printf("AVL deletion test passed\n");
+}
+
+int main()
+{
+    test_avl_init();
+    test_avl_rotations();
+    test_avl_deletion();
+
+    printf("All AVL Tree tests passed\n");
+    return 0;
+}


### PR DESCRIPTION
## Related Issue
Closes #72

## Description
This PR implements a modular, self-balancing Binary Search Tree (AVL Tree) data structure. All functions and the user-interactive menu demo are consolidated cleanly in the single file `avl.c` to maintain project structure.

### Changes Made:
- **AVL API & Data Structure (`data_structures.h` & `avl.c`)**:
  - Defined the `avlNode` structure tracking height.
  - Implemented left-rotations (`left_rotate`) and right-rotations (`right_rotate`) to balance subtrees.
  - Implemented self-balancing recursive insertion (`avl_insert()`) and deletion (`avl_delete()`).
  - Added recursive preorder, inorder, and postorder traversals, and resource cleanup (`destroy_avl()`).
  - Created the interactive console `avl_demo()` with robust `safe_input_int()` validation loops.
- **UI Integration (`data_structures_demo.c`)**:
  - Connected the new AVL demo into the non-linear data structures category.
- **Unit Testing (`test_avl.c`)**:
  - Added assert-based tests verifying tree balancing across LL, RR, LR, and RL rotation insertions, and post-deletion balancing.
- **Makefile**:
  - Configured compilation targets and automated the test runner.

## Verification & Testing
- Ran the test suite locally:
  ```bash
  mingw32-make test_avl
<img width="569" height="127" alt="ss4" src="https://github.com/user-attachments/assets/e89d60df-b73f-48c8-bed1-9e2115f081ea" />
<img width="592" height="310" alt="ss1" src="https://github.com/user-attachments/assets/c2d3ca0d-5db2-4571-bc00-7414e17a2622" />
<img width="953" height="473" alt="ss3" src="https://github.com/user-attachments/assets/6c52df6b-9e6b-42fc-9a1e-80e8cd2e24f2" />

