### PR TITLE
fix: Reset EOF flag for unix input handling

### DIFF
--- a/src/expression_evaluation/safe_input_infix.c
+++ b/src/expression_evaluation/safe_input_infix.c
@@ -16,6 +16,7 @@ int validate_infix_expr(char* buff, size_t size, const char* prompt)
     }
     if (!fgets(buff, size, stdin))
     { // return code 0 represents EOF
+        clearerr(stdin);
         printf("\ninput ended unexpectedly");
         return 0;
     }

--- a/src/expression_evaluation/safe_input_postfix.c
+++ b/src/expression_evaluation/safe_input_postfix.c
@@ -19,6 +19,7 @@ int validate_postfix_expr(char* buff, size_t size, const char* prompt)
 
     if (!fgets(buff, size, stdin))
     { // return code 0 represents EOF
+        clearerr(stdin);
         printf("\ninput ended unexpectedly");
         return 0;
     }


### PR DESCRIPTION
## Description

This PR fixes EOF handling in UNIX systems for expression input processing.

### Changes Made

* Added `clearerr(stdin);` after EOF detection to reset the EOF flag.
* Updated:

  * `safe_input_postfix.c`
  * `safe_input_prefix.c`

### Why

On UNIX systems, triggering EOF using `CTRL + D` sets the EOF flag on `stdin`, causing subsequent input operations (`fgets()`, `scanf()`, `getchar()`) to immediately return EOF.

This resulted in repeated:

`input ended unexpectedly`

messages and prevented further manual input.

Resetting the EOF flag using `clearerr(stdin);` allows the application to recover and continue accepting input normally.

### Testing Done

Tested on Ubuntu Linux.

#### Before Fix

* Pressing `CTRL + D` caused EOF flag to persist.
* Subsequent input attempts continuously failed.
* Program repeatedly printed:
  `input ended unexpectedly`

**Before Fix Screenshot:**
<img width="1430" height="936" alt="image" src="https://github.com/user-attachments/assets/ba2ce0e7-268e-4d87-8609-8e83b60d2041" />

#### After Fix

* Program recovered correctly after EOF.
* User was able to continue entering expressions normally.

**After Fix Screenshot:**
<img width="1898" height="829" alt="image" src="https://github.com/user-attachments/assets/a55936d2-ad66-46fe-ad3a-bdbb1921e42b" />

Fixes #103