### PR TITLE
refact(trees): Migrate tree files to src/trees/ and resolve Makefile Windows compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ $(TARGET): $(OBJS)
 	$(CC) $(CFLAGS) $(OBJS) -o $(TARGET)$(EXE)
 
 ifeq ($(OS),Windows_NT)
-MKDIR_P = if not exist "$(1)" mkdir "$(1)"
+MKDIR_P = cmd /c if not exist "$(subst /,\,$(1))" mkdir "$(subst /,\,$(1))"
 else
 MKDIR_P = mkdir -p "$(1)"
 endif
@@ -82,148 +82,148 @@ valgrind:
 test_tbt: $(TEST_DIR)/test_tbt$(EXE)
 	$(TEST_DIR)/test_tbt$(EXE)
 
-$(TEST_DIR)/test_tbt$(EXE): $(OBJ_DIR)/src/utils/safe_input_int.o $(OBJ_DIR)/src/data_structures/tbt.o tests/test_tbt.c
-	@mkdir -p $(TEST_DIR)
+$(TEST_DIR)/test_tbt$(EXE): $(OBJ_DIR)/src/utils/safe_input_int.o $(OBJ_DIR)/src/trees/tbt.o tests/test_tbt.c
+	@$(call MKDIR_P,$(TEST_DIR))
 	$(CC) $(CFLAGS) $^ -o $@
 
 test_circ_queue: $(TEST_DIR)/test_circ_queue$(EXE)
 	$(TEST_DIR)/test_circ_queue$(EXE)
 
 $(TEST_DIR)/test_circ_queue$(EXE): $(OBJ_DIR)/src/data_structures/circular_queue.o $(OBJ_DIR)/src/utils/safe_input_int.o tests/test_circ_queue.c
-	@mkdir -p $(TEST_DIR)
+	@$(call MKDIR_P,$(TEST_DIR))
 	$(CC) $(CFLAGS) $^ -o $@
 
 test_bst: $(TEST_DIR)/test_bst$(EXE)
 	$(TEST_DIR)/test_bst$(EXE)
 
-$(TEST_DIR)/test_bst$(EXE): $(OBJ_DIR)/src/data_structures/bst.o $(OBJ_DIR)/src/utils/safe_input_int.o tests/test_bst.c
-	@mkdir -p $(TEST_DIR)
+$(TEST_DIR)/test_bst$(EXE): $(OBJ_DIR)/src/trees/bst.o $(OBJ_DIR)/src/utils/safe_input_int.o tests/test_bst.c
+	@$(call MKDIR_P,$(TEST_DIR))
 	$(CC) $(CFLAGS) $^ -o $@
 
 test_search: $(TEST_DIR)/test_search$(EXE)
 	$(TEST_DIR)/test_search$(EXE)
 
 $(TEST_DIR)/test_search$(EXE): $(OBJ_DIR)/src/searching_algorithms/linear_search.o $(OBJ_DIR)/src/utils/safe_input_int.o $(OBJ_DIR)/src/utils/history_logger.o $(OBJ_DIR)/src/searching_algorithms/binary_search.o $(OBJ_DIR)/src/sorting_algorithms_n2/selection_sort.o $(OBJ_DIR)/src/data_structures/array.o tests/test_search.c
-	@mkdir -p $(TEST_DIR)
+	@$(call MKDIR_P,$(TEST_DIR))
 	$(CC) $(CFLAGS) $^ -o $@
 
 test_hash_func: $(TEST_DIR)/test_hash_func$(EXE)
 	$(TEST_DIR)/test_hash_func$(EXE)
 
 $(TEST_DIR)/test_hash_func$(EXE): $(OBJ_DIR)/src/hashing/linear_probing.o $(OBJ_DIR)/src/utils/safe_input_int.o $(OBJ_DIR)/src/utils/history_logger.o $(OBJ_DIR)/src/data_structures/array.o $(OBJ_DIR)/src/searching_algorithms/linear_search.o tests/test_hash_function.c
