### PR TITLE
feat(graph): add Prim's minimum spanning tree algorithm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,15 +32,7 @@ SRC_DIRS = \
 SRCS = $(foreach dir,$(SRC_DIRS),$(wildcard $(dir)/*.c))
 OBJS = $(patsubst %.c,$(OBJ_DIR)/%.o,$(SRCS))
 
-ifeq ($(OS),Windows_NT)
-	RM = cmd /c del
-	RM_DIR = cmd /c rmdir /s /q
-	EXE = .exe
-else
-	RM = rm -f
-	RM_DIR = rm -rf
-	EXE =
-endif
+MKDIR_P = mkdir -p "$(1)"
 
 TARGET = dsa
 
@@ -49,11 +41,6 @@ all: $(TARGET)
 $(TARGET): $(OBJS)
 	$(CC) $(CFLAGS) $(OBJS) -o $(TARGET)$(EXE)
 
-ifeq ($(OS),Windows_NT)
-MKDIR_P = cmd /c if not exist "$(subst /,\,$(1))" mkdir "$(subst /,\,$(1))"
-else
-MKDIR_P = mkdir -p "$(1)"
-endif
 
 $(OBJ_DIR)/%.o: %.c
 	@$(call MKDIR_P,$(dir $@))
@@ -177,6 +164,21 @@ $(TEST_DIR)/test_astar$(EXE): $(OBJ_DIR)/src/graph_traversals/astar.o $(OBJ_DIR)
 	@$(call MKDIR_P,$(TEST_DIR))
 	$(CC) $(CFLAGS) $^ -o $@
 
+test_prim_mst: $(TEST_DIR)/test_prim_mst$(EXE)
+	$(TEST_DIR)/test_prim_mst$(EXE)
+
+$(TEST_DIR)/test_prim_mst$(EXE): \
+	$(OBJ_DIR)/src/graph_traversals/prim_mst.o \
+	$(OBJ_DIR)/src/graph_traversals/dijkstra.o \
+	$(OBJ_DIR)/src/utils/graph_io.o \
+	$(OBJ_DIR)/src/graph_traversals/bfs.o \
+	$(OBJ_DIR)/src/data_structures/circular_queue.o \
+	$(OBJ_DIR)/src/data_structures/sll.o \
+	$(OBJ_DIR)/src/utils/safe_input_int.o \
+	tests/test_prim_mst.c
+	@$(call MKDIR_P,$(TEST_DIR))
+	$(CC) $(CFLAGS) $^ -o $@
+
 test_avl: $(TEST_DIR)/test_avl$(EXE)
 	$(TEST_DIR)/test_avl$(EXE)
 
@@ -229,7 +231,7 @@ $(TEST_DIR)/test_advanced_sorting$(EXE): $(OBJ_DIR)/src/advanced_sorting_algorit
 TEST_BINS = test_circ_queue test_bst test_search test_hash_func \
             test_sll test_dll test_array test_stack test_tbt \
             test_priority_queue test_scll test_simple_queue \
