### PR TITLE
feat(graph): CSV file input for Greedy Best-First Search

### DIFF
--- a/src/graph_traversals/greedy_best_first_search.c
+++ b/src/graph_traversals/greedy_best_first_search.c
@@ -1,8 +1,10 @@
+#include "graph_io.h"
 #include "graph_traversals.h"
 #include "safe_input.h"
 #include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 
 int greedy_best_first_search_solve(weightedGraph* graph, int start, int dest, int h[], int parent[],
                                    int traversal_order[], int* traversal_len)
@@ -143,51 +145,24 @@ void greedy_best_first_search_demo(void)
     int graph_capacity;
     int starting_node;
     int destination_node;
+    int input_method;
     weightedGraph* graph = NULL;
     int* h = NULL;
 
     while (1)
     {
-        int graph_capacity_status = safe_input_int(&graph_capacity,
-                                                   "\nenter the number of vertices in the graph, "
-                                                   "(between 1 and 10), enter '-1' to exit : ",
-                                                   1, 10);
+        int method_status = safe_input_int(&input_method,
+                                           "\nenter 1 to build the graph manually, 2 to load it "
+                                           "from a CSV file, enter '-1' to exit : ",
+                                           1, 2);
 
-        if (graph_capacity_status == INPUT_EXIT_SIGNAL)
+        if (method_status == INPUT_EXIT_SIGNAL)
         {
             printf("\nExiting Greedy Best-First Search demo.....\n");
             return;
         }
 
-        if (graph_capacity_status == 0)
-        {
-            continue;
-        }
-
-        graph = create_weightedGraph(graph_capacity);
-
-        if (!graph)
-        {
-            printf("\nmemory allocation failed\n");
-            return;
-        }
-
-        break;
-    }
-
-    while (1)
-    {
-        int edges_capacity_status = safe_input_int(
-            &edges, "\nenter number of edges (between 1 and 100), enter '-1' to exit :", 0, 100);
-
-        if (edges_capacity_status == INPUT_EXIT_SIGNAL)
-        {
-            printf("\nExiting Greedy Best-First Search demo\n");
-            free_weightedGraph(graph);
-            return;
-        }
-
-        if (edges_capacity_status == 0)
+        if (method_status == 0)
         {
             continue;
         }
@@ -195,60 +170,160 @@ void greedy_best_first_search_demo(void)
         break;
     }
 