-	@mkdir -p $(TEST_DIR)
+	@$(call MKDIR_P,$(TEST_DIR))
 	$(CC) $(CFLAGS) $^ -o $@
 
 test_sll: $(TEST_DIR)/test_sll$(EXE)
 	$(TEST_DIR)/test_sll$(EXE)
 
 $(TEST_DIR)/test_sll$(EXE): $(OBJ_DIR)/src/data_structures/sll.o $(OBJ_DIR)/src/utils/safe_input_int.o tests/test_sll.c
-	@mkdir -p $(TEST_DIR)
+	@$(call MKDIR_P,$(TEST_DIR))
 	$(CC) $(CFLAGS) $^ -o $@
 
 test_dll: $(TEST_DIR)/test_dll$(EXE)
 	$(TEST_DIR)/test_dll$(EXE)
 
 $(TEST_DIR)/test_dll$(EXE): $(OBJ_DIR)/src/data_structures/dll.o $(OBJ_DIR)/src/utils/safe_input_int.o tests/test_dll.c
-	@mkdir -p $(TEST_DIR)
+	@$(call MKDIR_P,$(TEST_DIR))
 	$(CC) $(CFLAGS) $^ -o $@
 
 test_array: $(TEST_DIR)/test_array$(EXE)
 	$(TEST_DIR)/test_array$(EXE)
 
 $(TEST_DIR)/test_array$(EXE): $(OBJ_DIR)/src/data_structures/array.o $(OBJ_DIR)/src/utils/safe_input_int.o tests/test_array.c
-	@mkdir -p $(TEST_DIR)
+	@$(call MKDIR_P,$(TEST_DIR))
 	$(CC) $(CFLAGS) $^ -o $@
 
 test_stack: $(TEST_DIR)/test_stack$(EXE)
 	$(TEST_DIR)/test_stack$(EXE)
 
 $(TEST_DIR)/test_stack$(EXE): $(OBJ_DIR)/src/expression_evaluation/stack.o $(OBJ_DIR)/src/data_structures/sll.o $(OBJ_DIR)/src/utils/safe_input_int.o tests/test_stack.c
-	@mkdir -p $(TEST_DIR)
+	@$(call MKDIR_P,$(TEST_DIR))
 	$(CC) $(CFLAGS) $^ -o $@
 
 test_priority_queue: $(TEST_DIR)/test_priority_queue$(EXE)
 	$(TEST_DIR)/test_priority_queue$(EXE)
 
 $(TEST_DIR)/test_priority_queue$(EXE): $(OBJ_DIR)/src/data_structures/array.o $(OBJ_DIR)/src/utils/safe_input_int.o $(OBJ_DIR)/src/data_structures/priority_queue.o tests/test_priority_queue.c
-	@mkdir -p $(TEST_DIR)
+	@$(call MKDIR_P,$(TEST_DIR))
 	$(CC) $(CFLAGS) $^ -o $@
 
 test_scll: $(TEST_DIR)/test_scll$(EXE)
 	$(TEST_DIR)/test_scll$(EXE)
 
 $(TEST_DIR)/test_scll$(EXE): $(OBJ_DIR)/src/data_structures/scll.o $(OBJ_DIR)/src/utils/safe_input_int.o tests/test_scll.c
-	@mkdir -p $(TEST_DIR)
+	@$(call MKDIR_P,$(TEST_DIR))
 	$(CC) $(CFLAGS) $^ -o $@
 
 test_simple_queue: $(TEST_DIR)/test_simple_queue$(EXE)
 	$(TEST_DIR)/test_simple_queue$(EXE)
 
 $(TEST_DIR)/test_simple_queue$(EXE): $(OBJ_DIR)/src/data_structures/simple_queue.o $(OBJ_DIR)/src/utils/safe_input_int.o tests/test_simple_queue.c
-	@mkdir -p $(TEST_DIR)
+	@$(call MKDIR_P,$(TEST_DIR))
 	$(CC) $(CFLAGS) $^ -o $@
 
 test_deque: $(TEST_DIR)/test_deque$(EXE)
 	$(TEST_DIR)/test_deque$(EXE)
 
 $(TEST_DIR)/test_deque$(EXE): $(OBJ_DIR)/src/data_structures/deque.o $(OBJ_DIR)/src/utils/safe_input_int.o tests/test_deque.c
