### PR TITLE
fix: remove sleep delays from n2 sorting algorithms

### DIFF
--- a/src/sorting_algorithms_n2/bubble_sort.c
+++ b/src/sorting_algorithms_n2/bubble_sort.c
@@ -83,7 +83,6 @@ void bubble_sort_optimized(int arr[], int length_of_array)
         printf("after iteration no %d - ", i + 1);
         print_array(arr, length_of_array);
         printf("\n");
-        sleep(1);
     }
 
     end_t = clock(); // time recorded at the end of the algorithm

--- a/src/sorting_algorithms_n2/insertion_sort.c
+++ b/src/sorting_algorithms_n2/insertion_sort.c
@@ -78,7 +78,6 @@ void insertion_sort(int arr[], int length_of_array)
         printf("after iteration no %d - ", i);
         print_array(arr, length_of_array);
         printf("\n");
-        sleep(1);
     }
 
     end_t = clock();

--- a/src/sorting_algorithms_n2/selection_sort.c
+++ b/src/sorting_algorithms_n2/selection_sort.c
@@ -79,7 +79,6 @@ void selection_sort(int arr[], int length_of_array)
         printf("after iteration no %d - ",i+1);
         print_array(arr,length_of_array);
         printf("\n");
-        sleep(1);
     }
 
     end_t = clock();

--- a/src/sorting_algorithms_n2/shell_sort.c
+++ b/src/sorting_algorithms_n2/shell_sort.c
@@ -84,7 +84,6 @@ void shell_sort(int arr[], int length_of_array)
         printf("after gap of %d - ", gap);
         print_array(arr, length_of_array);
         printf("\n");
-        sleep(1);
     }
 
     end_t = clock();


### PR DESCRIPTION
## Description

Removed unnecessary `sleep()` delays from the N² sorting algorithm implementations to improve test execution speed.

### Changes Made

* Removed `sleep()` calls from:

  * `bubble_sort_optimized()`
  * `insertion_sort()`
  * `selection_sort()`
  * `shell_sort()`

### Problem

The delay added for visualization purposes slowed down `make test`, causing longer execution times during automated testing.

## Type of Change

* [x] Bug fix
* [ ] New feature
* [ ] Documentation update
* [ ] Refactoring

### Testing

* Verified the project builds successfully.
* Confirmed delays were removed from the affected sorting algorithms.
* `make test` execution is no longer slowed by unnecessary sleep calls.

## Checklist

* [x] Code follows project style
* [x] Tested locally
* [ ] Updated documentation

Fixes #125
