### PR TITLE
feat(graph): CSV file input for Dijkstra (keep terminal input)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -131,6 +131,7 @@ DEQUE_TEST_SRC = \
 ASTAR_TEST_SRC = \
 	src/graph_traversals/astar.c \
 	src/graph_traversals/dijkstra.c \
+	src/graph_traversals/graph_io.c \
 	src/utils/safe_input_int.c \
 	tests/test_astar.c
 AVL_TEST_SRC = \
@@ -148,6 +149,7 @@ TRIE_TEST_SRC = \
 GREEDY_BFS_TEST_SRC = \
 	src/graph_traversals/greedy_best_first_search.c \
 	src/graph_traversals/dijkstra.c \
+	src/graph_traversals/graph_io.c \
 	src/utils/safe_input_int.c \
 	tests/test_greedy_best_first_search.c
 

--- a/src/graph_traversals/dijkstra.c
+++ b/src/graph_traversals/dijkstra.c
@@ -1,8 +1,10 @@
+#include "graph_io.h"
 #include "graph_traversals.h"
 #include "safe_input.h"
 #include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 
 // Min-heap ordering for PQ_graph: a node has higher priority when its
 // "distance" (used as a generic priority: g+h for A*, h for Greedy, path
@@ -214,52 +216,23 @@ void dijkstra_demo(void)
     int edges;
     int graph_capacity;
     int starting_node;
+    int input_method;
     weightedGraph* graph = NULL;
 
     while (1)
     {
-        int graph_capacity_status = safe_input_int(&graph_capacity,
-                                                   "\nenter the number of vertices in the graph, "
-                                                   "(between 1 and 10), enter '-1' to exit : ",
-                                                   1, 10);
+        int method_status = safe_input_int(&input_method,
+                                           "\nenter 1 to build the graph manually, 2 to load it "
+                                           "from a CSV file, enter '-1' to exit : ",
+                                           1, 2);
 
-        if (graph_capacity_status == INPUT_EXIT_SIGNAL)
+        if (method_status == INPUT_EXIT_SIGNAL)
         {
             printf("\nExiting Dijkstra demo.....\n");
-            free_weightedGraph(graph);
             return;
         }
 
-        if (graph_capacity_status == 0)
-        {
-            continue;
-        }
-
-        graph = create_weightedGraph(graph_capacity);
-
-        if (!graph)
-        {
-            printf("\nmemory allocation failed\n");
-            free_weightedGraph(graph);
-            return;
-        }
-
-        break;
-    }
-
-    while (1)
-    {
-        int edges_capacity_status = safe_input_int(
-            &edges, "\nenter number of edges (between 1 and 100), enter '-1' to exit :", 0, 100);
-
-        if (edges_capacity_status == INPUT_EXIT_SIGNAL)
-        {
-            printf("\nExiting Dijkstra demo\n");
-            free_weightedGraph(graph);
-            return;
-        }
-
-        if (edges_capacity_status == 0)
+        if (method_status == 0)
         {
             continue;
         }
@@ -267,60 +240,160 @@ void dijkstra_demo(void)
         break;
     }
 