-	@mkdir -p $(TEST_DIR)
+	@$(call MKDIR_P,$(TEST_DIR))
 	$(CC) $(CFLAGS) $^ -o $@
 
 test_astar: $(TEST_DIR)/test_astar$(EXE)
 	$(TEST_DIR)/test_astar$(EXE)
 
 $(TEST_DIR)/test_astar$(EXE): $(OBJ_DIR)/src/graph_traversals/astar.o $(OBJ_DIR)/src/graph_traversals/dijkstra.o $(OBJ_DIR)/src/utils/graph_io.o $(OBJ_DIR)/src/graph_traversals/bfs.o $(OBJ_DIR)/src/data_structures/circular_queue.o $(OBJ_DIR)/src/data_structures/sll.o $(OBJ_DIR)/src/utils/safe_input_int.o tests/test_astar.c
-	@mkdir -p $(TEST_DIR)
+	@$(call MKDIR_P,$(TEST_DIR))
 	$(CC) $(CFLAGS) $^ -o $@
 
 test_avl: $(TEST_DIR)/test_avl$(EXE)
 	$(TEST_DIR)/test_avl$(EXE)
 
-$(TEST_DIR)/test_avl$(EXE): $(OBJ_DIR)/src/data_structures/avl.o $(OBJ_DIR)/src/utils/safe_input_int.o tests/test_avl.c
-	@mkdir -p $(TEST_DIR)
+$(TEST_DIR)/test_avl$(EXE): $(OBJ_DIR)/src/trees/avl.o $(OBJ_DIR)/src/utils/safe_input_int.o tests/test_avl.c
+	@$(call MKDIR_P,$(TEST_DIR))
 	$(CC) $(CFLAGS) $^ -o $@
 
 test_trie: $(TEST_DIR)/test_trie$(EXE)
 	$(TEST_DIR)/test_trie$(EXE)
 
-$(TEST_DIR)/test_trie$(EXE): $(OBJ_DIR)/src/data_structures/trie.o $(OBJ_DIR)/src/utils/safe_input_int.o tests/test_trie.c
-	@mkdir -p $(TEST_DIR)
+$(TEST_DIR)/test_trie$(EXE): $(OBJ_DIR)/src/trees/trie.o $(OBJ_DIR)/src/utils/safe_input_int.o tests/test_trie.c
+	@$(call MKDIR_P,$(TEST_DIR))
 	$(CC) $(CFLAGS) $^ -o $@
 
 test_greedy_bfs: $(TEST_DIR)/test_greedy_bfs$(EXE)
 	$(TEST_DIR)/test_greedy_bfs$(EXE)
 
 $(TEST_DIR)/test_greedy_bfs$(EXE): $(OBJ_DIR)/src/graph_traversals/greedy_best_first_search.o $(OBJ_DIR)/src/graph_traversals/dijkstra.o $(OBJ_DIR)/src/utils/graph_io.o $(OBJ_DIR)/src/graph_traversals/bfs.o $(OBJ_DIR)/src/data_structures/circular_queue.o $(OBJ_DIR)/src/data_structures/sll.o $(OBJ_DIR)/src/utils/safe_input_int.o tests/test_greedy_best_first_search.c
-	@mkdir -p $(TEST_DIR)
+	@$(call MKDIR_P,$(TEST_DIR))
 	$(CC) $(CFLAGS) $^ -o $@
 
 test_history_logger: $(TEST_DIR)/test_history_logger$(EXE)
 	$(TEST_DIR)/test_history_logger$(EXE)
 
 $(TEST_DIR)/test_history_logger$(EXE): $(OBJ_DIR)/src/utils/history_logger.o tests/test_history_logger.c
-	@mkdir -p $(TEST_DIR)
+	@$(call MKDIR_P,$(TEST_DIR))
 	$(CC) $(CFLAGS) $^ -o $@
 
 test_shell_sort: $(TEST_DIR)/test_shell_sort$(EXE)
 	$(TEST_DIR)/test_shell_sort$(EXE)
 
 $(TEST_DIR)/test_shell_sort$(EXE): $(OBJ_DIR)/src/sorting_algorithms_n2/shell_sort.o $(OBJ_DIR)/src/data_structures/array.o $(OBJ_DIR)/src/utils/safe_input_int.o $(OBJ_DIR)/src/utils/history_logger.o tests/test_shell_sort.c
