### PR TITLE
feat: Implement Greedy Best-First Search and interactive demo 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -141,6 +141,12 @@ FLOYD_WARSHALL_TEST_SRC = \
 	src/utils/safe_input_int.c \
 	tests/test_floyd_warshall.c
 
+GREEDY_BFS_TEST_SRC = \
+	src/graph_traversals/greedy_best_first_search.c \
+	src/graph_traversals/dijkstra.c \
+	src/utils/safe_input_int.c \
+	tests/test_greedy_best_first_search.c
+
 test_tbt:
 	$(CC) $(CFLAGS) $(TBT_TEST_SRC) -o test_tbt$(EXE)
 	./test_tbt$(EXE)
@@ -206,7 +212,11 @@ test_floyd_warshall:
 	$(CC) $(CFLAGS) $(FLOYD_WARSHALL_TEST_SRC) -o test_floyd_warshall$(EXE)
 	./test_floyd_warshall$(EXE)
 
-TEST_BINS=test_circ_queue test_bst test_search test_hash_func test_sll test_dll test_array test_stack test_tbt test_priority_queue test_scll test_simple_queue test_deque test_astar test_avl test_floyd_warshall
+test_greedy_bfs:
+	$(CC) $(CFLAGS) $(GREEDY_BFS_TEST_SRC) -o test_greedy_bfs$(EXE)
+	./test_greedy_bfs$(EXE)
+
+TEST_BINS=test_circ_queue test_bst test_search test_hash_func test_sll test_dll test_array test_stack test_tbt test_priority_queue test_scll test_simple_queue test_deque test_astar test_avl test_floyd_warshall test_greedy_bfs
 test: $(TEST_BINS)
 
 .PHONY: $(TARGET) $(TEST_BINS)

--- a/src/graph_traversals/graph_traversals.h
+++ b/src/graph_traversals/graph_traversals.h
@@ -67,4 +67,10 @@ void floyd_warshall(int** graph, int V, int** dist, int** next);
 void print_floyd_warshall_solution(int** dist, int** next, int V);
 void floyd_warshall_demo(void);
 
+// ------------------For Greedy Best-First Search-----------------------
+
+int greedy_best_first_search_solve(weightedGraph* graph, int start, int dest, int h[], int parent[], int traversal_order[], int* traversal_len);
+void greedy_best_first_search(weightedGraph* graph, int start, int dest, int h[]);
+void greedy_best_first_search_demo(void);
+
 #endif

--- a/src/graph_traversals/graph_traversals_demo.c
+++ b/src/graph_traversals/graph_traversals_demo.c
@@ -8,7 +8,7 @@ void graph_traversals_demo(void)
     {
         int graph_traversal_choice;
         int graph_traversal_status = safe_input_int(
-            &graph_traversal_choice, "\nenter 1 for bfs, 2 for dfs, 3 for dijkstra, 4 for astar and 5 for floyd-warshall : ", 1, 5);
+            &graph_traversal_choice, "\nenter 1 for bfs, 2 for dfs, 3 for dijkstra, 4 for astar, 5 for floyd-warshall and 6 for greedy-bfs : ", 1, 6);
 
         if (graph_traversal_status == INPUT_EXIT_SIGNAL)
         {
@@ -37,6 +37,9 @@ void graph_traversals_demo(void)
                 break;
             case 5:
                 floyd_warshall_demo();
+                break;
+            case 6:
+                greedy_best_first_search_demo();
                 break;
         }
     }

