### PR TITLE
refactor: add time delay between loop iterations in expression demos

### DIFF
--- a/src/expression_evaluation/infix_to_postfix.c
+++ b/src/expression_evaluation/infix_to_postfix.c
@@ -4,6 +4,7 @@
 #include <ctype.h>
 #include <stdio.h>
 #include <string.h>
+#include <unistd.h>
 
 // rn this program only has support for four operators - +-/* and parantheses. this program doesnt
 // support '^ or %' operators maximum expression length is 50 characters
@@ -149,6 +150,7 @@ void infix_to_postfix_Demo(void)
             printf("----------------------------------\n");
 
             i++;
+            sleep(1);
         }
 
         while (!isEmpty(operators))

--- a/src/expression_evaluation/postfix_evaluation.c
+++ b/src/expression_evaluation/postfix_evaluation.c
@@ -2,6 +2,7 @@
 #include "stack.h"
 #include <ctype.h>
 #include <stdio.h>
+#include <unistd.h>
 
 // if postfix expression attempts to divide by zero or the stack doesnt get emptied at the end of
 // main while loop, it indicates malformed postfix expression and program exits with error code '-1'
@@ -128,6 +129,7 @@ void postfix_evaluation_Demo(void)
             }
 
             i++;
+            sleep(1);
         }
 
         int final_result = pop(operands);


### PR DESCRIPTION
## Description

This PR adds a 1-second delay between loop iterations in the demo functions of:

* `infix_to_postfix.c`
* `postfix_evaluation.c`

### Changes Made

* Added `sleep(1)` at the end of parsing loops to improve visualization
* Added `unistd.h` for `sleep()` support where required

### Why

This allows users to observe expression parsing and evaluation step-by-step instead of the output scrolling instantly.

### Testing Done

* Verified delay in infix to postfix demo
* Verified delay in postfix evaluation demo
* Confirmed successful build and execution locally

Fixes #97