### PR TITLE
fix(graph): deterministic tie-break in shared PQ_graph (closes #107)

### DIFF
--- a/src/graph_traversals/dijkstra.c
+++ b/src/graph_traversals/dijkstra.c
@@ -4,6 +4,17 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+// Min-heap ordering for PQ_graph: a node has higher priority when its
+// "distance" (used as a generic priority: g+h for A*, h for Greedy, path
+// cost for Dijkstra) is smaller. Equal priorities are broken by the lower
+// vertex id so expansion order is deterministic and platform-independent.
+static int pq_graph_higher_priority(PQ_graph_node a, PQ_graph_node b)
+{
+    if (a.distance != b.distance)
+        return a.distance < b.distance;
+    return a.vertex < b.vertex;
+}
+
 int insert_pq_graph(PQ_graph* pq, int vertex, int distance)
 {
     if (pq == NULL || pq->size == HEAP_CAPACITY)
@@ -17,7 +28,7 @@ int insert_pq_graph(PQ_graph* pq, int vertex, int distance)
     while (i > 0)
     {
         int parent = (i - 1) / 2;
-        if (pq->heap[i].distance >= pq->heap[parent].distance)
+        if (!pq_graph_higher_priority(pq->heap[i], pq->heap[parent]))
             break;
 
         PQ_graph_node temp = pq->heap[i];
@@ -50,9 +61,9 @@ bool extractTop_pq_graph(PQ_graph* pq, PQ_graph_node* result)
         int right = 2 * i + 2;
         int target = i;
 
-        if (left < pq->size && pq->heap[left].distance < pq->heap[target].distance)
+        if (left < pq->size && pq_graph_higher_priority(pq->heap[left], pq->heap[target]))
             target = left;
-        if (right < pq->size && pq->heap[right].distance < pq->heap[target].distance)
+        if (right < pq->size && pq_graph_higher_priority(pq->heap[right], pq->heap[target]))
             target = right;
 
         if (target == i)


### PR DESCRIPTION
## What

Restores deterministic ordering in the shared graph priority queue (`PQ_graph`) when two nodes have equal priority.

After #104 consolidated A*, Greedy-BFS and Dijkstra onto the single-priority `PQ_graph`, the A*-specific heuristic tie-break was (intentionally) dropped. Equal-`f` nodes were then ordered by arbitrary binary-heap sift order, which is not stable across platforms — the concern raised in #107.

## How

Added a small `pq_graph_higher_priority()` comparator used by both `insert_pq_graph` (sift-up) and `extractTop_pq_graph` (sift-down):

- primary: lower `distance` (the generic priority — `g+h` for A*, `h` for Greedy, path cost for Dijkstra) wins;
- tie-break: lower `vertex` id wins.

This makes expansion order **deterministic and platform-independent** for Dijkstra, A* and Greedy-BFS alike, without reintroducing `h[]` into the heap (so the single-priority design from #104 is preserved).

## Confirming the questions from #107

- **Was dropping the heuristic tie-break intentional?** Yes — it was the #104 design decision; pulling `h[]` back into the shared heap would re-couple it to A*.
- **Do any tests rely on the previous ordering?** No. `tests/test_astar.c` asserts only cost + parent pointers; `tests/test_greedy_best_first_search.c` asserts `traversal_order` but every branch point has distinct `h`, so no equal-priority competition exists.

## Verification

- `make` — clean (`-Wall -Wextra -Werror`)
- `make test` — all pass, incl. A* (3/3) and Greedy-BFS (3/3)
- `make valgrind` — clean
- `clang-format` — no changes

Closes #107
