### PR TITLE
Add visualization delays for expression and sorting demos

### DIFF
--- a/src/expression_evaluation/infix_to_postfix.c
+++ b/src/expression_evaluation/infix_to_postfix.c
@@ -4,6 +4,7 @@
 #include <ctype.h>
 #include <stdio.h>
 #include <string.h>
+#include <unistd.h>
 
 // rn this program only has support for four operators - +-/* and parantheses. this program doesnt
 // support '^ or %' operators maximum expression length is 50 characters
@@ -149,6 +150,7 @@ void infix_to_postfix_Demo(void)
             printf("----------------------------------\n");
 
             i++;
+            sleep(1);
         }
 
         while (!isEmpty(operators))

--- a/src/expression_evaluation/postfix_evaluation.c
+++ b/src/expression_evaluation/postfix_evaluation.c
@@ -2,6 +2,7 @@
 #include "stack.h"
 #include <ctype.h>
 #include <stdio.h>
+#include <unistd.h>
 
 // if postfix expression attempts to divide by zero or the stack doesnt get emptied at the end of
 // main while loop, it indicates malformed postfix expression and program exits with error code '-1'
@@ -128,6 +129,7 @@ void postfix_evaluation_Demo(void)
             }
 
             i++;
+            sleep(1);
         }
 
         int final_result = pop(operands);

--- a/src/sorting_algorithms_n2/bubble_sort.c
+++ b/src/sorting_algorithms_n2/bubble_sort.c
@@ -3,6 +3,7 @@
 #include "history_logger.h"
 #include <stdio.h>
 #include <time.h>
+#include <unistd.h>
 
 void bubble_sort_optimized(int arr[], int length_of_array);
 
@@ -82,6 +83,7 @@ void bubble_sort_optimized(int arr[], int length_of_array)
         printf("after iteration no %d - ", i + 1);
         print_array(arr, length_of_array);
         printf("\n");
+        sleep(1);
     }
 
     end_t = clock(); // time recorded at the end of the algorithm

--- a/src/sorting_algorithms_n2/insertion_sort.c
+++ b/src/sorting_algorithms_n2/insertion_sort.c
@@ -3,6 +3,7 @@
 #include "history_logger.h"
 #include <stdio.h>
 #include <time.h>
+#include <unistd.h>
 
 void insertion_sort(int arr[], int length_of_array);
 
@@ -77,6 +78,7 @@ void insertion_sort(int arr[], int length_of_array)
         printf("after iteration no %d - ", i);
         print_array(arr, length_of_array);
         printf("\n");
+        sleep(1);
     }
 
     end_t = clock();

--- a/src/sorting_algorithms_n2/selection_sort.c
+++ b/src/sorting_algorithms_n2/selection_sort.c
@@ -3,6 +3,7 @@
 #include "history_logger.h"
 #include <stdio.h>
 #include <time.h>
+#include <unistd.h>
 
 void selection_sort(int arr[], int length_of_array);
 
@@ -75,9 +76,10 @@ void selection_sort(int arr[], int length_of_array)
             arr[i] = temp;
         }
 
-        // printf("after iteration no %d - ",i+1);
-        // print_array(arr,length_of_array);
-        // printf("\n");
+        printf("after iteration no %d - ",i+1);
+        print_array(arr,length_of_array);
+        printf("\n");
+        sleep(1);
     }
 
     end_t = clock();


### PR DESCRIPTION
## Description

This PR adds a 1-second delay between visualization steps to improve user understanding of algorithm execution.

### Changes Made

#### Expression Evaluation

Added step-by-step delay in:

* `infix_to_postfix.c`
* `postfix_evaluation.c`

#### Sorting Algorithms (`sorting_algorithms_n2`)

Added visualization delay in:

* Bubble Sort
* Selection Sort
* Insertion Sort

### Implementation Details

* Added `sleep(1)` between iterations to allow users to observe state changes clearly.
* Used `unistd.h` for `sleep()` support where required.

### Why

Previously, outputs were scrolling instantly, making it difficult for users to understand intermediate states. This change improves educational clarity by enabling step-by-step visualization of algorithm execution.

### Testing Done

* Verified delay in infix to postfix demo
* Verified delay in postfix evaluation demo
* Verified delay in bubble sort demo
* Verified delay in selection sort demo
* Verified delay in insertion sort demo
* Confirmed successful build and execution locally

Fixes #97 