### PR TITLE
test: add unit tests for sorting algorithms

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -224,7 +224,7 @@ TEST_BINS = test_circ_queue test_bst test_search test_hash_func \
             test_sll test_dll test_array test_stack test_tbt \
             test_priority_queue test_scll test_simple_queue \
             test_deque test_astar test_avl test_floyd_warshall \
-            test_greedy_bfs test_kruskal
+            test_greedy_bfs test_kruskal test_sorting_n2 test_advanced_sorting
 
 test_kruskal:
 	$(CC) $(CFLAGS) $(KRUSKAL_TEST_SRC) -o test_kruskal$(EXE)
@@ -235,3 +235,30 @@ test: $(TEST_BINS)
 .PHONY: $(TARGET) $(TEST_BINS)
 
 
+
+# ---- sorting algorithm unit tests (issue #92) ----
+SORTING_N2_TEST_SRC = \
+	src/sorting_algorithms_n2/bubble_sort.c \
+	src/sorting_algorithms_n2/insertion_sort.c \
+	src/sorting_algorithms_n2/selection_sort.c \
+	src/data_structures/array.c \
+	src/utils/safe_input_int.c \
+	tests/test_sorting_n2.c
+
+ADVANCED_SORTING_TEST_SRC = \
+	src/advanced_sorting_algorithms/quick_sort.c \
+	src/advanced_sorting_algorithms/merge_sort.c \
+	src/advanced_sorting_algorithms/heap_sort.c \
+	src/advanced_sorting_algorithms/radix_sort.c \
+	src/data_structures/priority_queue.c \
+	src/data_structures/array.c \
+	src/utils/safe_input_int.c \
+	tests/test_advanced_sorting.c
+
+test_sorting_n2:
+	$(CC) $(CFLAGS) $(SORTING_N2_TEST_SRC) -o test_sorting_n2$(EXE)
+	./test_sorting_n2$(EXE)
+
+test_advanced_sorting:
+	$(CC) $(CFLAGS) $(ADVANCED_SORTING_TEST_SRC) -o test_advanced_sorting$(EXE)
+	./test_advanced_sorting$(EXE)

