### PR TITLE
feat(graph): CSV file input for DFS and BFS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -164,7 +164,7 @@ $(TEST_DIR)/test_deque$(EXE): $(OBJ_DIR)/src/data_structures/deque.o $(OBJ_DIR)/
 test_astar: $(TEST_DIR)/test_astar$(EXE)
 	$(TEST_DIR)/test_astar$(EXE)
 
-$(TEST_DIR)/test_astar$(EXE): $(OBJ_DIR)/src/graph_traversals/astar.o $(OBJ_DIR)/src/graph_traversals/dijkstra.o $(OBJ_DIR)/src/utils/graph_io.o $(OBJ_DIR)/src/utils/safe_input_int.o tests/test_astar.c
+$(TEST_DIR)/test_astar$(EXE): $(OBJ_DIR)/src/graph_traversals/astar.o $(OBJ_DIR)/src/graph_traversals/dijkstra.o $(OBJ_DIR)/src/utils/graph_io.o $(OBJ_DIR)/src/graph_traversals/bfs.o $(OBJ_DIR)/src/data_structures/circular_queue.o $(OBJ_DIR)/src/data_structures/sll.o $(OBJ_DIR)/src/utils/safe_input_int.o tests/test_astar.c
 	@mkdir -p $(TEST_DIR)
 	$(CC) $(CFLAGS) $^ -o $@
 
@@ -185,7 +185,7 @@ $(TEST_DIR)/test_trie$(EXE): $(OBJ_DIR)/src/data_structures/trie.o $(OBJ_DIR)/sr
 test_greedy_bfs: $(TEST_DIR)/test_greedy_bfs$(EXE)
 	$(TEST_DIR)/test_greedy_bfs$(EXE)
 
-$(TEST_DIR)/test_greedy_bfs$(EXE): $(OBJ_DIR)/src/graph_traversals/greedy_best_first_search.o $(OBJ_DIR)/src/graph_traversals/dijkstra.o $(OBJ_DIR)/src/utils/graph_io.o $(OBJ_DIR)/src/utils/safe_input_int.o tests/test_greedy_best_first_search.c
+$(TEST_DIR)/test_greedy_bfs$(EXE): $(OBJ_DIR)/src/graph_traversals/greedy_best_first_search.o $(OBJ_DIR)/src/graph_traversals/dijkstra.o $(OBJ_DIR)/src/utils/graph_io.o $(OBJ_DIR)/src/graph_traversals/bfs.o $(OBJ_DIR)/src/data_structures/circular_queue.o $(OBJ_DIR)/src/data_structures/sll.o $(OBJ_DIR)/src/utils/safe_input_int.o tests/test_greedy_best_first_search.c
 	@mkdir -p $(TEST_DIR)
 	$(CC) $(CFLAGS) $^ -o $@
 

--- a/src/graph_traversals/bfs.c
+++ b/src/graph_traversals/bfs.c
@@ -1,4 +1,5 @@
 #include "data_structures.h"
+#include "graph_io.h"
 #include "graph_traversals.h"
 #include "safe_input.h"
 #include <stdio.h>
@@ -124,52 +125,23 @@ void bfs_demo(void)
     int edges;
     int graph_capacity;
     int starting_node;
+    int input_method;
     Graph* graph = NULL;
 
     while (1)
     {
-        int graph_capacity_status = safe_input_int(&graph_capacity,
-                                                   "\nenter the number of vertices in the graph, "
-                                                   "(between 1 and 10), enter '-1' to exit : ",
-                                                   1, 10);
+        int method_status = safe_input_int(&input_method,
+                                           "\nenter 1 to build the graph manually, 2 to load it "
+                                           "from a CSV file, enter '-1' to exit : ",
+                                           1, 2);
 
-        if (graph_capacity_status == INPUT_EXIT_SIGNAL)
+        if (method_status == INPUT_EXIT_SIGNAL)
         {
             printf("\nExiting bfs demo.....\n");
-            free_graph(graph);
             return;
         }
 
-        if (graph_capacity_status == 0)
-        {
-            continue;
-        }
-
-        graph = create_graph(graph_capacity);
-
-        if (!graph)
-        {
-            printf("\nmemory allocation failed\n");
-            free_graph(graph);
-            return;
-        }
-
-        break;
-    }
-
-    while (1)
-    {
-        int edges_capacity_status = safe_input_int(
-            &edges, "\nenter number of edges (between 1 and 100), enter '-1' to exit :", 1, 100);
-
-        if (edges_capacity_status == INPUT_EXIT_SIGNAL)
-        {
-            printf("\nExiting bfs demo\n");
-            free_graph(graph);
-            return;
-        }
-
-        if (edges_capacity_status == 0)
+        if (method_status == 0)
         {
             continue;
         }
@@ -177,43 +149,142 @@ void bfs_demo(void)
         break;
     }
 
