### PR TITLE
refactor(graph): reuse a shared PQ_graph in A* and Greedy-BFS (Closes #95)

### DIFF
--- a/src/graph_traversals/astar.c
+++ b/src/graph_traversals/astar.c
@@ -3,153 +3,6 @@
 #include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
-
-typedef struct
-{
-    int f;
-    int node;
-} HeapNode;
-
-typedef struct
-{
-    HeapNode* data;
-    int size;
-    int capacity;
-} MinHeap;
-
-MinHeap* create_min_heap(int capacity)
-{
-    MinHeap* heap = malloc(sizeof(MinHeap));
-    if (!heap)
-    {
-        return NULL;
-    }
-    heap->data = malloc(capacity * sizeof(HeapNode));
-    if (!heap->data)
-    {
-        free(heap);
-        return NULL;
-    }
-    heap->size = 0;
-    heap->capacity = capacity;
-    return heap;
-}
-
-void free_min_heap(MinHeap* heap)
-{
-    if (heap)
-    {
-        free(heap->data);
-        free(heap);
-    }
-}
-
-void swap_heap_nodes(HeapNode* a, HeapNode* b)
-{
-    HeapNode temp = *a;
-    *a = *b;
-    *b = temp;
-}
-
-int compare_nodes(HeapNode a, HeapNode b, int h[])
-{
-    if (a.f < b.f)
-    {
-        return -1;
-    }
-    if (a.f > b.f)
-    {
-        return 1;
-    }
-    // Tie-break: prefer lower h value (more goal-directed)
-    if (h[a.node] < h[b.node])
-    {
-        return -1;
-    }
-    if (h[a.node] > h[b.node])
-    {
-        return 1;
-    }
-    // Further tie-break: prefer lower node ID
-    if (a.node < b.node)
-    {
-        return -1;
-    }
-    if (a.node > b.node)
-    {
-        return 1;
-    }
-    return 0;
-}
-
-void heapify_up(MinHeap* heap, int idx, int h[])
-{
-    while (idx > 0)
-    {
-        int parent = (idx - 1) / 2;
-        if (compare_nodes(heap->data[idx], heap->data[parent], h) < 0)
-        {
-            swap_heap_nodes(&heap->data[idx], &heap->data[parent]);
-            idx = parent;
-        }
-        else
-        {
-            break;
-        }
-    }
-}
-
-void heapify_down(MinHeap* heap, int idx, int h[])
-{
-    int smallest = idx;
-    int left = 2 * idx + 1;
-    int right = 2 * idx + 2;
-
-    if (left < heap->size && compare_nodes(heap->data[left], heap->data[smallest], h) < 0)
-    {
-        smallest = left;
-    }
-    if (right < heap->size && compare_nodes(heap->data[right], heap->data[smallest], h) < 0)
-    {
-        smallest = right;
-    }
-
-    if (smallest != idx)
-    {
-        swap_heap_nodes(&heap->data[idx], &heap->data[smallest]);
-        heapify_down(heap, smallest, h);
-    }
-}
-
-int heap_push(MinHeap* heap, int f, int node, int h[])
-{
-    if (heap->size >= heap->capacity)
-    {
-        return 0;
-    }
-    heap->data[heap->size].f = f;
-    heap->data[heap->size].node = node;
-    heapify_up(heap, heap->size, h);
-    heap->size++;
-    return 1;
-}
-
-int heap_pop(MinHeap* heap, HeapNode* popped, int h[])
-{
-    if (heap->size <= 0)
-    {
-        return 0;
-    }
-    *popped = heap->data[0];
-    heap->size--;
-    if (heap->size > 0)
-    {
-        heap->data[0] = heap->data[heap->size];
-        heapify_down(heap, 0, h);
-    }
-    return 1;
-}
 
 int astar_solve(weightedGraph* graph, int start, int dest, int h[], int parent[])
 {
@@ -159,16 +12,6 @@ int astar_solve(weightedGraph* graph, int start, int dest, int h[], int parent[]
     int* fScore = malloc(size * sizeof(int));
 
     if (!visited || !dist || !fScore)
-    {
-        free(visited);
-        free(dist);
-        free(fScore);
-        return -1;
-    }
-
-    // Allocate heap to hold up to size * size entries (to support duplicates)
-    MinHeap* heap = create_min_heap(size * size + 5);
-    if (!heap)
     {
         free(visited);
         free(dist);
@@ -186,29 +29,31 @@ int astar_solve(weightedGraph* graph, int start, int dest, int h[], int parent[]
         }
     }
 
+    // Reuse the shared graph priority queue: a min-heap keyed on the node's
+    // "distance" field, which here carries the f-score (f = g + h). Duplicate
+    // entries are handled lazily via the visited[] check on pop.
+    PQ_graph pq;
+    pq.size = 0;
+
     dist[start] = 0;
     fScore[start] = h[start];
-    heap_push(heap, fScore[start], start, h);
+    insert_pq_graph(&pq, start, fScore[start]);
 
     int result = INT_MAX;
 
-    while (heap->size > 0)
+    PQ_graph_node popped;
+    while (extractTop_pq_graph(&pq, &popped))
     {
-        HeapNode popped;
-        if (!heap_pop(heap, &popped, h))
-        {
-            break;
-        }
-
-        int u = popped.node;
+        int u = popped.vertex;
 
         if (visited[u])
         {
             continue;
         }
 
-        // Display expansion details for learning/trace
-        printf("[Expansion] Popped Node %d | g = %d, h = %d, f = %d\n", u, dist[u], h[u], popped.f);
+        // Display expansion details for learning/trace (popped.distance == f)
+        printf("[Expansion] Popped Node %d | g = %d, h = %d, f = %d\n", u, dist[u], h[u],
+               popped.distance);
 
         // Goal timing: stop when popped
         if (u == dest)
@@ -243,14 +88,13 @@ int astar_solve(weightedGraph* graph, int start, int dest, int h[], int parent[]
                     }
                     fScore[v] = tentative_f;
 
-                    heap_push(heap, fScore[v], v, h);
+                    insert_pq_graph(&pq, v, fScore[v]);
                 }
             }
             current = current->next;
         }
     }
 