--- a/tests/test_advanced_sorting.c
+++ b/tests/test_advanced_sorting.c
@@ -1,0 +1,261 @@
+#include <assert.h>
+#include <stdio.h>
+
+/* Functions under test (forward-declared, same approach as the other tests).
+   quicksort takes (arr, low, high); the rest take (arr, n). radix_sort only
+   supports non-negative integers, so every case below uses non-negative data
+   to keep one consistent set of expectations across all four algorithms. */
+void quicksort(int arr[], int low, int high);
+void merge_sort(int arr[], int n);
+void heap_sort(int arr[], int n);
+void radix_sort(int arr[], int n);
+
+void test_quick_sort()
+{
+    /* empty array: the sort must touch nothing */
+    int empty[1] = {42};
+    quicksort(empty, 0, -1);
+    assert(empty[0] == 42);
+
+    /* single element */
+    int single[1] = {7};
+    quicksort(single, 0, 0);
+    assert(single[0] == 7);
+
+    /* already sorted ascending */
+    int asc[6] = {1, 2, 3, 4, 5, 6};
+    quicksort(asc, 0, 5);
+    assert(asc[0] == 1);
+    assert(asc[1] == 2);
+    assert(asc[2] == 3);
+    assert(asc[3] == 4);
+    assert(asc[4] == 5);
+    assert(asc[5] == 6);
+
+    /* sorted descending (reverse order) */
+    int desc[6] = {6, 5, 4, 3, 2, 1};
+    quicksort(desc, 0, 5);
+    assert(desc[0] == 1);
+    assert(desc[1] == 2);
+    assert(desc[2] == 3);
+    assert(desc[3] == 4);
+    assert(desc[4] == 5);
+    assert(desc[5] == 6);
+
+    /* duplicate values */
+    int dup[8] = {5, 1, 5, 2, 1, 3, 5, 2};
+    quicksort(dup, 0, 7);
+    assert(dup[0] == 1);
+    assert(dup[1] == 1);
+    assert(dup[2] == 2);
+    assert(dup[3] == 2);
+    assert(dup[4] == 3);
+    assert(dup[5] == 5);
+    assert(dup[6] == 5);
+    assert(dup[7] == 5);
+
+    /* random values (multi-digit) */
+    int random_vals[9] = {170, 45, 75, 90, 2, 802, 24, 66, 1};
+    quicksort(random_vals, 0, 8);
+    assert(random_vals[0] == 1);
+    assert(random_vals[1] == 2);
+    assert(random_vals[2] == 24);
+    assert(random_vals[3] == 45);
+    assert(random_vals[4] == 66);
+    assert(random_vals[5] == 75);
+    assert(random_vals[6] == 90);
+    assert(random_vals[7] == 170);
+    assert(random_vals[8] == 802);
+
+    printf("Quick sort tests passed\n");
+}
+
+void test_merge_sort()
+{
+    /* empty array: the sort must touch nothing */
+    int empty[1] = {42};
+    merge_sort(empty, 0);
+    assert(empty[0] == 42);
+
+    /* single element */
+    int single[1] = {7};
+    merge_sort(single, 1);
+    assert(single[0] == 7);
+
+    /* already sorted ascending */
+    int asc[6] = {1, 2, 3, 4, 5, 6};
+    merge_sort(asc, 6);
+    assert(asc[0] == 1);
+    assert(asc[1] == 2);
+    assert(asc[2] == 3);
+    assert(asc[3] == 4);
+    assert(asc[4] == 5);
+    assert(asc[5] == 6);
+
+    /* sorted descending (reverse order) */
+    int desc[6] = {6, 5, 4, 3, 2, 1};
+    merge_sort(desc, 6);
+    assert(desc[0] == 1);
+    assert(desc[1] == 2);
+    assert(desc[2] == 3);
+    assert(desc[3] == 4);
+    assert(desc[4] == 5);
+    assert(desc[5] == 6);
+
+    /* duplicate values */
+    int dup[8] = {5, 1, 5, 2, 1, 3, 5, 2};
+    merge_sort(dup, 8);
+    assert(dup[0] == 1);
+    assert(dup[1] == 1);
+    assert(dup[2] == 2);
+    assert(dup[3] == 2);
+    assert(dup[4] == 3);
+    assert(dup[5] == 5);
+    assert(dup[6] == 5);
+    assert(dup[7] == 5);
+
+    /* random values (multi-digit) */
+    int random_vals[9] = {170, 45, 75, 90, 2, 802, 24, 66, 1};
+    merge_sort(random_vals, 9);
+    assert(random_vals[0] == 1);
+    assert(random_vals[1] == 2);
+    assert(random_vals[2] == 24);
+    assert(random_vals[3] == 45);
+    assert(random_vals[4] == 66);
+    assert(random_vals[5] == 75);
+    assert(random_vals[6] == 90);
+    assert(random_vals[7] == 170);
+    assert(random_vals[8] == 802);
+
+    printf("Merge sort tests passed\n");
+}
+
+void test_heap_sort()
+{
+    /* empty array: the sort must touch nothing */
+    int empty[1] = {42};
+    heap_sort(empty, 0);
+    assert(empty[0] == 42);
+
+    /* single element */
+    int single[1] = {7};
+    heap_sort(single, 1);
+    assert(single[0] == 7);
+
+    /* already sorted ascending */
+    int asc[6] = {1, 2, 3, 4, 5, 6};
+    heap_sort(asc, 6);
+    assert(asc[0] == 1);
+    assert(asc[1] == 2);
+    assert(asc[2] == 3);
+    assert(asc[3] == 4);
+    assert(asc[4] == 5);
+    assert(asc[5] == 6);
+
+    /* sorted descending (reverse order) */
+    int desc[6] = {6, 5, 4, 3, 2, 1};
+    heap_sort(desc, 6);
+    assert(desc[0] == 1);
+    assert(desc[1] == 2);
+    assert(desc[2] == 3);
+    assert(desc[3] == 4);
+    assert(desc[4] == 5);
+    assert(desc[5] == 6);
+
+    /* duplicate values */
+    int dup[8] = {5, 1, 5, 2, 1, 3, 5, 2};
+    heap_sort(dup, 8);
+    assert(dup[0] == 1);
+    assert(dup[1] == 1);
+    assert(dup[2] == 2);
+    assert(dup[3] == 2);
+    assert(dup[4] == 3);
+    assert(dup[5] == 5);
+    assert(dup[6] == 5);
+    assert(dup[7] == 5);
+
+    /* random values (multi-digit) */
+    int random_vals[9] = {170, 45, 75, 90, 2, 802, 24, 66, 1};
+    heap_sort(random_vals, 9);
+    assert(random_vals[0] == 1);
+    assert(random_vals[1] == 2);
+    assert(random_vals[2] == 24);
+    assert(random_vals[3] == 45);
+    assert(random_vals[4] == 66);
+    assert(random_vals[5] == 75);
+    assert(random_vals[6] == 90);
+    assert(random_vals[7] == 170);
+    assert(random_vals[8] == 802);
+
+    printf("Heap sort tests passed\n");
+}
+
+void test_radix_sort()
+{
+    /* empty array: the sort must touch nothing */
+    int empty[1] = {42};
+    radix_sort(empty, 0);
+    assert(empty[0] == 42);
+
+    /* single element */
+    int single[1] = {7};
+    radix_sort(single, 1);
+    assert(single[0] == 7);
+
+    /* already sorted ascending */
+    int asc[6] = {1, 2, 3, 4, 5, 6};
+    radix_sort(asc, 6);
+    assert(asc[0] == 1);
+    assert(asc[1] == 2);
+    assert(asc[2] == 3);
+    assert(asc[3] == 4);
+    assert(asc[4] == 5);
+    assert(asc[5] == 6);
+
+    /* sorted descending (reverse order) */
+    int desc[6] = {6, 5, 4, 3, 2, 1};
+    radix_sort(desc, 6);
+    assert(desc[0] == 1);
+    assert(desc[1] == 2);
+    assert(desc[2] == 3);
+    assert(desc[3] == 4);
+    assert(desc[4] == 5);
+    assert(desc[5] == 6);
+
+    /* duplicate values */
+    int dup[8] = {5, 1, 5, 2, 1, 3, 5, 2};
+    radix_sort(dup, 8);
+    assert(dup[0] == 1);
+    assert(dup[1] == 1);
+    assert(dup[2] == 2);
+    assert(dup[3] == 2);
+    assert(dup[4] == 3);
+    assert(dup[5] == 5);
+    assert(dup[6] == 5);
+    assert(dup[7] == 5);
+
+    /* random values (multi-digit, exercises multiple radix passes) */
+    int random_vals[9] = {170, 45, 75, 90, 2, 802, 24, 66, 1};
+    radix_sort(random_vals, 9);
+    assert(random_vals[0] == 1);
+    assert(random_vals[1] == 2);
+    assert(random_vals[2] == 24);
+    assert(random_vals[3] == 45);
+    assert(random_vals[4] == 66);
+    assert(random_vals[5] == 75);
+    assert(random_vals[6] == 90);
+    assert(random_vals[7] == 170);
+    assert(random_vals[8] == 802);
+
+    printf("Radix sort tests passed\n");
+}
+
+int main()
+{
+    test_quick_sort();
+    test_merge_sort();
+    test_heap_sort();
+    test_radix_sort();
+    printf("All advanced sorting tests passed\n");
+    return 0;
+}