-    printf("\nEnter source, destination, weight pairs (Source, Destination must be b/w 0 and %d "
-           "(both inclusive)):\n",
-           graph_capacity - 1);
-
-    for (int i = 0; i < edges; i++)
+    if (input_method == 2)
     {
-        int src_status;
-        int dest_status;
-        int wt_status;
-        int src;
-        int dest;
-        int wt;
-
-    retry:
-        src_status = safe_input_int(&src, "src: ", 0, graph_capacity - 1);
-
-        if (src_status == INPUT_EXIT_SIGNAL)
+        while (1)
         {
-            printf("\nExiting Greedy Best-First Search demo\n");
-            free_weightedGraph(graph);
-            return;
-        }
-        if (src_status == 0)
-        {
-            goto retry;
-        }
+            char path[256];
+            printf("\nenter the path to the CSV file, enter '-1' to exit : ");
+            fflush(stdout);
 
-        dest_status = safe_input_int(&dest, "dest: ", 0, graph_capacity - 1);
+            if (!fgets(path, sizeof(path), stdin))
+            {
+                printf("\ninput ended unexpectedly\n");
+                clearerr(stdin);
+                return;
+            }
 
-        if (dest_status == INPUT_EXIT_SIGNAL)
-        {
-            printf("\nExiting Greedy Best-First Search demo\n");
-            free_weightedGraph(graph);
-            return;
-        }
-        if (dest_status == 0)
-        {
-            goto retry;
-        }
+            size_t len = strlen(path);
+            while (len > 0 && (path[len - 1] == '\n' || path[len - 1] == '\r'))
+                path[--len] = '\0';
 
-        wt_status = safe_input_int(&wt, "weight: ", 0, INT_MAX);
+            if (strcmp(path, "-1") == 0)
+            {
+                printf("\nExiting Greedy Best-First Search demo.....\n");
+                return;
+            }
 
-        if (wt_status == INPUT_EXIT_SIGNAL)
-        {
-            printf("\nExiting Greedy Best-First Search demo\n");
-            free_weightedGraph(graph);
-            return;
-        }
-        if (wt_status == 0)
-        {
-            goto retry;
+            if (len == 0)
+            {
+                continue;
+            }
+
+            // Loads the graph and its per-vertex heuristic together, so the
+            // manual heuristic-entry block below is skipped on this path.
+            graph = load_weightedGraph_with_heuristic_from_csv(path, &h);
+
+            if (!graph)
+            {
+                // error already reported by the loader, let the user retry
+                continue;
+            }
+
+            break;
         }
 
-        add_edge_directed(graph, src, dest, wt);
+        graph_capacity = graph->V;
+    }
+    else
+    {
+        while (1)
+        {
+            int graph_capacity_status =
+                safe_input_int(&graph_capacity,
+                               "\nenter the number of vertices in the graph, "
+                               "(between 1 and 10), enter '-1' to exit : ",
+                               1, 10);
+
+            if (graph_capacity_status == INPUT_EXIT_SIGNAL)
+            {
+                printf("\nExiting Greedy Best-First Search demo.....\n");
+                return;
+            }
+
+            if (graph_capacity_status == 0)
+            {
+                continue;
+            }
+
+            graph = create_weightedGraph(graph_capacity);
+
+            if (!graph)
+            {
+                printf("\nmemory allocation failed\n");
+                return;
+            }
+
+            break;
+        }
+
+        while (1)
+        {
+            int edges_capacity_status = safe_input_int(
+                &edges, "\nenter number of edges (between 1 and 100), enter '-1' to exit :", 0,
+                100);
+
+            if (edges_capacity_status == INPUT_EXIT_SIGNAL)
+            {
+                printf("\nExiting Greedy Best-First Search demo\n");
+                free_weightedGraph(graph);
+                return;
+            }
+
+            if (edges_capacity_status == 0)
+            {
+                continue;
+            }
+
+            break;
+        }
+
+        printf(
+            "\nEnter source, destination, weight pairs (Source, Destination must be b/w 0 and %d "
+            "(both inclusive)):\n",
+            graph_capacity - 1);
+
+        for (int i = 0; i < edges; i++)
+        {
+            int src_status;
+            int dest_status;
+            int wt_status;
+            int src;
+            int dest;
+            int wt;
+
+        retry:
+            src_status = safe_input_int(&src, "src: ", 0, graph_capacity - 1);
+
+            if (src_status == INPUT_EXIT_SIGNAL)
+            {
+                printf("\nExiting Greedy Best-First Search demo\n");
+                free_weightedGraph(graph);
+                return;
+            }
+            if (src_status == 0)
+            {
+                goto retry;
+            }
+
+            dest_status = safe_input_int(&dest, "dest: ", 0, graph_capacity - 1);
+
+            if (dest_status == INPUT_EXIT_SIGNAL)
+            {
+                printf("\nExiting Greedy Best-First Search demo\n");
+                free_weightedGraph(graph);
+                return;
+            }
+            if (dest_status == 0)
+            {
+                goto retry;
+            }
+
+            wt_status = safe_input_int(&wt, "weight: ", 0, INT_MAX);
+
+            if (wt_status == INPUT_EXIT_SIGNAL)
+            {
+                printf("\nExiting Greedy Best-First Search demo\n");
+                free_weightedGraph(graph);
+                return;
+            }
+            if (wt_status == 0)
+            {
+                goto retry;
+            }
+
+            add_edge_directed(graph, src, dest, wt);
+        }
     }
 
     while (1)


### PR DESCRIPTION
Closes #129

## What

Adds CSV file input for **Greedy Best-First Search** as an alternative to manual terminal entry. This is the final piece of the dijkstra -> A\* -> greedy CSV input feature, following #117 / #118 (Dijkstra) and #119 / #128 (A\*).

## Changes

One file — `src/graph_traversals/greedy_best_first_search.c`:

- **CSV menu** — `greedy_best_first_search_demo()` now starts with `1 = build manually`, `2 = load from CSV`. The terminal flow is kept exactly as before (only wrapped in the `else` branch); CSV is an additional option, not a replacement.
- **Reuses existing infra** — the A\* CSV format and the shared `load_weightedGraph_with_heuristic_from_csv()` loader added in #128. No new loader.
- **No Makefile change** — `graph_io` already lives in `src/utils/` (moved in #128) and `GREEDY_BFS_TEST_SRC` already points there.

## CSV format (same as A\*)

```
V E
src,dest,weight      (x E rows)
h0 h1 ... h(V-1)     (V non-negative heuristics, one per vertex)
```

Example (4 vertices, 4 edges):

```
4 4
0,1,1
1,3,10
0,2,2
2,3,2
3 4 2 0
```

## Testing

- `make` clean under `-Wall -Wextra -Werror`.
- Drove `./dsa` interactively through **both** Greedy paths — CSV-loaded graph and manual entry. On the example, Greedy expands by heuristic `0 -> 2 -> 3`.
- `make test` — full suite passes, including `test_greedy_bfs`.
- `make valgrind` — 0 errors / 0 leaks across all tests.
- `clang-format` applied to the changed file.

With this merged, the graph algorithms (Dijkstra, A\*, Greedy BFS) all support CSV input.