-    printf("\nenter edges (src dest) (from 0 to vertices-1, enter '-1' to exit):\n");
-
-    for (int i = 0; i < edges; i++)
+    if (input_method == 2)
     {
-        int src_status;
-        int dest_status;
-        int src;
-        int dest;
-
-    retry:
-        src_status = safe_input_int(&src, "src: ", 0, graph_capacity - 1);
-
-        if (src_status == INPUT_EXIT_SIGNAL)
+        while (1)
         {
-            printf("\nExiting bfs demo\n");
-            free_graph(graph);
-            return;
-        }
-        if (src_status == 0)
-        {
-            goto retry;
+            char path[256];
+            printf("\nenter the path to the CSV file, enter '-1' to exit : ");
+            fflush(stdout);
+
+            if (!fgets(path, sizeof(path), stdin))
+            {
+                printf("\ninput ended unexpectedly\n");
+                clearerr(stdin);
+                return;
+            }
+
+            size_t len = strlen(path);
+            while (len > 0 && (path[len - 1] == '\n' || path[len - 1] == '\r'))
+                path[--len] = '\0';
+
+            if (strcmp(path, "-1") == 0)
+            {
+                printf("\nExiting bfs demo.....\n");
+                return;
+            }
+
+            if (len == 0)
+            {
+                continue;
+            }
+
+            graph = load_graph_from_csv(path);
+
+            if (!graph)
+            {
+                // error already reported by the loader, let the user retry
+                continue;
+            }
+
+            break;
         }
 
-        dest_status = safe_input_int(&dest, "dest: ", 0, graph_capacity - 1);
-
-        if (dest_status == INPUT_EXIT_SIGNAL)
+        graph_capacity = graph->V;
+    }
+    else
+    {
+        while (1)
         {
-            printf("\nExiting bfs demo\n");
-            free_graph(graph);
-            return;
-        }
-        if (dest_status == 0)
-        {
-            goto retry;
+            int graph_capacity_status =
+                safe_input_int(&graph_capacity,
+                               "\nenter the number of vertices in the graph, "
+                               "(between 1 and 10), enter '-1' to exit : ",
+                               1, 10);
+
+            if (graph_capacity_status == INPUT_EXIT_SIGNAL)
+            {
+                printf("\nExiting bfs demo.....\n");
+                free_graph(graph);
+                return;
+            }
+
+            if (graph_capacity_status == 0)
+            {
+                continue;
+            }
+
+            graph = create_graph(graph_capacity);
+
+            if (!graph)
+            {
+                printf("\nmemory allocation failed\n");
+                free_graph(graph);
+                return;
+            }
+
+            break;
         }
 
-        add_edge_undirected(graph, src, dest);
+        while (1)
+        {
+            int edges_capacity_status = safe_input_int(
+                &edges, "\nenter number of edges (between 1 and 100), enter '-1' to exit :", 1,
+                100);
+
+            if (edges_capacity_status == INPUT_EXIT_SIGNAL)
+            {
+                printf("\nExiting bfs demo\n");
+                free_graph(graph);
+                return;
+            }
+
+            if (edges_capacity_status == 0)
+            {
+                continue;
+            }
+
+            break;
+        }
+
+        printf("\nenter edges (src dest) (from 0 to vertices-1, enter '-1' to exit):\n");
+
+        for (int i = 0; i < edges; i++)
+        {
+            int src_status;
+            int dest_status;
+            int src;
+            int dest;
+
+        retry:
+            src_status = safe_input_int(&src, "src: ", 0, graph_capacity - 1);
+
+            if (src_status == INPUT_EXIT_SIGNAL)
+            {
+                printf("\nExiting bfs demo\n");
+                free_graph(graph);
+                return;
+            }
+            if (src_status == 0)
+            {
+                goto retry;
+            }
+
+            dest_status = safe_input_int(&dest, "dest: ", 0, graph_capacity - 1);
+
+            if (dest_status == INPUT_EXIT_SIGNAL)
+            {
+                printf("\nExiting bfs demo\n");
+                free_graph(graph);
+                return;
+            }
+            if (dest_status == 0)
+            {
+                goto retry;
+            }
+
+            add_edge_undirected(graph, src, dest);
+        }
     }
 
     while (1)
