### PR TITLE
feat: wire tree demo functions into trees_demo

### DIFF
--- a/src/trees/trees_demo.c
+++ b/src/trees/trees_demo.c
@@ -2,16 +2,48 @@
 #include "safe_input.h"
 #include <stdio.h>
 
-/*
- * trees_demo()
- *
- * Top-level demo dispatcher for the trees module.
- * Called from main menu option 8.
- * Sub-menus for B-Tree and B+ Tree will be added here
- * once their implementations are complete.
- */
 void trees_demo(void)
 {
-    printf("\nTrees module - B-Tree and B+ Tree implementations coming soon.\n");
-    printf("Returning to main menu...\n");
+    int tree_status, tree_choice;
+
+    while (1)
+    {
+        tree_status = safe_input_int(
+            &tree_choice,
+            "\nenter 1 for Binary Search Tree demo"
+            "\nenter 2 for AVL Tree demo"
+            "\nenter 3 for Threaded Binary Tree demo"
+            "\nenter 4 for Trie demo"
+            "\nenter choice : ",
+            1, 4
+        );
+
+        if (tree_status == INPUT_EXIT_SIGNAL)
+        {
+            printf("\nExiting trees_demo....\n");
+            return;
+        }
+
+        if (tree_status == 0)
+            continue;
+
+        switch (tree_choice)
+        {
+            case 1:
+                binary_search_tree_Demo();
+                break;
+
+            case 2:
+                avl_demo();
+                break;
+
+            case 3:
+                TBT_demo();
+                break;
+
+            case 4:
+                trie_demo();
+                break;
+        }
+    }
 }


### PR DESCRIPTION
## Description

Connected the existing tree demo functions to `trees_demo.c` by replacing the placeholder implementation with an interactive menu-based dispatcher.

### Changes Made

* Added menu options for:

  * Binary Search Tree (BST)
  * AVL Tree
  * Threaded Binary Tree (TBT)
  * Trie
* Wired corresponding demo functions:

  * `binary_search_tree_Demo()`
  * `avl_demo()`
  * `TBT_demo()`
  * `trie_demo()`
* Added `-1 to exit` option for consistency with other modules.

### Problem

Previously, `trees_demo.c` only displayed a placeholder message and did not invoke the already implemented tree demos.

### Testing

* Verified all tree demos open correctly from the Trees module.
* Confirmed `-1` exits back to the main menu.
* Tested interactive navigation for each tree demo.

## Type of Change

* [x] New feature
* [ ] Bug fix
* [ ] Documentation update
* [ ] Refactoring

Fixes #145 