-	@mkdir -p $(TEST_DIR)
+	@$(call MKDIR_P,$(TEST_DIR))
 	$(CC) $(CFLAGS) $^ -o $@
 
 test_sorting_n2: $(TEST_DIR)/test_sorting_n2$(EXE)
 	$(TEST_DIR)/test_sorting_n2$(EXE)
 
 $(TEST_DIR)/test_sorting_n2$(EXE): $(OBJ_DIR)/src/sorting_algorithms_n2/bubble_sort.o $(OBJ_DIR)/src/sorting_algorithms_n2/insertion_sort.o $(OBJ_DIR)/src/sorting_algorithms_n2/selection_sort.o $(OBJ_DIR)/src/data_structures/array.o $(OBJ_DIR)/src/utils/safe_input_int.o $(OBJ_DIR)/src/utils/history_logger.o tests/test_sorting_n2.c
-	@mkdir -p $(TEST_DIR)
+	@$(call MKDIR_P,$(TEST_DIR))
 	$(CC) $(CFLAGS) $^ -o $@
 
 test_advanced_sorting: $(TEST_DIR)/test_advanced_sorting$(EXE)
 	$(TEST_DIR)/test_advanced_sorting$(EXE)
 
 $(TEST_DIR)/test_advanced_sorting$(EXE): $(OBJ_DIR)/src/advanced_sorting_algorithms/quick_sort.o $(OBJ_DIR)/src/advanced_sorting_algorithms/merge_sort.o $(OBJ_DIR)/src/advanced_sorting_algorithms/heap_sort.o $(OBJ_DIR)/src/advanced_sorting_algorithms/radix_sort.o $(OBJ_DIR)/src/data_structures/priority_queue.o $(OBJ_DIR)/src/data_structures/array.o $(OBJ_DIR)/src/utils/safe_input_int.o $(OBJ_DIR)/src/utils/history_logger.o tests/test_advanced_sorting.c
-	@mkdir -p $(TEST_DIR)
+	@$(call MKDIR_P,$(TEST_DIR))
 	$(CC) $(CFLAGS) $^ -o $@
 
 TEST_BINS = test_circ_queue test_bst test_search test_hash_func \

--- a/src/data_structures/data_structures.h
+++ b/src/data_structures/data_structures.h
@@ -29,22 +29,6 @@ void print_array(const int arr[], int length_of_array);
 void reverse_array(int arr[], int length_of_array);
 void array_demo(void);
 
-// For Binary Search Tree
-typedef struct bstNode
-{
-    int data;
-    struct bstNode* left;
-    struct bstNode* right;
-} bstNode;
-void binary_search_tree_Demo(void);
-int bst_insert(bstNode** head_ref, int value);
-void bst_inorder(const bstNode* head);
-void bst_preorder(const bstNode* head);
-void bst_postorder(const bstNode* head);
-int countnodes(const bstNode* head);
-int tree_height(const bstNode* root);
-void destroy_bst(bstNode* head);
-bstNode* bst_delete(bstNode* root, int value);
 
 // For circular queue
 typedef struct circular_queue
@@ -102,22 +86,6 @@ int sll_getLength(const Node* head);
 int sll_insertAtPosition(Node** head_ref, int value, int position);
 int sll_deleteAtPosition(Node** head_ref, int position);
 
-// For Threadded Binary Tree
-typedef struct TBTnode
-{
-    int data;
-    bool lthread;
-    bool rthread;
-    struct TBTnode* left;
-    struct TBTnode* right;
-} TBTnode;
-TBTnode* leftmost(TBTnode* node);
-TBTnode* create_node_tbt(int data);
-void preorder_tbt(TBTnode* node);
-void inorder_tbt(TBTnode* node);
-int insert_node_tbt(TBTnode** root_ref, int key);
-void destroy_tbt(TBTnode* node);
-void TBT_demo(void);
 
 // For Priority Queue
 typedef enum
@@ -211,39 +179,5 @@ bool deque_is_full(const deque* dq);
 void display_deque(const deque* dq);
 void deque_demo(void);
 