-    free_min_heap(heap);
     free(visited);
     free(dist);
     free(fScore);
@@ -478,8 +322,8 @@ void astar_demo(void)
 
         while (1)
         {
-            int dest_status =
-                safe_input_int(&destination_node, "\nenter destination node: ", 0, graph_capacity - 1);
+            int dest_status = safe_input_int(&destination_node, "\nenter destination node: ", 0,
+                                             graph_capacity - 1);
 
             if (dest_status == INPUT_EXIT_SIGNAL)
             {
@@ -502,7 +346,8 @@ void astar_demo(void)
 
         int choice;
     retry_choice:
-        printf("\nOptions:\n1. Re-run A* with NEW heuristics\n2. Re-run A* with SAME heuristics (new start/destination)\n0. Exit A* demo\n");
+        printf("\nOptions:\n1. Re-run A* with NEW heuristics\n2. Re-run A* with SAME heuristics "
+               "(new start/destination)\n0. Exit A* demo\n");
         int choice_status = safe_input_int(&choice, "Enter choice: ", 0, 2);
         if (choice_status == INPUT_EXIT_SIGNAL || choice == 0)
         {

--- a/src/graph_traversals/dijkstra.c
+++ b/src/graph_traversals/dijkstra.c
@@ -4,7 +4,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-int insert_pq_dijkstra(PQ_dijkstra* pq, int vertex, int distance)
+int insert_pq_graph(PQ_graph* pq, int vertex, int distance)
 {
     if (pq == NULL || pq->size == HEAP_CAPACITY)
         return 0;
@@ -20,7 +20,7 @@ int insert_pq_dijkstra(PQ_dijkstra* pq, int vertex, int distance)
         if (pq->heap[i].distance >= pq->heap[parent].distance)
             break;
 
-        PQ_dijkstra_node temp = pq->heap[i];
+        PQ_graph_node temp = pq->heap[i];
         pq->heap[i] = pq->heap[parent];
         pq->heap[parent] = temp;
 
@@ -30,13 +30,13 @@ int insert_pq_dijkstra(PQ_dijkstra* pq, int vertex, int distance)
     return 1;
 }
 
-bool extractTop_pq_dijkstra(PQ_dijkstra* pq, PQ_dijkstra_node* result)
+bool extractTop_pq_graph(PQ_graph* pq, PQ_graph_node* result)
 {
     if (pq == NULL || result == NULL || pq->size == 0)
         return false;
 
     int topIndex = 0;
-    PQ_dijkstra_node topElement = pq->heap[topIndex];
+    PQ_graph_node topElement = pq->heap[topIndex];
     int lastElementIndex = pq->size - 1;
 
     pq->heap[topIndex] = pq->heap[lastElementIndex];
@@ -58,7 +58,7 @@ bool extractTop_pq_dijkstra(PQ_dijkstra* pq, PQ_dijkstra_node* result)
         if (target == i)
             break;
 
-        PQ_dijkstra_node temp = pq->heap[i];
+        PQ_graph_node temp = pq->heap[i];
         pq->heap[i] = pq->heap[target];
         pq->heap[target] = temp;
 
@@ -80,13 +80,13 @@ void dijkstra(weightedGraph* graph, int start)
 
     dist[start] = 0;
 
-    PQ_dijkstra pq;
+    PQ_graph pq;
     pq.size = 0;
-    insert_pq_dijkstra(&pq, start, 0);
+    insert_pq_graph(&pq, start, 0);
 
-    PQ_dijkstra_node currentNode;
+    PQ_graph_node currentNode;
 
-    while (extractTop_pq_dijkstra(&pq, &currentNode))
+    while (extractTop_pq_graph(&pq, &currentNode))
     {
         int u = currentNode.vertex;
 
@@ -102,7 +102,7 @@ void dijkstra(weightedGraph* graph, int start)
             if (dist[u] != INT_MAX && dist[u] + currentWeight < dist[v])
             {
                 dist[v] = dist[u] + currentWeight;
-                insert_pq_dijkstra(&pq, v, dist[v]);
+                insert_pq_graph(&pq, v, dist[v]);
             }
 
             current = current->next;

--- a/src/graph_traversals/graph_traversals.h
+++ b/src/graph_traversals/graph_traversals.h
@@ -31,16 +31,15 @@ typedef struct
 {
     int vertex;
     int distance;
-} PQ_dijkstra_node;
+} PQ_graph_node;
 
 typedef struct
 {
     int size;
-    PQ_dijkstra_node heap[HEAP_CAPACITY];
-} PQ_dijkstra;
-int insert_pq_dijkstra(PQ_dijkstra* pq, int vertex, int distance);
-bool extractTop_pq_dijkstra(PQ_dijkstra* pq, PQ_dijkstra_node* result);
-
+    PQ_graph_node heap[HEAP_CAPACITY];
+} PQ_graph;
+int insert_pq_graph(PQ_graph* pq, int vertex, int distance);
+bool extractTop_pq_graph(PQ_graph* pq, PQ_graph_node* result);
 
 // New graph structure which stores the new type of edge node
 typedef struct weightedGraph
@@ -62,16 +61,12 @@ int astar_solve(weightedGraph* graph, int start, int dest, int h[], int parent[]
 void astar(weightedGraph* graph, int start, int dest, int h[]);
 void astar_demo(void);
 
-
 // ------------------For Greedy Best-First Search-----------------------
 
-int greedy_best_first_search_solve(weightedGraph* graph, int start, int dest,
-                                   int h[], int parent[],
-                                   int traversal_order[],
-                                   int* traversal_len);
+int greedy_best_first_search_solve(weightedGraph* graph, int start, int dest, int h[], int parent[],
+                                   int traversal_order[], int* traversal_len);
 
 void greedy_best_first_search(weightedGraph* graph, int start, int dest, int h[]);
 void greedy_best_first_search_demo(void);
-
 
 #endif

--- a/src/graph_traversals/greedy_best_first_search.c
+++ b/src/graph_traversals/greedy_best_first_search.c
@@ -3,146 +3,9 @@
 #include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
 
-typedef struct
-{
-    int h;
-    int node;
-} HeapNode;
-
-typedef struct
-{
-    HeapNode* data;
-    int size;
-    int capacity;
-} MinHeap;
-
-static MinHeap* create_min_heap(int capacity)
-{
-    MinHeap* heap = malloc(sizeof(MinHeap));
-    if (!heap)
-    {
-        return NULL;
-    }
-    heap->data = malloc(capacity * sizeof(HeapNode));
-    if (!heap->data)
-    {
-        free(heap);
-        return NULL;
-    }
-    heap->size = 0;
-    heap->capacity = capacity;
-    return heap;
-}
-
-static void free_min_heap(MinHeap* heap)
-{
-    if (heap)
-    {
-        free(heap->data);
-        free(heap);
-    }
-}
-
-static void swap_heap_nodes(HeapNode* a, HeapNode* b)
-{
-    HeapNode temp = *a;
-    *a = *b;
-    *b = temp;
-}
-
-static int compare_nodes(HeapNode a, HeapNode b)
-{
-    if (a.h < b.h)
-    {
-        return -1;
-    }
-    if (a.h > b.h)
-    {
-        return 1;
-    }
-    // Tie-break: prefer lower node ID
-    if (a.node < b.node)
-    {
-        return -1;
-    }
-    if (a.node > b.node)
-    {
-        return 1;
-    }
-    return 0;
-}
-
-static void heapify_up(MinHeap* heap, int idx)
-{
-    while (idx > 0)
-    {
-        int parent = (idx - 1) / 2;
-        if (compare_nodes(heap->data[idx], heap->data[parent]) < 0)
-        {
-            swap_heap_nodes(&heap->data[idx], &heap->data[parent]);
-            idx = parent;
-        }
-        else
-        {
-            break;
-        }
-    }
-}
-
-static void heapify_down(MinHeap* heap, int idx)
-{
-    int smallest = idx;
-    int left = 2 * idx + 1;
-    int right = 2 * idx + 2;
-
-    if (left < heap->size && compare_nodes(heap->data[left], heap->data[smallest]) < 0)
-    {
-        smallest = left;
-    }
-    if (right < heap->size && compare_nodes(heap->data[right], heap->data[smallest]) < 0)
-    {
-        smallest = right;
-    }
-
-    if (smallest != idx)
-    {
-        swap_heap_nodes(&heap->data[idx], &heap->data[smallest]);
-        heapify_down(heap, smallest);
-    }
-}
-
-static int heap_push(MinHeap* heap, int h_val, int node)
-{
-    if (heap->size >= heap->capacity)
-    {
-        return 0;
-    }
-    heap->data[heap->size].h = h_val;
-    heap->data[heap->size].node = node;
-    heapify_up(heap, heap->size);
-    heap->size++;
-    return 1;
-}
-
-static int heap_pop(MinHeap* heap, HeapNode* popped)
-{
-    if (heap->size <= 0)
-    {
-        return 0;
-    }
-    *popped = heap->data[0];
-    heap->size--;
-    if (heap->size > 0)
-    {
-        heap->data[0] = heap->data[heap->size];
-        heapify_down(heap, 0);
-    }
-    return 1;
-}
-
-int greedy_best_first_search_solve(weightedGraph* graph, int start, int dest, int h[], int parent[], int traversal_order[], int* traversal_len)
+int greedy_best_first_search_solve(weightedGraph* graph, int start, int dest, int h[], int parent[],
+                                   int traversal_order[], int* traversal_len)
 {
     int size = graph->V;
     int* visited = calloc(size, sizeof(int));
@@ -151,32 +14,26 @@ int greedy_best_first_search_solve(weightedGraph* graph, int start, int dest, in
         return 0;
     }
 
-    MinHeap* heap = create_min_heap(size * size + 5);
-    if (!heap)
-    {
-        free(visited);
-        return 0;
-    }
+    // Reuse the shared graph priority queue: a min-heap keyed on the node's
+    // "distance" field, which here carries the heuristic h. Duplicate entries
+    // are handled lazily via the visited[] check on pop.
+    PQ_graph pq;
+    pq.size = 0;
 
     for (int i = 0; i < size; i++)
     {
         parent[i] = -1;
     }
 
-    heap_push(heap, h[start], start);
+    insert_pq_graph(&pq, start, h[start]);
 
     int found = 0;
     *traversal_len = 0;
 
-    while (heap->size > 0)
+    PQ_graph_node popped;
+    while (extractTop_pq_graph(&pq, &popped))
     {
-        HeapNode popped;
-        if (!heap_pop(heap, &popped))
-        {
-            break;
-        }
-
-        int u = popped.node;
+        int u = popped.vertex;
         if (visited[u])
         {
             continue;
@@ -202,13 +59,12 @@ int greedy_best_first_search_solve(weightedGraph* graph, int start, int dest, in
             if (!visited[v] && parent[v] == -1 && v != start)
             {
                 parent[v] = u;
-                heap_push(heap, h[v], v);
+                insert_pq_graph(&pq, v, h[v]);
             }
             current = current->next;
         }
     }
 
-    free_min_heap(heap);
     free(visited);
     return found;
 }
@@ -228,7 +84,8 @@ void greedy_best_first_search(weightedGraph* graph, int start, int dest, int h[]
         return;
     }
 
-    int found = greedy_best_first_search_solve(graph, start, dest, h, parent, traversal_order, &traversal_len);
+    int found = greedy_best_first_search_solve(graph, start, dest, h, parent, traversal_order,
+                                               &traversal_len);
 
     printf("Traversal Order: ");
     for (int i = 0; i < traversal_len; i++)
@@ -453,8 +310,8 @@ void greedy_best_first_search_demo(void)
 
         while (1)
         {
-            int dest_status =
-                safe_input_int(&destination_node, "\nenter destination node: ", 0, graph_capacity - 1);
+            int dest_status = safe_input_int(&destination_node, "\nenter destination node: ", 0,
+                                             graph_capacity - 1);
 
             if (dest_status == INPUT_EXIT_SIGNAL)
             {
@@ -477,7 +334,8 @@ void greedy_best_first_search_demo(void)
 
         int choice;
     retry_choice:
-        printf("\nOptions:\n1. Re-run Greedy BFS with NEW heuristics\n2. Re-run Greedy BFS with SAME heuristics (new start/destination)\n0. Exit Greedy BFS demo\n");
+        printf("\nOptions:\n1. Re-run Greedy BFS with NEW heuristics\n2. Re-run Greedy BFS with "
+               "SAME heuristics (new start/destination)\n0. Exit Greedy BFS demo\n");
         int choice_status = safe_input_int(&choice, "Enter choice: ", 0, 2);
         if (choice_status == INPUT_EXIT_SIGNAL || choice == 0)
         {


### PR DESCRIPTION
## What

Consolidates the three near-identical graph priority queues into one shared min-heap, as agreed in #ssoc and tracked in #95.

- **Generalised** the existing Dijkstra heap: `PQ_dijkstra` -> `PQ_graph`, `PQ_dijkstra_node` -> `PQ_graph_node`, `insert_pq_dijkstra` / `extractTop_pq_dijkstra` -> `insert_pq_graph` / `extractTop_pq_graph`. The node still holds `{vertex, distance}`, but `distance` is now treated as a generic **priority**. Dijkstra keeps using it unchanged (mechanical rename).
- **A\*** — deleted its private `MinHeap`/`HeapNode` and pushes `(node, f)` where `f = g + h`.
- **Greedy-BFS** — deleted its private `MinHeap`/`HeapNode` and pushes `(node, h)`.

Net: ~355 lines of copy-pasted heap code removed.

## Notes

- The data-structures `priority_queue` module and `heap_sort` are intentionally **not** touched.
- A\*'s secondary heuristic tie-break is dropped in favour of the single-priority heap, consistent with Dijkstra/Greedy; ordering by `f` is correct.
- Duplicate queue entries are handled lazily via the existing `visited[]` check on pop (unchanged behaviour).

## Testing

- `make` — clean under `-Wall -Wextra -Werror -std=c11`.
- `make test` — full suite green, including `test_astar` and `test_greedy_bfs` (both link `dijkstra.c`, exercising the renamed `PQ_graph`).
- `valgrind --leak-check=full` on `test_astar` and `test_greedy_bfs` — 0 errors, all heap blocks freed.
- clang-format applied to changed files.

Closes #95