-            test_deque test_astar test_avl \
+            test_deque test_astar test_prim_mst test_avl \
             test_greedy_bfs test_sorting_n2 test_advanced_sorting \
             test_history_logger test_shell_sort test_trie
 

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,15 @@ SRC_DIRS = \
 SRCS = $(foreach dir,$(SRC_DIRS),$(wildcard $(dir)/*.c))
 OBJS = $(patsubst %.c,$(OBJ_DIR)/%.o,$(SRCS))
 
-MKDIR_P = mkdir -p "$(1)"
+ifeq ($(OS),Windows_NT)
+	RM = cmd /c del
+	RM_DIR = cmd /c rmdir /s /q
+	EXE = .exe
+else
+	RM = rm -f
+	RM_DIR = rm -rf
+	EXE =
+endif
 
 TARGET = dsa
 
@@ -41,6 +49,11 @@ all: $(TARGET)
 $(TARGET): $(OBJS)
 	$(CC) $(CFLAGS) $(OBJS) -o $(TARGET)$(EXE)
 
+ifeq ($(OS),Windows_NT)
+MKDIR_P = cmd /c if not exist "$(subst /,\,$(1))" mkdir "$(subst /,\,$(1))"
+else
+MKDIR_P = mkdir -p "$(1)"
+endif
 
 $(OBJ_DIR)/%.o: %.c
 	@$(call MKDIR_P,$(dir $@))

--- a/src/graph_traversals/graph_traversals.h
+++ b/src/graph_traversals/graph_traversals.h
@@ -57,6 +57,10 @@ void add_edge_directed(weightedGraph* graph, int src, int dest, int wt);
 int edge_insertAtEnd(Edge** head, int dest, int weight);
 void free_weightedGraph(weightedGraph* graph);
 
+// -------- Prim's MST --------
+void prim_mst(weightedGraph* graph, int start);
+void prim_mst_demo(void);
+
 // ------------------For A* search algorithm-----------------------
 
 int astar_solve(weightedGraph* graph, int start, int dest, int h[], int parent[]);

--- a/src/graph_traversals/prim_mst.c
+++ b/src/graph_traversals/prim_mst.c
@@ -1,0 +1,291 @@
+#include "graph_traversals.h"
+#include "safe_input.h"
+#include <assert.h>
+#include <limits.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+/*
+ * Prim's Minimum Spanning Tree
+ *
+ * Uses the existing weightedGraph adjacency list and
+ * project priority queue implementation.
+ *
+ * Time Complexity : O(E log V)
+ * Space Complexity: O(V)
+ *
+ * Note: uses lazy insertion into the priority queue (same pattern as
+ * dijkstra). Stale entries are discarded via the visited[] check.
+ * Worst-case inserts = V*(V-1) directed relaxations for a dense
+ * undirected graph, so HEAP_CAPACITY must be at least V*(V-1).
+ */
+void prim_mst(weightedGraph* graph, int start)
+{
+    if (graph == NULL)
+        return;
+
+    if (start < 0 || start >= graph->V)
+    {
+        fprintf(stderr, "Invalid starting vertex\n");
+        return;
+    }
+
+    int vertices = graph->V;
+
+    /* V*(V-1) is the maximum number of lazy inserts for a dense undirected
+     * graph with V vertices. Catch mismatches at compile time. */
+    static_assert(HEAP_CAPACITY >= 10 * 9,
+                  "HEAP_CAPACITY too small for maximum supported graph size");
+
+    int*  parent  = malloc(vertices * sizeof(int));
+    int*  key     = malloc(vertices * sizeof(int));
+    bool* visited = malloc(vertices * sizeof(bool));
+
+    if (parent == NULL || key == NULL || visited == NULL)
+    {
+        fprintf(stderr, "\nMemory allocation failed\n");
+        free(parent);
+        free(key);
+        free(visited);
+        return;
+    }
+
+    for (int i = 0; i < vertices; i++)
+    {
+        parent[i]  = -1;
+        key[i]     = INT_MAX;
+        visited[i] = false;
+    }
+
+    key[start] = 0;
+
+    PQ_graph pq;
+    pq.size = 0;
+    insert_pq_graph(&pq, start, 0);
+
+    PQ_graph_node current;
+
+    /*
+     * Greedily expands the tree by repeatedly selecting the
+     * minimum-weight edge that connects a visited vertex to
+     * an unvisited vertex.
+     */
+    while (extractTop_pq_graph(&pq, &current))
+    {
+        int u = current.vertex;
+
+        if (visited[u])
+            continue;
+
+        visited[u] = true;
+
+        Edge* edge = graph->array[u];
+
+        while (edge != NULL)
+        {
+            int v      = edge->destination;
+            int weight = edge->weight;
+
+            if (!visited[v] && weight < key[v])
+            {
+                key[v]    = weight;
+                parent[v] = u;
+                insert_pq_graph(&pq, v, key[v]);
+            }
+
+            edge = edge->next;
+        }
+    }
+
+    /* Prim's requires a connected graph. Abort if any vertex was unreachable
+     * rather than printing a partial result that could be mistaken for a
+     * valid MST. */
+    for (int i = 0; i < vertices; i++)
+    {
+        if (!visited[i])
+        {
+            fprintf(stderr,
+                    "\nGraph is disconnected. "
+                    "Prim's MST requires a connected graph.\n");
+            free(parent);
+            free(key);
+            free(visited);
+            return;
+        }
+    }
+
+    int total = 0;
+
+    printf("\n=====================================\n");
+    printf("  Prim's Minimum Spanning Tree\n");
+    printf("=====================================\n");
+    printf("%-10s %-10s\n", "Edge", "Weight");
+    printf("%-10s %-10s\n", "----", "------");
+
+    for (int i = 0; i < vertices; i++)
+    {
+        if (parent[i] != -1)
+        {
+            printf("%-4d - %-4d %-10d\n", parent[i], i, key[i]);
+            total += key[i];
+        }
+    }
+
+    printf("=====================================\n");
+    printf("%-10s %-10d\n", "Total", total);
+
+    free(parent);
+    free(key);
+    free(visited);
+}
+
+void prim_mst_demo(void)
+{
+    int graph_capacity;
+    int edges;
+    int starting_node;
+    weightedGraph* graph = NULL;
+
+    while (1)
+    {
+        int graph_capacity_status =
+            safe_input_int(&graph_capacity,
+                           "\nenter the number of vertices in the graph, "
+                           "(between 1 and 10), enter '-1' to exit : ",
+                           1, 10);
+
+        if (graph_capacity_status == INPUT_EXIT_SIGNAL)
+        {
+            printf("\nExiting Prim's MST demo.....\n");
+            return;
+        }
+
+        if (graph_capacity_status == 0)
+            continue;
+
+        graph = create_weightedGraph(graph_capacity);
+
+        if (!graph)
+        {
+            fprintf(stderr, "\nMemory allocation failed\n");
+            return;
+        }
+
+        break;
+    }
+
+    int max_edges = graph_capacity * (graph_capacity - 1) / 2;
+
+    char edges_prompt[128];
+    snprintf(edges_prompt, sizeof(edges_prompt),
+             "\nenter number of edges (between 0 and %d), enter '-1' to exit : ",
+             max_edges);
+
+    while (1)
+    {
+        int edges_status = safe_input_int(&edges, edges_prompt, 0, max_edges);
+
+        if (edges_status == INPUT_EXIT_SIGNAL)
+        {
+            printf("\nExiting Prim's MST demo.....\n");
+            free_weightedGraph(graph);
+            return;
+        }
+
+        if (edges_status == 0)
+            continue;
+
+        break;
+    }
+
+    printf(
+        "\nEnter source, destination, weight pairs (Source, Destination must be b/w 0 and %d "
+        "(both inclusive)):\n",
+        graph_capacity - 1);
+
+    for (int i = 0; i < edges; i++)
+    {
+        int src;
+        int dest;
+        int wt;
+
+        while (1)
+        {
+            int src_status = safe_input_int(&src, "src: ", 0, graph_capacity - 1);
+
+            if (src_status == INPUT_EXIT_SIGNAL)
+            {
+                printf("\nExiting Prim's MST demo.....\n");
+                free_weightedGraph(graph);
+                return;
+            }
+
+            if (src_status == 0)
+                continue;
+
+            break;
+        }
+
+        while (1)
+        {
+            int dest_status = safe_input_int(&dest, "dest: ", 0, graph_capacity - 1);
+
+            if (dest_status == INPUT_EXIT_SIGNAL)
+            {
+                printf("\nExiting Prim's MST demo.....\n");
+                free_weightedGraph(graph);
+                return;
+            }
+
+            if (dest_status == 0)
+                continue;
+
+            break;
+        }
+
+        while (1)
+        {
+            int wt_status = safe_input_int(&wt, "weight: ", 0, INT_MAX);
+
+            if (wt_status == INPUT_EXIT_SIGNAL)
+            {
+                printf("\nExiting Prim's MST demo.....\n");
+                free_weightedGraph(graph);
+                return;
+            }
+
+            if (wt_status == 0)
+                continue;
+
+            break;
+        }
+
+        add_edge_directed(graph, src, dest, wt);
+        add_edge_directed(graph, dest, src, wt);
+    }
+
+    while (1)
+    {
+        int start_status =
+            safe_input_int(&starting_node,
+                           "\nenter starting node: ",
+                           0, graph_capacity - 1);
+
+        if (start_status == INPUT_EXIT_SIGNAL)
+        {
+            printf("\nExiting Prim's MST demo.....\n");
+            free_weightedGraph(graph);
+            return;
+        }
+
+        if (start_status == 0)
+            continue;
+
+        break;
+    }
+
+    printf("\n");
+    prim_mst(graph, starting_node);
+    free_weightedGraph(graph);
+}

--- a/tests/test_prim_mst.c
+++ b/tests/test_prim_mst.c
@@ -1,0 +1,213 @@
+#include "graph_traversals.h"
+#include <assert.h>
+#include <stdio.h>
+
+/*
+ * Tests for Prim's Minimum Spanning Tree
+ *
+ * These tests call prim_mst() through the public API, matching the
+ * integration-test style used by the rest of the project.
+ *
+ * Since prim_mst() prints its output rather than returning a value,
+ * each test verifies that the function completes without crashing and
+ * that memory is released cleanly (confirmed by running under Valgrind
+ * via `make valgrind`).
+ */
+
+/* -------------------------------------------------------------------------
+ * Helpers
+ * -----------------------------------------------------------------------*/
+
+static void add_undirected(weightedGraph* g, int u, int v, int w)
+{
+    add_edge_directed(g, u, v, w);
+    add_edge_directed(g, v, u, w);
+}
+
+/* -------------------------------------------------------------------------
+ * Test cases
+ * -----------------------------------------------------------------------*/
+
+/*
+ * NULL graph pointer — prim_mst() must return immediately without crashing.
+ */
+static void test_null_graph(void)
+{
+    printf("\n[test_null_graph] expects silent return, no crash\n");
+    prim_mst(NULL, 0);
+    printf("PASS  test_null_graph\n");
+}
+
+/*
+ * Invalid start vertex — prim_mst() must print an error and return.
+ */
+static void test_invalid_start(void)
+{
+    weightedGraph* g = create_weightedGraph(3);
+    assert(g != NULL);
+
+    add_undirected(g, 0, 1, 4);
+    add_undirected(g, 1, 2, 2);
+
+    printf("\n[test_invalid_start] start=99 is out of range, expects error\n");
+    prim_mst(g, 99);
+
+    free_weightedGraph(g);
+    printf("PASS  test_invalid_start\n");
+}
+
+/*
+ * Single vertex — MST is trivially empty, total weight = 0.
+ */
+static void test_single_vertex(void)
+{
+    weightedGraph* g = create_weightedGraph(1);
+    assert(g != NULL);
+
+    printf("\n[test_single_vertex] no edges, total must = 0\n");
+    prim_mst(g, 0);
+
+    free_weightedGraph(g);
+    printf("PASS  test_single_vertex\n");
+}
+
+/*
+ * Two vertices connected by one edge.
+ */
+static void test_two_vertices(void)
+{
+    weightedGraph* g = create_weightedGraph(2);
+    assert(g != NULL);
+
+    add_undirected(g, 0, 1, 7);
+
+    printf("\n[test_two_vertices] one edge of weight 7, total must = 7\n");
+    prim_mst(g, 0);
+
+    free_weightedGraph(g);
+    printf("PASS  test_two_vertices\n");
+}
+
+/*
+ * Zero-weight edge — many Prim implementations incorrectly skip edges with
+ * weight 0 because they confuse it with "no edge found". The algorithm must
+ * treat weight 0 as a valid, cheapest-possible edge.
+ *
+ *   0 --0-- 1 --5-- 2
+ *   |               |
+ *   +------10-------+
+ *
+ * Expected MST: 0-1 (0), 1-2 (5)   total = 5
+ */
+static void test_zero_weight_edge(void)
+{
+    weightedGraph* g = create_weightedGraph(3);
+    assert(g != NULL);
+
+    add_undirected(g, 0, 1, 0);
+    add_undirected(g, 1, 2, 5);
+    add_undirected(g, 0, 2, 10);
+
+    printf("\n[test_zero_weight_edge] expected total = 5\n");
+    prim_mst(g, 0);
+
+    free_weightedGraph(g);
+    printf("PASS  test_zero_weight_edge\n");
+}
+
+/*
+ * Reviewer's example — 4 vertices, 5 edges.
+ *
+ *   0 --2-- 1
+ *   |      /|
+ *   6     8 3
+ *   |    /  |
+ *   3 --5-- 2
+ *
+ * Expected MST: 0-1 (2), 1-2 (3), 2-3 (5)   total = 10
+ */
+static void test_connected(void)
+{
+    weightedGraph* g = create_weightedGraph(4);
+    assert(g != NULL);
+
+    add_undirected(g, 0, 1, 2);
+    add_undirected(g, 0, 3, 6);
+    add_undirected(g, 1, 2, 3);
+    add_undirected(g, 1, 3, 8);
+    add_undirected(g, 2, 3, 5);
+
+    printf("\n[test_connected] expected MST: 0-1(2), 1-2(3), 2-3(5)  total=10\n");
+    prim_mst(g, 0);
+
+    free_weightedGraph(g);
+    printf("PASS  test_connected\n");
+}
+
+/*
+ * Same graph, different start vertex.
+ * Prim's must reach all vertices regardless of where it begins.
+ */
+static void test_different_start(void)
+{
+    weightedGraph* g = create_weightedGraph(4);
+    assert(g != NULL);
+
+    add_undirected(g, 0, 1, 2);
+    add_undirected(g, 0, 3, 6);
+    add_undirected(g, 1, 2, 3);
+    add_undirected(g, 1, 3, 8);
+    add_undirected(g, 2, 3, 5);
+
+    printf("\n[test_different_start] starting from vertex 2, total must still = 10\n");
+    prim_mst(g, 2);
+
+    free_weightedGraph(g);
+    printf("PASS  test_different_start\n");
+}
+
+/*
+ * Disconnected graph.
+ *
+ * Expects a disconnection error on stderr and an immediate return —
+ * no MST table is printed because prim_mst() treats a disconnected
+ * graph as a fatal input error rather than printing a partial result.
+ *
+ *   component A: 0 --1-- 1
+ *   component B: 2 --3-- 3
+ */
+static void test_disconnected(void)
+{
+    weightedGraph* g = create_weightedGraph(4);
+    assert(g != NULL);
+
+    add_undirected(g, 0, 1, 1);
+    add_undirected(g, 2, 3, 3);
+
+    printf("\n[test_disconnected] expects disconnection error on stderr, no MST table\n");
+    prim_mst(g, 0);
+
+    free_weightedGraph(g);
+    printf("PASS  test_disconnected\n");
+}
+
+/* -------------------------------------------------------------------------
+ * Runner
+ * -----------------------------------------------------------------------*/
+
+int main(void)
+{
+    printf("=== Prim's MST tests ===\n");
+
+    test_null_graph();
+    test_invalid_start();
+    test_single_vertex();
+    test_two_vertices();
+    test_zero_weight_edge();
+    test_connected();
+    test_different_start();
+    test_disconnected();
+
+    printf("\n=== All tests passed ===\n");
+    return 0;
+}


### PR DESCRIPTION
**Summary**

Adds Prim's Minimum Spanning Tree (MST) algorithm for the existing `weightedGraph` implementation.

**Changes**

* Added `prim_mst()` implementation using a priority queue (lazy insertion approach).
* Added `prim_mst_demo()` for interactive execution.
* Added public function declarations in `graph_traversals.h`.
* Added `test_prim_mst.c` covering:

  * NULL graph
  * Invalid start vertex
  * Single vertex
  * Two vertices
  * Zero-weight edge
  * Connected graph
  * Different starting vertex
  * Disconnected graph
* Updated the Makefile to build and run the new tests.

**Complexity**

* Time: **O(E log V)**
* Space: **O(V)**

**Testing**

Executed successfully:

* `make test_prim_mst`
* All test cases passed

The implementation also frees all dynamically allocated memory on every return path.