-    printf("\nEnter source, destination, weight pairs (Source, Destination must be b/w 0 and %d "
-           "(both inclusive)):\n",
-           graph_capacity - 1);
-
-    for (int i = 0; i < edges; i++)
+    if (input_method == 2)
     {
-        int src_status;
-        int dest_status;
-        int wt_status;
-        int src;
-        int dest;
-        int wt;
-
-    retry:
-        src_status = safe_input_int(&src, "src: ", 0, graph_capacity - 1);
-
-        if (src_status == INPUT_EXIT_SIGNAL)
+        while (1)
         {
-            printf("\nExiting Dijkstra demo\n");
-            free_weightedGraph(graph);
-            return;
-        }
-        if (src_status == 0)
-        {
-            goto retry;
-        }
+            char path[256];
+            printf("\nenter the path to the CSV file, enter '-1' to exit : ");
+            fflush(stdout);
 
-        dest_status = safe_input_int(&dest, "dest: ", 0, graph_capacity - 1);
+            if (!fgets(path, sizeof(path), stdin))
+            {
+                printf("\ninput ended unexpectedly\n");
+                clearerr(stdin);
+                return;
+            }
 
-        if (dest_status == INPUT_EXIT_SIGNAL)
-        {
-            printf("\nExiting Dijsktra demo\n");
-            free_weightedGraph(graph);
-            return;
-        }
-        if (dest_status == 0)
-        {
-            goto retry;
-        }
+            size_t len = strlen(path);
+            while (len > 0 && (path[len - 1] == '\n' || path[len - 1] == '\r'))
+                path[--len] = '\0';
 
-        wt_status = safe_input_int(&wt, "weight: ", 0, INT_MAX);
+            if (strcmp(path, "-1") == 0)
+            {
+                printf("\nExiting Dijkstra demo.....\n");
+                return;
+            }
 
-        if (wt_status == INPUT_EXIT_SIGNAL)
-        {
-            printf("\nExiting Dijsktra demo\n");
-            free_weightedGraph(graph);
-            return;
-        }
-        if (wt_status == 0)
-        {
-            goto retry;
+            if (len == 0)
+            {
+                continue;
+            }
+
+            graph = load_weightedGraph_from_csv(path);
+
+            if (!graph)
+            {
+                // error already reported by the loader, let the user retry
+                continue;
+            }
+
+            break;
         }
 
-        add_edge_directed(graph, src, dest, wt);
+        graph_capacity = graph->V;
+    }
+    else
+    {
+        while (1)
+        {
+            int graph_capacity_status =
+                safe_input_int(&graph_capacity,
+                               "\nenter the number of vertices in the graph, "
+                               "(between 1 and 10), enter '-1' to exit : ",
+                               1, 10);
+
+            if (graph_capacity_status == INPUT_EXIT_SIGNAL)
+            {
+                printf("\nExiting Dijkstra demo.....\n");
+                free_weightedGraph(graph);
+                return;
+            }
+
+            if (graph_capacity_status == 0)
+            {
+                continue;
+            }
+
+            graph = create_weightedGraph(graph_capacity);
+
+            if (!graph)
+            {
+                printf("\nmemory allocation failed\n");
+                free_weightedGraph(graph);
+                return;
+            }
+
+            break;
+        }
+
+        while (1)
+        {
+            int edges_capacity_status = safe_input_int(
+                &edges, "\nenter number of edges (between 1 and 100), enter '-1' to exit :", 0,
+                100);
+
+            if (edges_capacity_status == INPUT_EXIT_SIGNAL)
+            {
+                printf("\nExiting Dijkstra demo\n");
+                free_weightedGraph(graph);
+                return;
+            }
+
+            if (edges_capacity_status == 0)
+            {
+                continue;
+            }
+
+            break;
+        }
+
+        printf(
+            "\nEnter source, destination, weight pairs (Source, Destination must be b/w 0 and %d "
+            "(both inclusive)):\n",
+            graph_capacity - 1);
+
+        for (int i = 0; i < edges; i++)
+        {
+            int src_status;
+            int dest_status;
+            int wt_status;
+            int src;
+            int dest;
+            int wt;
+
+        retry:
+            src_status = safe_input_int(&src, "src: ", 0, graph_capacity - 1);
+
+            if (src_status == INPUT_EXIT_SIGNAL)
+            {
+                printf("\nExiting Dijkstra demo\n");
+                free_weightedGraph(graph);
+                return;
+            }
+            if (src_status == 0)
+            {
+                goto retry;
+            }
+
+            dest_status = safe_input_int(&dest, "dest: ", 0, graph_capacity - 1);
+
+            if (dest_status == INPUT_EXIT_SIGNAL)
+            {
+                printf("\nExiting Dijsktra demo\n");
+                free_weightedGraph(graph);
+                return;
+            }
+            if (dest_status == 0)
+            {
+                goto retry;
+            }
+
+            wt_status = safe_input_int(&wt, "weight: ", 0, INT_MAX);
+
+            if (wt_status == INPUT_EXIT_SIGNAL)
+            {
+                printf("\nExiting Dijsktra demo\n");
+                free_weightedGraph(graph);
+                return;
+            }
+            if (wt_status == 0)
+            {
+                goto retry;
+            }
+
+            add_edge_directed(graph, src, dest, wt);
+        }
     }
 
     while (1)