--- a/src/graph_traversals/greedy_best_first_search.c
+++ b/src/graph_traversals/greedy_best_first_search.c
@@ -1,0 +1,500 @@
+#include "graph_traversals.h"
+#include "safe_input.h"
+#include <limits.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+typedef struct
+{
+    int h;
+    int node;
+} HeapNode;
+
+typedef struct
+{
+    HeapNode* data;
+    int size;
+    int capacity;
+} MinHeap;
+
+static MinHeap* create_min_heap(int capacity)
+{
+    MinHeap* heap = malloc(sizeof(MinHeap));
+    if (!heap)
+    {
+        return NULL;
+    }
+    heap->data = malloc(capacity * sizeof(HeapNode));
+    if (!heap->data)
+    {
+        free(heap);
+        return NULL;
+    }
+    heap->size = 0;
+    heap->capacity = capacity;
+    return heap;
+}
+
+static void free_min_heap(MinHeap* heap)
+{
+    if (heap)
+    {
+        free(heap->data);
+        free(heap);
+    }
+}
+
+static void swap_heap_nodes(HeapNode* a, HeapNode* b)
+{
+    HeapNode temp = *a;
+    *a = *b;
+    *b = temp;
+}
+
+static int compare_nodes(HeapNode a, HeapNode b)
+{
+    if (a.h < b.h)
+    {
+        return -1;
+    }
+    if (a.h > b.h)
+    {
+        return 1;
+    }
+    // Tie-break: prefer lower node ID
+    if (a.node < b.node)
+    {
+        return -1;
+    }
+    if (a.node > b.node)
+    {
+        return 1;
+    }
+    return 0;
+}
+
+static void heapify_up(MinHeap* heap, int idx)
+{
+    while (idx > 0)
+    {
+        int parent = (idx - 1) / 2;
+        if (compare_nodes(heap->data[idx], heap->data[parent]) < 0)
+        {
+            swap_heap_nodes(&heap->data[idx], &heap->data[parent]);
+            idx = parent;
+        }
+        else
+        {
+            break;
+        }
+    }
+}
+
+static void heapify_down(MinHeap* heap, int idx)
+{
+    int smallest = idx;
+    int left = 2 * idx + 1;
+    int right = 2 * idx + 2;
+
+    if (left < heap->size && compare_nodes(heap->data[left], heap->data[smallest]) < 0)
+    {
+        smallest = left;
+    }
+    if (right < heap->size && compare_nodes(heap->data[right], heap->data[smallest]) < 0)
+    {
+        smallest = right;
+    }
+
+    if (smallest != idx)
+    {
+        swap_heap_nodes(&heap->data[idx], &heap->data[smallest]);
+        heapify_down(heap, smallest);
+    }
+}
+
+static int heap_push(MinHeap* heap, int h_val, int node)
+{
+    if (heap->size >= heap->capacity)
+    {
+        return 0;
+    }
+    heap->data[heap->size].h = h_val;
+    heap->data[heap->size].node = node;
+    heapify_up(heap, heap->size);
+    heap->size++;
+    return 1;
+}
+
+static int heap_pop(MinHeap* heap, HeapNode* popped)
+{
+    if (heap->size <= 0)
+    {
+        return 0;
+    }
+    *popped = heap->data[0];
+    heap->size--;
+    if (heap->size > 0)
+    {
+        heap->data[0] = heap->data[heap->size];
+        heapify_down(heap, 0);
+    }
+    return 1;
+}
+
+int greedy_best_first_search_solve(weightedGraph* graph, int start, int dest, int h[], int parent[], int traversal_order[], int* traversal_len)
+{
+    int size = graph->V;
+    int* visited = calloc(size, sizeof(int));
+    if (!visited)
+    {
+        return 0;
+    }
+
+    MinHeap* heap = create_min_heap(size * size + 5);
+    if (!heap)
+    {
+        free(visited);
+        return 0;
+    }
+
+    for (int i = 0; i < size; i++)
+    {
+        parent[i] = -1;
+    }
+
+    heap_push(heap, h[start], start);
+
+    int found = 0;
+    *traversal_len = 0;
+
+    while (heap->size > 0)
+    {
+        HeapNode popped;
+        if (!heap_pop(heap, &popped))
+        {
+            break;
+        }
+
+        int u = popped.node;
+        if (visited[u])
+        {
+            continue;
+        }
+
+        traversal_order[(*traversal_len)++] = u;
+
+        // Display expansion details for learning/trace
+        printf("[Expansion] Popped Node %d | h = %d\n", u, h[u]);
+
+        if (u == dest)
+        {
+            found = 1;
+            break;
+        }
+
+        visited[u] = 1;
+
+        Edge* current = graph->array[u];
+        while (current != NULL)
+        {
+            int v = current->destination;
+            if (!visited[v] && parent[v] == -1 && v != start)
+            {
+                parent[v] = u;
+                heap_push(heap, h[v], v);
+            }
+            current = current->next;
+        }
+    }
+
+    free_min_heap(heap);
+    free(visited);
+    return found;
+}
+
+void greedy_best_first_search(weightedGraph* graph, int start, int dest, int h[])
+{
+    int size = graph->V;
+    int* parent = malloc(size * sizeof(int));
+    int* traversal_order = malloc(size * sizeof(int));
+    int traversal_len = 0;
+
+    if (!parent || !traversal_order)
+    {
+        printf("Memory allocation failed in Greedy Best-First Search\n");
+        free(parent);
+        free(traversal_order);
+        return;
+    }
+
+    int found = greedy_best_first_search_solve(graph, start, dest, h, parent, traversal_order, &traversal_len);
+
+    printf("Traversal Order: ");
+    for (int i = 0; i < traversal_len; i++)
+    {
+        printf("%d", traversal_order[i]);
+        if (i < traversal_len - 1)
+        {
+            printf(" -> ");
+        }
+    }
+    printf("\n");
+
+    if (!found)
+    {
+        printf("No path exists from %d to %d\n", start, dest);
+    }
+    else
+    {
+        int* path = malloc(size * sizeof(int));
+        if (!path)
+        {
+            printf("Memory allocation failed in Greedy Best-First Search\n");
+            free(parent);
+            free(traversal_order);
+            return;
+        }
+        int pathLen = 0;
+        int curr = dest;
+        while (curr != -1)
+        {
+            path[pathLen++] = curr;
+            curr = parent[curr];
+        }
+
+        printf("Discovered Path: ");
+        for (int i = pathLen - 1; i >= 0; i--)
+        {
+            printf("%d", path[i]);
+            if (i > 0)
+            {
+                printf(" -> ");
+            }
+        }
+        printf("\n");
+        free(path);
+    }
+
+    free(parent);
+    free(traversal_order);
+}
+
+void greedy_best_first_search_demo(void)
+{
+    int edges;
+    int graph_capacity;
+    int starting_node;
+    int destination_node;
+    weightedGraph* graph = NULL;
+    int* h = NULL;
+
+    while (1)
+    {
+        int graph_capacity_status = safe_input_int(&graph_capacity,
+                                                   "\nenter the number of vertices in the graph, "
+                                                   "(between 1 and 10), enter '-1' to exit : ",
+                                                   1, 10);
+
+        if (graph_capacity_status == INPUT_EXIT_SIGNAL)
+        {
+            printf("\nExiting Greedy Best-First Search demo.....\n");
+            return;
+        }
+
+        if (graph_capacity_status == 0)
+        {
+            continue;
+        }
+
+        graph = create_weightedGraph(graph_capacity);
+
+        if (!graph)
+        {
+            printf("\nmemory allocation failed\n");
+            return;
+        }
+
+        break;
+    }
+
+    while (1)
+    {
+        int edges_capacity_status = safe_input_int(
+            &edges, "\nenter number of edges (between 1 and 100), enter '-1' to exit :", 0, 100);
+
+        if (edges_capacity_status == INPUT_EXIT_SIGNAL)
+        {
+            printf("\nExiting Greedy Best-First Search demo\n");
+            free_weightedGraph(graph);
+            return;
+        }
+
+        if (edges_capacity_status == 0)
+        {
+            continue;
+        }
+
+        break;
+    }
+
+    printf("\nEnter source, destination, weight pairs (Source, Destination must be b/w 0 and %d "
+           "(both inclusive)):\n",
+           graph_capacity - 1);
+
+    for (int i = 0; i < edges; i++)
+    {
+        int src_status;
+        int dest_status;
+        int wt_status;
+        int src;
+        int dest;
+        int wt;
+
+    retry:
+        src_status = safe_input_int(&src, "src: ", 0, graph_capacity - 1);
+
+        if (src_status == INPUT_EXIT_SIGNAL)
+        {
+            printf("\nExiting Greedy Best-First Search demo\n");
+            free_weightedGraph(graph);
+            return;
+        }
+        if (src_status == 0)
+        {
+            goto retry;
+        }
+
+        dest_status = safe_input_int(&dest, "dest: ", 0, graph_capacity - 1);
+
+        if (dest_status == INPUT_EXIT_SIGNAL)
+        {
+            printf("\nExiting Greedy Best-First Search demo\n");
+            free_weightedGraph(graph);
+            return;
+        }
+        if (dest_status == 0)
+        {
+            goto retry;
+        }
+
+        wt_status = safe_input_int(&wt, "weight: ", 0, INT_MAX);
+
+        if (wt_status == INPUT_EXIT_SIGNAL)
+        {
+            printf("\nExiting Greedy Best-First Search demo\n");
+            free_weightedGraph(graph);
+            return;
+        }
+        if (wt_status == 0)
+        {
+            goto retry;
+        }
+
+        add_edge_directed(graph, src, dest, wt);
+    }
+
+    while (1)
+    {
+        if (!h)
+        {
+            h = malloc(graph_capacity * sizeof(int));
+            if (!h)
+            {
+                printf("\nmemory allocation failed for heuristics\n");
+                free_weightedGraph(graph);
+                return;
+            }
+
+            printf("\nEnter heuristic values for each vertex:\n");
+            for (int i = 0; i < graph_capacity; i++)
+            {
+                int h_val;
+                int h_status;
+                char prompt[50];
+                sprintf(prompt, "h(%d): ", i);
+            retry_h:
+                h_status = safe_input_int(&h_val, prompt, 0, INT_MAX);
+                if (h_status == INPUT_EXIT_SIGNAL)
+                {
+                    printf("\nExiting Greedy Best-First Search demo\n");
+                    free(h);
+                    free_weightedGraph(graph);
+                    return;
+                }
+                if (h_status == 0)
+                {
+                    goto retry_h;
+                }
+                h[i] = h_val;
+            }
+        }
+
+        while (1)
+        {
+            int start_status =
+                safe_input_int(&starting_node, "\nenter starting node: ", 0, graph_capacity - 1);
+
+            if (start_status == INPUT_EXIT_SIGNAL)
+            {
+                printf("\nExiting Greedy Best-First Search demo.....\n");
+                free(h);
+                free_weightedGraph(graph);
+                return;
+            }
+
+            if (start_status == 0)
+            {
+                continue;
+            }
+
+            break;
+        }
+
+        while (1)
+        {
+            int dest_status =
+                safe_input_int(&destination_node, "\nenter destination node: ", 0, graph_capacity - 1);
+
+            if (dest_status == INPUT_EXIT_SIGNAL)
+            {
+                printf("\nExiting Greedy Best-First Search demo.....\n");
+                free(h);
+                free_weightedGraph(graph);
+                return;
+            }
+
+            if (dest_status == 0)
+            {
+                continue;
+            }
+
+            break;
+        }
+
+        printf("\n");
+        greedy_best_first_search(graph, starting_node, destination_node, h);
+
+        int choice;
+    retry_choice:
+        printf("\nOptions:\n1. Re-run Greedy BFS with NEW heuristics\n2. Re-run Greedy BFS with SAME heuristics (new start/destination)\n0. Exit Greedy BFS demo\n");
+        int choice_status = safe_input_int(&choice, "Enter choice: ", 0, 2);
+        if (choice_status == INPUT_EXIT_SIGNAL || choice == 0)
+        {
+            printf("\nExiting Greedy Best-First Search demo.....\n");
+            free(h);
+            free_weightedGraph(graph);
+            return;
+        }
+        if (choice_status == 0)
+        {
+            goto retry_choice;
+        }
+
+        if (choice == 1)
+        {
+            free(h);
+            h = NULL;
+        }
+    }
+}