-// For AVL Tree (Self-Balancing Binary Search Tree)
-typedef struct avlNode
-{
-    int data;
-    int height;
-    struct avlNode* left;
-    struct avlNode* right;
-} avlNode;
-int avl_insert(avlNode** root_ref, int value);
-int avl_delete(avlNode** root_ref, int value);
-int avl_height(const avlNode* node);
-int avl_balance_factor(const avlNode* node);
-void avl_inorder(const avlNode* root);
-void avl_preorder(const avlNode* root);
-void avl_postorder(const avlNode* root);
-void destroy_avl(avlNode* root);
-void avl_demo(void);
-
-// For Trie (Prefix Tree)
-#define TRIE_ALPHA_SIZE 26
-
-typedef struct TrieNode
-{
-    struct TrieNode *children[TRIE_ALPHA_SIZE];
-    int is_end;
-} TrieNode;
-
-TrieNode *trie_create_node(void);
-void      trie_insert(TrieNode *root, const char *word);
-int       trie_search(TrieNode *root, const char *word);
-int       trie_starts_with_prefix(TrieNode *root, const char *prefix);
-void      trie_delete(TrieNode *root, const char *word);
-void      trie_free(TrieNode *node);
-void      trie_demo(void);
 
 #endif

--- a/src/data_structures/data_structures_demo.c
+++ b/src/data_structures/data_structures_demo.c
@@ -1,4 +1,5 @@
 #include "data_structures.h"
+#include "trees.h"
 #include "safe_input.h"
 #include <stdio.h>
 

--- a/src/trees/avl.c
+++ b/src/trees/avl.c
@@ -1,4 +1,4 @@
-#include "data_structures.h"
+#include "trees.h"
 #include "safe_input.h"
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/trees/bst.c
+++ b/src/trees/bst.c
@@ -1,4 +1,4 @@
-#include "data_structures.h"
+#include "trees.h"
 #include "safe_input.h"
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/trees/tbt.c
+++ b/src/trees/tbt.c
@@ -1,4 +1,4 @@
-#include "data_structures.h"
+#include "trees.h"
 #include "safe_input.h"
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/trees/trees.h
+++ b/src/trees/trees.h
@@ -1,22 +1,94 @@
 #ifndef TREES_H
 #define TREES_H
 
+#include <stdbool.h>
+#include <stddef.h>
+
 /*
  * TREES MODULE
  *
  * This module is the dedicated directory for tree-based data structures.
- * It follows the same structure as other modules in this project
- * (e.g. graph_traversals, data_structures, hashing).
+ * It includes:
+ *   - Binary Search Tree (BST)
+ *   - Threaded Binary Tree (TBT)
+ *   - AVL Tree
+ *   - Trie (Prefix Tree)
  *
  * Upcoming implementations:
  *   - B-Tree
  *   - B+ Tree
- *
- * Function declarations and struct definitions will be added here
- * as each implementation is completed.
  */
 
 /* Top-level demo dispatcher - called from main menu (option 8) */
 void trees_demo(void);
+
+// For Binary Search Tree
+typedef struct bstNode
+{
+    int data;
+    struct bstNode* left;
+    struct bstNode* right;
+} bstNode;
+void binary_search_tree_Demo(void);
+int bst_insert(bstNode** head_ref, int value);
+void bst_inorder(const bstNode* head);
+void bst_preorder(const bstNode* head);
+void bst_postorder(const bstNode* head);
+int countnodes(const bstNode* head);
+int tree_height(const bstNode* root);
+void destroy_bst(bstNode* head);
+bstNode* bst_delete(bstNode* root, int value);
+
+// For Threaded Binary Tree
+typedef struct TBTnode
+{
+    int data;
+    bool lthread;
+    bool rthread;
+    struct TBTnode* left;
+    struct TBTnode* right;
+} TBTnode;
+TBTnode* leftmost(TBTnode* node);
+TBTnode* create_node_tbt(int data);
+void preorder_tbt(TBTnode* node);
+void inorder_tbt(TBTnode* node);
+int insert_node_tbt(TBTnode** root_ref, int key);
+void destroy_tbt(TBTnode* node);
+void TBT_demo(void);
+
+// For AVL Tree (Self-Balancing Binary Search Tree)
+typedef struct avlNode
+{
+    int data;
+    int height;
+    struct avlNode* left;
+    struct avlNode* right;
+} avlNode;
+int avl_insert(avlNode** root_ref, int value);
+int avl_delete(avlNode** root_ref, int value);
+int avl_height(const avlNode* node);
+int avl_balance_factor(const avlNode* node);
+void avl_inorder(const avlNode* root);
+void avl_preorder(const avlNode* root);
+void avl_postorder(const avlNode* root);
+void destroy_avl(avlNode* root);
+void avl_demo(void);
+
+// For Trie (Prefix Tree)
+#define TRIE_ALPHA_SIZE 26
+
+typedef struct TrieNode
+{
+    struct TrieNode *children[TRIE_ALPHA_SIZE];
+    int is_end;
+} TrieNode;
+
+TrieNode *trie_create_node(void);
+void      trie_insert(TrieNode *root, const char *word);
+int       trie_search(TrieNode *root, const char *word);
+int       trie_starts_with_prefix(TrieNode *root, const char *prefix);
+void      trie_delete(TrieNode *root, const char *word);
+void      trie_free(TrieNode *node);
+void      trie_demo(void);
 
 #endif