@@ -320,8 +391,7 @@ void topological_sort_kahn(Graph* graph)
     /* Step 4: Cycle detection */
     if (processed != size)
     {
-        printf("Cycle detected! Only %d of %d vertices were processed.\n",
-               processed, size);
+        printf("Cycle detected! Only %d of %d vertices were processed.\n", processed, size);
         printf("The graph is NOT a DAG -- topological sort is not possible.\n");
     }
     else
@@ -372,8 +442,8 @@ void topological_sort_demo(void)
     while (1)
     {
         int edges_capacity_status = safe_input_int(
-            &edges, "\nenter number of directed edges (between 1 and 100), enter '-1' to exit :",
-            1, 100);
+            &edges, "\nenter number of directed edges (between 1 and 100), enter '-1' to exit :", 1,
+            100);
 
         if (edges_capacity_status == INPUT_EXIT_SIGNAL)
         {

--- a/src/graph_traversals/dfs.c
+++ b/src/graph_traversals/dfs.c
@@ -1,3 +1,4 @@
+#include "graph_io.h"
 #include "graph_traversals.h"
 #include "safe_input.h"
 #include "stack.h"
@@ -11,51 +12,23 @@ void dfs_demo(void)
     int edges;
     int graph_capacity;
     int starting_node;
+    int input_method;
     Graph* graph = NULL;
 
     while (1)
     {
-        int graph_capacity_status = safe_input_int(&graph_capacity,
-                                                   "\nenter the number of vertices in the graph, "
-                                                   "(between 1 and 10), enter '-1' to exit : ",
-                                                   1, 10);
+        int method_status = safe_input_int(&input_method,
+                                           "\nenter 1 to build the graph manually, 2 to load it "
+                                           "from a CSV file, enter '-1' to exit : ",
+                                           1, 2);
 
-        if (graph_capacity_status == INPUT_EXIT_SIGNAL)
+        if (method_status == INPUT_EXIT_SIGNAL)
         {
             printf("\nExiting dfs demo.....\n");
             return;
         }
 
-        if (graph_capacity_status == 0)
-        {
-            continue;
-        }
-
-        graph = create_graph(graph_capacity);
-
-        if (!graph)
-        {
-            printf("\nmalloc allocation failed\n");
-            free_graph(graph);
-            return;
-        }
-
-        break;
-    }
-
-    while (1)
-    {
-        int edges_capacity_status = safe_input_int(
-            &edges, "\nenter number of edges (between 1 and 100), enter '-1' to exit :", 1, 100);
-
-        if (edges_capacity_status == INPUT_EXIT_SIGNAL)
-        {
-            printf("\nExiting dfs demo\n");
-            free_graph(graph);
-            return;
-        }
-
-        if (edges_capacity_status == 0)
+        if (method_status == 0)
         {
             continue;
         }
@@ -63,43 +36,141 @@ void dfs_demo(void)
         break;
     }
 
-    printf("\nenter edges (src dest) (from 0 to vertices-1, enter '-1' to exit):\n");
-
-    for (int i = 0; i < edges; i++)
+    if (input_method == 2)
     {
-        int src_status;
-        int dest_status;
-        int src;
-        int dest;
-
-    retry:
-        src_status = safe_input_int(&src, "src: ", 0, graph_capacity - 1);
-
-        if (src_status == INPUT_EXIT_SIGNAL)
+        while (1)
         {
-            printf("\nExiting dfs demo\n");
-            free_graph(graph);
-            return;
-        }
-        if (src_status == 0)
-        {
-            goto retry;
+            char path[256];
+            printf("\nenter the path to the CSV file, enter '-1' to exit : ");
+            fflush(stdout);
+
+            if (!fgets(path, sizeof(path), stdin))
+            {
+                printf("\ninput ended unexpectedly\n");
+                clearerr(stdin);
+                return;
+            }
+
+            size_t len = strlen(path);
+            while (len > 0 && (path[len - 1] == '\n' || path[len - 1] == '\r'))
+                path[--len] = '\0';
+
+            if (strcmp(path, "-1") == 0)
+            {
+                printf("\nExiting dfs demo.....\n");
+                return;
+            }
+
+            if (len == 0)
+            {
+                continue;
+            }
+
+            graph = load_graph_from_csv(path);
+
+            if (!graph)
+            {
+                // error already reported by the loader, let the user retry
+                continue;
+            }
+
+            break;
         }
 
-        dest_status = safe_input_int(&dest, "dest: ", 0, graph_capacity - 1);
-
-        if (dest_status == INPUT_EXIT_SIGNAL)
+        graph_capacity = graph->V;
+    }
+    else
+    {
+        while (1)
         {
-            printf("\nExiting dfs demo\n");
-            free_graph(graph);
-            return;
-        }
-        if (dest_status == 0)
-        {
-            goto retry;
+            int graph_capacity_status =
+                safe_input_int(&graph_capacity,
+                               "\nenter the number of vertices in the graph, "
+                               "(between 1 and 10), enter '-1' to exit : ",
+                               1, 10);
+
+            if (graph_capacity_status == INPUT_EXIT_SIGNAL)
+            {
+                printf("\nExiting dfs demo.....\n");
+                return;
+            }
+
+            if (graph_capacity_status == 0)
+            {
+                continue;
+            }
+
+            graph = create_graph(graph_capacity);
+
+            if (!graph)
+            {
+                printf("\nmalloc allocation failed\n");
+                free_graph(graph);
+                return;
+            }
+
+            break;
         }
 
-        add_edge_undirected(graph, src, dest);
+        while (1)
+        {
+            int edges_capacity_status = safe_input_int(
+                &edges, "\nenter number of edges (between 1 and 100), enter '-1' to exit :", 1,
+                100);
+
+            if (edges_capacity_status == INPUT_EXIT_SIGNAL)
+            {
+                printf("\nExiting dfs demo\n");
+                free_graph(graph);
+                return;
+            }
+
+            if (edges_capacity_status == 0)
+            {
+                continue;
+            }
+
+            break;
+        }
+
+        printf("\nenter edges (src dest) (from 0 to vertices-1, enter '-1' to exit):\n");
+
+        for (int i = 0; i < edges; i++)
+        {
+            int src_status;
+            int dest_status;
+            int src;
+            int dest;
+
+        retry:
+            src_status = safe_input_int(&src, "src: ", 0, graph_capacity - 1);
+
+            if (src_status == INPUT_EXIT_SIGNAL)
+            {
+                printf("\nExiting dfs demo\n");
+                free_graph(graph);
+                return;
+            }
+            if (src_status == 0)
+            {
+                goto retry;
+            }
+
+            dest_status = safe_input_int(&dest, "dest: ", 0, graph_capacity - 1);
+
+            if (dest_status == INPUT_EXIT_SIGNAL)
+            {
+                printf("\nExiting dfs demo\n");
+                free_graph(graph);
+                return;
+            }
+            if (dest_status == 0)
+            {
+                goto retry;
+            }
+
+            add_edge_undirected(graph, src, dest);
+        }
     }
 
     while (1)

--- a/src/utils/graph_io.c
+++ b/src/utils/graph_io.c
@@ -204,3 +204,75 @@ weightedGraph* load_weightedGraph_with_heuristic_from_csv(const char* path, int*
     printf("\nLoaded graph from '%s' (%d vertices, %d edges) with heuristics.\n", path, V, E);
     return graph;
 }
+
+Graph* load_graph_from_csv(const char* path)
+{
+    FILE* fp = fopen(path, "r");
+
+    if (!fp)
+    {
+        printf("\nCould not open file '%s'. Please check the path and try again.\n", path);
+        return NULL;
+    }
+
+    int V;
+    int E;
+
+    if (fscanf(fp, "%d %d", &V, &E) != 2)
+    {
+        printf("\nInvalid file: the first line must be '<vertices> <edges>'.\n");
+        fclose(fp);
+        return NULL;
+    }
+
+    if (V < 1 || V > CSV_MAX_VERTICES)
+    {
+        printf("\nInvalid vertex count %d (must be between 1 and %d).\n", V, CSV_MAX_VERTICES);
+        fclose(fp);
+        return NULL;
+    }
+
+    if (E < 0 || E > CSV_MAX_EDGES)
+    {
+        printf("\nInvalid edge count %d (must be between 0 and %d).\n", E, CSV_MAX_EDGES);
+        fclose(fp);
+        return NULL;
+    }
+
+    Graph* graph = create_graph(V);
+
+    if (!graph)
+    {
+        printf("\nMemory allocation failed while building the graph.\n");
+        fclose(fp);
+        return NULL;
+    }
+
+    for (int i = 0; i < E; i++)
+    {
+        int src;
+        int dest;
+
+        if (fscanf(fp, "%d,%d", &src, &dest) != 2)
+        {
+            printf("\nInvalid file: edge %d is not in the form '<src>,<dest>'.\n", i + 1);
+            free_graph(graph);
+            fclose(fp);
+            return NULL;
+        }
+
+        if (src < 0 || src >= V || dest < 0 || dest >= V)
+        {
+            printf("\nInvalid edge %d: vertices must be between 0 and %d.\n", i + 1, V - 1);
+            free_graph(graph);
+            fclose(fp);
+            return NULL;
+        }
+
+        add_edge_undirected(graph, src, dest);
+    }
+
+    fclose(fp);
+    printf("\nLoaded graph from '%s' (%d vertices, %d edges).\n", path, V, E);
+    return graph;
+}

--- a/src/utils/graph_io.h
+++ b/src/utils/graph_io.h
@@ -30,4 +30,17 @@ weightedGraph* load_weightedGraph_from_csv(const char* path);
 // NULL, and prints a descriptive message.
 weightedGraph* load_weightedGraph_with_heuristic_from_csv(const char* path, int** out_h);
 
+// Loads an unweighted, undirected graph from a CSV file for the traversals
+// (BFS / DFS).
+//
+// Expected format:
+//   line 1 : <number_of_vertices> <number_of_edges>
+//   next E : <src>,<dest>                    (one undirected edge per line)
+//
+// Each edge is added with add_edge_undirected, so both endpoints reference each
+// other. Returns a newly allocated Graph on success (caller frees it with
+// free_graph), or NULL if the file cannot be opened or its contents are
+// malformed/out of range. A descriptive message is printed on failure.
+Graph* load_graph_from_csv(const char* path);
+
 #endif


### PR DESCRIPTION
Closes #135

## What

Adds CSV file input to **DFS** and **BFS** — the last two graph algorithms that
were still limited to manual terminal entry. Dijkstra, A* and Greedy Best-First
already support CSV input (#117, #119, #129); this brings the traversals in line.

The existing manual terminal entry is kept — CSV is an additional menu choice
(`1 = manual`, `2 = load from CSV`), not a replacement.

## CSV format

DFS/BFS use the unweighted, undirected `Graph`, so there is no weight column:

```text
V E              <- vertex count and edge count
src,dest         <- one undirected edge per line (E lines)
```

- `V` in `1..10`, `E` in `0..100` (same caps as the manual path).
- The **starting node** is still prompted interactively after the graph loads.

## Changes

- **`src/utils/graph_io.{c,h}`** — new `load_graph_from_csv()` returning a `Graph*`.
  It reuses the existing `create_graph` / `add_edge_undirected` from `bfs.c`, and
  is the unweighted analogue of `load_weightedGraph_from_csv`. NULL + a descriptive
  message (no leaks) on a bad path / malformed / out-of-range file.
- **`src/graph_traversals/dfs.c`, `bfs.c`** — added the `1 = manual / 2 = CSV` menu
  to `dfs_demo()` and `bfs_demo()`, mirroring `dijkstra_demo()`. The manual build is
  kept in the `else` branch; the start-node prompt and the traversal call are shared.
- **`Makefile`** — `graph_io.o` now references the unweighted `Graph` builders, so the
  `test_astar` and `test_greedy_bfs` link lines (which already link `graph_io.o`) gain
  `bfs.o` + its `circular_queue.o` / `sll.o` dependencies.

## Testing

- `make` clean under `-Werror`.
- Drove `./dsa` through **both** manual and CSV paths for DFS and BFS — correct
  traversals (BFS `0->1->2->3`, DFS `0->2->3->1` on the same 4-vertex graph).
- Exercised loader error paths (missing file, malformed edge, out-of-range vertex) —
  all rejected gracefully with a retry prompt.
- `make test` — all suites pass.
- `make valgrind` — 0 errors / 0 leaks across all test binaries; also ran valgrind on
  `./dsa` driving the CSV happy and error paths (0 leaks).
- `clang-format` applied to the changed files.