--- a/tests/test_greedy_best_first_search.c
+++ b/tests/test_greedy_best_first_search.c
@@ -1,0 +1,85 @@
+#include "graph_traversals.h"
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+void test_greedy_bfs_simple()
+{
+    weightedGraph* graph = create_weightedGraph(4);
+    assert(graph != NULL);
+
+    add_edge_directed(graph, 0, 1, 1);
+    add_edge_directed(graph, 0, 2, 1);
+    add_edge_directed(graph, 1, 3, 1);
+    add_edge_directed(graph, 2, 3, 1);
+
+    int h[] = {4, 1, 2, 0};
+    int parent[4];
+    int traversal_order[4];
+    int traversal_len = 0;
+
+    int found = greedy_best_first_search_solve(graph, 0, 3, h, parent, traversal_order, &traversal_len);
+
+    assert(found == 1);
+    assert(traversal_len == 3);
+    assert(traversal_order[0] == 0);
+    assert(traversal_order[1] == 1);
+    assert(traversal_order[2] == 3);
+    assert(parent[3] == 1);
+    assert(parent[1] == 0);
+
+    free_weightedGraph(graph);
+    printf("test_greedy_bfs_simple passed\n");
+}
+
+void test_greedy_bfs_unreachable()
+{
+    weightedGraph* graph = create_weightedGraph(3);
+    assert(graph != NULL);
+
+    add_edge_directed(graph, 0, 1, 1);
+
+    int h[] = {2, 1, 0};
+    int parent[3];
+    int traversal_order[3];
+    int traversal_len = 0;
+
+    int found = greedy_best_first_search_solve(graph, 0, 2, h, parent, traversal_order, &traversal_len);
+
+    assert(found == 0);
+
+    free_weightedGraph(graph);
+    printf("test_greedy_bfs_unreachable passed\n");
+}
+
+void test_greedy_bfs_same_src_dest()
+{
+    weightedGraph* graph = create_weightedGraph(3);
+    assert(graph != NULL);
+
+    add_edge_directed(graph, 0, 1, 1);
+
+    int h[] = {0, 0, 0};
+    int parent[3];
+    int traversal_order[3];
+    int traversal_len = 0;
+
+    int found = greedy_best_first_search_solve(graph, 1, 1, h, parent, traversal_order, &traversal_len);
+
+    assert(found == 1);
+    assert(traversal_len == 1);
+    assert(traversal_order[0] == 1);
+
+    free_weightedGraph(graph);
+    printf("test_greedy_bfs_same_src_dest passed\n");
+}
+
+int main()
+{
+    test_greedy_bfs_simple();
+    test_greedy_bfs_unreachable();
+    test_greedy_bfs_same_src_dest();
+
+    printf("All Greedy Best-First Search tests passed\n");
+    return 0;
+}