--- a/tests/test_sorting_n2.c
+++ b/tests/test_sorting_n2.c
@@ -1,0 +1,186 @@
+#include <assert.h>
+#include <stdio.h>
+
+/* Functions under test. They have external linkage but are not exposed in
+   sorting_algorithms_n2.h, so we forward-declare them here (same approach the
+   other test files use). All three share the (arr, length) signature. */
+void bubble_sort_optimized(int arr[], int length_of_array);
+void insertion_sort(int arr[], int length_of_array);
+void selection_sort(int arr[], int length_of_array);
+
+void test_bubble_sort()
+{
+    /* empty array: the sort must touch nothing */
+    int empty[1] = {42};
+    bubble_sort_optimized(empty, 0);
+    assert(empty[0] == 42);
+
+    /* single element */
+    int single[1] = {7};
+    bubble_sort_optimized(single, 1);
+    assert(single[0] == 7);
+
+    /* already sorted ascending */
+    int asc[5] = {1, 2, 3, 4, 5};
+    bubble_sort_optimized(asc, 5);
+    assert(asc[0] == 1);
+    assert(asc[1] == 2);
+    assert(asc[2] == 3);
+    assert(asc[3] == 4);
+    assert(asc[4] == 5);
+
+    /* sorted descending (reverse order) */
+    int desc[5] = {5, 4, 3, 2, 1};
+    bubble_sort_optimized(desc, 5);
+    assert(desc[0] == 1);
+    assert(desc[1] == 2);
+    assert(desc[2] == 3);
+    assert(desc[3] == 4);
+    assert(desc[4] == 5);
+
+    /* duplicate values */
+    int dup[7] = {4, 1, 4, 2, 1, 3, 4};
+    bubble_sort_optimized(dup, 7);
+    assert(dup[0] == 1);
+    assert(dup[1] == 1);
+    assert(dup[2] == 2);
+    assert(dup[3] == 3);
+    assert(dup[4] == 4);
+    assert(dup[5] == 4);
+    assert(dup[6] == 4);
+
+    /* random values (including negatives) */
+    int random_vals[8] = {9, -3, 0, 7, -10, 5, 2, -3};
+    bubble_sort_optimized(random_vals, 8);
+    assert(random_vals[0] == -10);
+    assert(random_vals[1] == -3);
+    assert(random_vals[2] == -3);
+    assert(random_vals[3] == 0);
+    assert(random_vals[4] == 2);
+    assert(random_vals[5] == 5);
+    assert(random_vals[6] == 7);
+    assert(random_vals[7] == 9);
+
+    printf("Bubble sort tests passed\n");
+}
+
+void test_insertion_sort()
+{
+    /* empty array: the sort must touch nothing */
+    int empty[1] = {42};
+    insertion_sort(empty, 0);
+    assert(empty[0] == 42);
+
+    /* single element */
+    int single[1] = {7};
+    insertion_sort(single, 1);
+    assert(single[0] == 7);
+
+    /* already sorted ascending */
+    int asc[5] = {1, 2, 3, 4, 5};
+    insertion_sort(asc, 5);
+    assert(asc[0] == 1);
+    assert(asc[1] == 2);
+    assert(asc[2] == 3);
+    assert(asc[3] == 4);
+    assert(asc[4] == 5);
+
+    /* sorted descending (reverse order) */
+    int desc[5] = {5, 4, 3, 2, 1};
+    insertion_sort(desc, 5);
+    assert(desc[0] == 1);
+    assert(desc[1] == 2);
+    assert(desc[2] == 3);
+    assert(desc[3] == 4);
+    assert(desc[4] == 5);
+
+    /* duplicate values */
+    int dup[7] = {4, 1, 4, 2, 1, 3, 4};
+    insertion_sort(dup, 7);
+    assert(dup[0] == 1);
+    assert(dup[1] == 1);
+    assert(dup[2] == 2);
+    assert(dup[3] == 3);
+    assert(dup[4] == 4);
+    assert(dup[5] == 4);
+    assert(dup[6] == 4);
+
+    /* random values (including negatives) */
+    int random_vals[8] = {9, -3, 0, 7, -10, 5, 2, -3};
+    insertion_sort(random_vals, 8);
+    assert(random_vals[0] == -10);
+    assert(random_vals[1] == -3);
+    assert(random_vals[2] == -3);
+    assert(random_vals[3] == 0);
+    assert(random_vals[4] == 2);
+    assert(random_vals[5] == 5);
+    assert(random_vals[6] == 7);
+    assert(random_vals[7] == 9);
+
+    printf("Insertion sort tests passed\n");
+}
+
+void test_selection_sort()
+{
+    /* empty array: the sort must touch nothing */
+    int empty[1] = {42};
+    selection_sort(empty, 0);
+    assert(empty[0] == 42);
+
+    /* single element */
+    int single[1] = {7};
+    selection_sort(single, 1);
+    assert(single[0] == 7);
+
+    /* already sorted ascending */
+    int asc[5] = {1, 2, 3, 4, 5};
+    selection_sort(asc, 5);
+    assert(asc[0] == 1);
+    assert(asc[1] == 2);
+    assert(asc[2] == 3);
+    assert(asc[3] == 4);
+    assert(asc[4] == 5);
+
+    /* sorted descending (reverse order) */
+    int desc[5] = {5, 4, 3, 2, 1};
+    selection_sort(desc, 5);
+    assert(desc[0] == 1);
+    assert(desc[1] == 2);
+    assert(desc[2] == 3);
+    assert(desc[3] == 4);
+    assert(desc[4] == 5);
+
+    /* duplicate values */
+    int dup[7] = {4, 1, 4, 2, 1, 3, 4};
+    selection_sort(dup, 7);
+    assert(dup[0] == 1);
+    assert(dup[1] == 1);
+    assert(dup[2] == 2);
+    assert(dup[3] == 3);
+    assert(dup[4] == 4);
+    assert(dup[5] == 4);
+    assert(dup[6] == 4);
+
+    /* random values (including negatives) */
+    int random_vals[8] = {9, -3, 0, 7, -10, 5, 2, -3};
+    selection_sort(random_vals, 8);
+    assert(random_vals[0] == -10);
+    assert(random_vals[1] == -3);
+    assert(random_vals[2] == -3);
+    assert(random_vals[3] == 0);
+    assert(random_vals[4] == 2);
+    assert(random_vals[5] == 5);
+    assert(random_vals[6] == 7);
+    assert(random_vals[7] == 9);
+
+    printf("Selection sort tests passed\n");
+}
+
+int main()
+{
+    test_bubble_sort();
+    test_insertion_sort();
+    test_selection_sort();
+    printf("All O(n^2) sorting tests passed\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary

Adds the missing automated unit tests for the sorting algorithms, as requested in #92.

- `tests/test_sorting_n2.c` — validates `bubble_sort_optimized`, `insertion_sort`, `selection_sort`
- `tests/test_advanced_sorting.c` — validates `quicksort`, `merge_sort`, `heap_sort`, `radix_sort`

## Cases covered (per algorithm)

- empty array and single-element array
- already-sorted ascending input
- sorted descending (reverse) input
- arrays with duplicate values
- random values

Following the convention in `tests/test_array.c`, each result is checked with explicit per-element `assert(arr[i] == expected)` calls.

## Conventions / notes

- Forward-declares the functions under test (they are not exposed in the module headers), matching the existing test files.
- `radix_sort` only supports non-negative integers, so the advanced-sort cases use non-negative data; the O(n^2) tests additionally cover negatives.
- Wired both targets into the Makefile (sources, run targets and `TEST_BINS`), so `make test`, `make valgrind` and `clean` pick them up.

## Verification (local)

- Clean build under `-Wall -Wextra -Werror -std=c11`
- Full `make test` green (no regressions)
- `valgrind` clean (0 errors, 0 leaks) on both new binaries
- `clang-format` clean

Closes #92