--- a/src/trees/trie.c
+++ b/src/trees/trie.c
@@ -1,4 +1,4 @@
-#include "data_structures.h"
+#include "trees.h"
 #include "safe_input.h"
 #include <stdio.h>
 #include <stdlib.h>

--- a/tests/test_avl.c
+++ b/tests/test_avl.c
@@ -1,4 +1,4 @@
-#include "data_structures.h"
+#include "trees.h"
 #include <assert.h>
 #include <stdio.h>
 

--- a/tests/test_bst.c
+++ b/tests/test_bst.c
@@ -1,4 +1,4 @@
-#include "data_structures.h"
+#include "trees.h"
 #include <assert.h>
 #include <stdio.h>
 

--- a/tests/test_tbt.c
+++ b/tests/test_tbt.c
@@ -1,4 +1,4 @@
-#include "data_structures.h"
+#include "trees.h"
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/tests/test_trie.c
+++ b/tests/test_trie.c
@@ -1,4 +1,4 @@
-#include "data_structures.h"
+#include "trees.h"
 #include <assert.h>
 #include <stdio.h>
 


### PR DESCRIPTION
***
resolves : #139 
### Description
This Pull Request restructures the tree-based data structures into their dedicated directory (`src/trees/`), updates their declarations/includes, and improves the `Makefile` to make directory creation fully compatible with Windows environments.

#### Key Changes

1. **Directory Structure Refactoring**:
   * **Source Files Moved**: Relocated `avl.c`, `bst.c`, `tbt.c`, and `trie.c` from `src/data_structures/` to `src/trees/`.
   * **Header Relocation**: Moved tree node definitions (`avlNode`, `bstNode`, `TBTnode`, `TrieNode`) and their respective function prototypes from `src/data_structures/data_structures.h` into `src/trees/trees.h`.
   * **Includes Updated**: Refactored tree source files, tree unit tests (`test_avl.c`, `test_bst.c`, `test_tbt.c`, `test_trie.c`), and `data_structures_demo.c` to use `#include "trees.h"`.

2. **Makefile Improvements & Windows Compatibility**:
   * **Cross-platform Directory Creation**: Refactored the `MKDIR_P` variable inside the `Makefile` for Windows to run via `cmd /c` and convert forward slashes to backslashes (`subst`) to prevent directory creation errors in standard command prompt shells.
   * **Macro Migration**: Replaced all hardcoded `@mkdir -p $(TEST_DIR)` shell commands in the 21 test targets with the `@$(call MKDIR_P,$(TEST_DIR))` macro.
   * **Dependency Updates**: Updated the compilation rules for the tree test targets to link with object files in `object_files/src/trees/` instead of the old data structures path.

---

### Verification & Testing

* **Clean & Build**: Ran `make clean && make` to confirm the main binary compiles successfully with the new tree directory layout.
* **Test Suite Verification**: Ran `make test` and verified all 21 unit tests (including BST, TBT, AVL, and Trie) compile and pass cleanly without any memory leaks or warnings.