### PR DESCRIPTION
resolves #75
 ### Description
This PR implements the Greedy Best-First Search algorithm using the existing `weightedGraph` structure in the `graph_traversals` module to resolve issue #75.

### Key Implementation Details
- **Heuristic-Driven Priority Queue (Min-Heap):** Implemented a custom min-heap structure in `greedy_best_first_search.c` supporting `(h, node)` entries to select the node with the minimum heuristic value $h(n)$ at each step.
- **Closed Set (Visited Array):** Maintained a `visited` array to represent the closed set, avoiding redundant node expansions and preventing infinite loops in cyclic graphs.
- **Goal Test Timing:** The search correctly terminates when the destination vertex is popped from the priority queue.
- **Interactive Demo CLI:** Integrated as Option `6` inside the Graph Traversals interactive menu. Prompts for dynamic, non-negative heuristic values for all vertices, allows start/destination selections, and logs each popped node's parameters (`h` values) for educational visual tracing. It also supports re-running Greedy BFS on the same graph with either the same or newly input heuristics.

### Verification Results
- Created unit tests in `tests/test_greedy_best_first_search.c` covering optimal path accuracy, unreachable node scenarios, and same-source-destination boundary cases.
- Tested and verified compiling with `-Wall -Wextra -Werror -std=c11` under GCC:
```bash
make test_greedy_bfs
./test_greedy_bfs