--- a/src/graph_traversals/graph_io.c
+++ b/src/graph_traversals/graph_io.c
@@ -1,0 +1,88 @@
+#include "graph_io.h"
+#include <stdio.h>
+
+// Vertex count is capped to match the manual-input path in dijkstra_demo so
+// both input methods accept the same range of graphs.
+#define CSV_MAX_VERTICES 10
+#define CSV_MAX_EDGES 100
+
+weightedGraph* load_weightedGraph_from_csv(const char* path)
+{
+    FILE* fp = fopen(path, "r");
+
+    if (!fp)
+    {
+        printf("\nCould not open file '%s'. Please check the path and try again.\n", path);
+        return NULL;
+    }
+
+    int V;
+    int E;
+
+    if (fscanf(fp, "%d %d", &V, &E) != 2)
+    {
+        printf("\nInvalid file: the first line must be '<vertices> <edges>'.\n");
+        fclose(fp);
+        return NULL;
+    }
+
+    if (V < 1 || V > CSV_MAX_VERTICES)
+    {
+        printf("\nInvalid vertex count %d (must be between 1 and %d).\n", V, CSV_MAX_VERTICES);
+        fclose(fp);
+        return NULL;
+    }
+
+    if (E < 0 || E > CSV_MAX_EDGES)
+    {
+        printf("\nInvalid edge count %d (must be between 0 and %d).\n", E, CSV_MAX_EDGES);
+        fclose(fp);
+        return NULL;
+    }
+
+    weightedGraph* graph = create_weightedGraph(V);
+
+    if (!graph)
+    {
+        printf("\nMemory allocation failed while building the graph.\n");
+        fclose(fp);
+        return NULL;
+    }
+
+    for (int i = 0; i < E; i++)
+    {
+        int src;
+        int dest;
+        int wt;
+
+        if (fscanf(fp, "%d,%d,%d", &src, &dest, &wt) != 3)
+        {
+            printf("\nInvalid file: edge %d is not in the form '<src>,<dest>,<weight>'.\n", i + 1);
+            free_weightedGraph(graph);
+            fclose(fp);
+            return NULL;
+        }
+
+        if (src < 0 || src >= V || dest < 0 || dest >= V)
+        {
+            printf("\nInvalid edge %d: vertices must be between 0 and %d.\n", i + 1, V - 1);
+            free_weightedGraph(graph);
+            fclose(fp);
+            return NULL;
+        }
+
+        if (wt < 0)
+        {
+            printf("\nInvalid edge %d: weight must be non-negative.\n", i + 1);
+            free_weightedGraph(graph);
+            fclose(fp);
+            return NULL;
+        }
+
+        add_edge_directed(graph, src, dest, wt);
+    }
+
+    fclose(fp);
+    printf("\nLoaded graph from '%s' (%d vertices, %d edges).\n", path, V, E);
+    return graph;
+}

--- a/src/graph_traversals/graph_io.h
+++ b/src/graph_traversals/graph_io.h
@@ -1,0 +1,16 @@
+#ifndef GRAPH_IO_H
+#define GRAPH_IO_H
+#include "graph_traversals.h"
+
+// Loads a directed weighted graph from a CSV file for the graph algorithms.
+//
+// Expected format (Dijkstra):
+//   line 1 : <number_of_vertices> <number_of_edges>
+//   next E : <src>,<dest>,<weight>          (one directed edge per line)
+//
+// Returns a newly allocated weightedGraph on success (caller frees it with
+// free_weightedGraph), or NULL if the file cannot be opened or its contents
+// are malformed/out of range. A descriptive message is printed on failure.
+weightedGraph* load_weightedGraph_from_csv(const char* path);
+
+#endif


### PR DESCRIPTION
## What

Adds the ability to load a graph for **Dijkstra** from a **CSV file**, as an *additional* input option. The existing manual terminal input is kept unchanged — the user now picks one of the two at the start of the demo.

Closes #117

## Why

Currently building a graph for Dijkstra means typing the vertex count, the edge count, and then a `src` / `dest` / `weight` prompt for every single edge. For anything beyond a tiny graph this is tedious and easy to get wrong. Loading from a file makes it quick and repeatable.

## CSV format

```
<vertices> <edges>
<src>,<dest>,<weight>
<src>,<dest>,<weight>
...
```

- **Line 1**: number of vertices and number of edges.
- **Each following line**: one directed edge `src,dest,weight`.

Example (4 vertices, 5 edges):

```
4 5
0,1,10
0,2,3
2,1,1
1,3,2
2,3,8
```

## Changes

- New module `src/graph_traversals/graph_io.{c,h}` with `load_weightedGraph_from_csv()`. It reuses the existing `create_weightedGraph` and `add_edge_directed`, and validates the header line, vertex ranges (`0..V-1`), non-negative weights and the edge count. On any error it prints a clear message and returns `NULL`.
- `dijkstra_demo()` now asks for the input method (1 = manual, 2 = CSV). The CSV branch prompts for a file path; the manual branch is the original flow, untouched. The starting-node prompt and the Dijkstra run are shared by both.
- `Makefile`: `graph_io.c` added to `ASTAR_TEST_SRC` and `GREEDY_BFS_TEST_SRC` (those test binaries link `dijkstra.c`, which now references the loader). The main `dsa` target picks it up via the existing `src/graph_traversals/*.c` glob.

## Scope

Dijkstra only, as agreed. A* and Greedy-BFS need an extra per-vertex heuristic, so they will get their own CSV format and follow-up PRs.

## Testing

- `make` — clean build, `-Werror`.
- `make test` — full suite passes, including `test_astar` and `test_greedy_bfs` (which now link `graph_io.c`).
- `make valgrind` — 0 errors, no leaks across all test binaries.
- Drove `./dsa` manually: CSV load on the example above gives the correct shortest paths (`0,4,3,6` from node 0); the manual path is unaffected; missing file, out-of-range vertex and wrong edge count each report cleanly and let the user retry. Loader checked under Valgrind on both the success and error paths (no leaks on the partial-graph free paths).
