### PR TITLE
build(makefile): add run target and avoid unnecessary rebuilds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,10 @@ all: $(TARGET)
 $(TARGET): $(OBJS)
 	$(CC) $(CFLAGS) $(OBJS) -o $(TARGET)$(EXE)
 
+run: $(TARGET)
+	./$(TARGET)$(EXE)
+
+
 ifeq ($(OS),Windows_NT)
 MKDIR_P = cmd /c if not exist "$(subst /,\,$(1))" mkdir "$(subst /,\,$(1))"
 else
@@ -235,4 +239,4 @@ TEST_BINS = test_circ_queue test_bst test_search test_hash_func \
 
 test: $(TEST_BINS)
 
-.PHONY: all fmt clean valgrind test $(TARGET) $(TEST_BINS)
+.PHONY: all fmt clean valgrind test run $(TEST_BINS)


### PR DESCRIPTION
## changes done 

* Added a `run` target to build and execute the project using a single command.
* Removed `$(TARGET)` from `.PHONY` to allow Make to skip unnecessary rebuilds when files are unchanged.
* Preserved existing build and test workflows.

## Testing

* Verified `make` builds the executable successfully.
* Verified consecutive `make` calls do not rebuild unchanged sources.
* Verified `make run` executes the generated executable correctly.
 
closes #148 