### PR TITLE
feat(graph): visualize a graph as an adjacency list

### DIFF
--- a/src/graph_traversals/graph_traversals.h
+++ b/src/graph_traversals/graph_traversals.h
@@ -5,6 +5,7 @@
 void bfs_demo(void);
 void dfs_demo(void);
 void graph_traversals_demo(void);
+void visualize_graph_demo(void);
 typedef struct Graph
 {
     int V;
@@ -14,6 +15,7 @@ typedef struct Graph
 Graph* create_graph(int V);
 void add_edge_undirected(Graph* graph, int src, int dest);
 void free_graph(Graph* graph);
+void print_graph(const Graph* graph);
 void add_edge_directed_unweighted(Graph* graph, int src, int dest);
 void topological_sort_kahn(Graph* graph);
 void topological_sort_demo(void);

--- a/src/graph_traversals/graph_traversals_demo.c
+++ b/src/graph_traversals/graph_traversals_demo.c
@@ -7,12 +7,14 @@ void graph_traversals_demo(void)
     while (1)
     {
         int graph_traversal_choice;
-        int graph_traversal_status = safe_input_int(
-    &graph_traversal_choice,
-    "\nenter 1 for bfs, 2 for dfs, 3 for dijkstra, 4 for astar, "
+        int graph_traversal_status =
+            safe_input_int(&graph_traversal_choice,
+                           "\nenter 1 for bfs, 2 for dfs, 3 for dijkstra, 4 for astar, "
 
-    "5 for greedy-bfs, 6 for bellman ford, 7 for topological-sort : ",
-    1, 7);
+                           "5 for greedy-bfs, 6 for bellman ford, 7 for topological-sort, "
+
+                           "8 for visualize-graph : ",
+                           1, 8);
 
         if (graph_traversal_status == INPUT_EXIT_SIGNAL)
         {
@@ -40,15 +42,17 @@ void graph_traversals_demo(void)
                 astar_demo();
                 break;
             case 5:
-                  greedy_best_first_search_demo();
-                 break;
+                greedy_best_first_search_demo();
+                break;
             case 6:
-                 bellman_ford_demo();
-                 break;
+                bellman_ford_demo();
+                break;
             case 7:
                 topological_sort_demo();
                 break;
-
+            case 8:
+                visualize_graph_demo();
+                break;
         }
     }
 }

--- a/src/graph_traversals/graph_visualize.c
+++ b/src/graph_traversals/graph_visualize.c
@@ -1,0 +1,175 @@
+#include "graph_io.h"
+#include "graph_traversals.h"
+#include "safe_input.h"
+#include <stdio.h>
+#include <string.h>
+
+// Standalone "visualize graph" demo: builds an unweighted graph the same two
+// ways the traversal demos do (manual entry or CSV import) and then prints it
+// as an adjacency list. It deliberately shows the structure itself, separate
+// from any traversal output.
+void visualize_graph_demo(void)
+{
+    int edges;
+    int graph_capacity;
+    int input_method;
+    Graph* graph = NULL;
+
+    while (1)
+    {
+        int method_status = safe_input_int(&input_method,
+                                           "\nenter 1 to build the graph manually, 2 to load it "
+                                           "from a CSV file, enter '-1' to exit : ",
+                                           1, 2);
+
+        if (method_status == INPUT_EXIT_SIGNAL)
+        {
+            printf("\nExiting graph visualization.....\n");
+            return;
+        }
+
+        if (method_status == 0)
+        {
+            continue;
+        }
+
+        break;
+    }
+
+    if (input_method == 2)
+    {
+        while (1)
+        {
+            char path[256];
+            printf("\nenter the path to the CSV file, enter '-1' to exit : ");
+            fflush(stdout);
+
+            if (!fgets(path, sizeof(path), stdin))
+            {
+                printf("\ninput ended unexpectedly\n");
+                clearerr(stdin);
+                return;
+            }
+
+            size_t len = strlen(path);
+            while (len > 0 && (path[len - 1] == '\n' || path[len - 1] == '\r'))
+                path[--len] = '\0';
+
+            if (strcmp(path, "-1") == 0)
+            {
+                printf("\nExiting graph visualization.....\n");
+                return;
+            }
+
+            if (len == 0)
+            {
+                continue;
+            }
+
+            graph = load_graph_from_csv(path);
+
+            if (!graph)
+            {
+                // error already reported by the loader, let the user retry
+                continue;
+            }
+
+            break;
+        }
+    }
+    else
+    {
+        while (1)
+        {
+            int graph_capacity_status =
+                safe_input_int(&graph_capacity,
+                               "\nenter the number of vertices in the graph, "
+                               "(between 1 and 10), enter '-1' to exit : ",
+                               1, 10);
+
+            if (graph_capacity_status == INPUT_EXIT_SIGNAL)
+            {
+                printf("\nExiting graph visualization.....\n");
+                return;
+            }
+
+            if (graph_capacity_status == 0)
+            {
+                continue;
+            }
+
+            graph = create_graph(graph_capacity);
+
+            if (!graph)
+            {
+                printf("\nmalloc allocation failed\n");
+                return;
+            }
+
+            break;
+        }
+
+        while (1)
+        {
+            int edges_capacity_status = safe_input_int(
+                &edges, "\nenter number of edges (between 1 and 100), enter '-1' to exit :", 1,
+                100);
+
+            if (edges_capacity_status == INPUT_EXIT_SIGNAL)
+            {
+                printf("\nExiting graph visualization\n");
+                free_graph(graph);
+                return;
+            }
+
+            if (edges_capacity_status == 0)
+            {
+                continue;
+            }
+
+            break;
+        }
+
+        printf("\nenter edges (src dest) (from 0 to vertices-1, enter '-1' to exit):\n");
+
+        for (int i = 0; i < edges; i++)
+        {
+            int src_status;
+            int dest_status;
+            int src;
+            int dest;
+
+        retry:
+            src_status = safe_input_int(&src, "src: ", 0, graph_capacity - 1);
+
+            if (src_status == INPUT_EXIT_SIGNAL)
+            {
+                printf("\nExiting graph visualization\n");
+                free_graph(graph);
+                return;
+            }
+            if (src_status == 0)
+            {
+                goto retry;
+            }
+
+            dest_status = safe_input_int(&dest, "dest: ", 0, graph_capacity - 1);
+
+            if (dest_status == INPUT_EXIT_SIGNAL)
+            {
+                printf("\nExiting graph visualization\n");
+                free_graph(graph);
+                return;
+            }
+            if (dest_status == 0)
+            {
+                goto retry;
+            }
+
+            add_edge_undirected(graph, src, dest);
+        }
+    }
+
+    print_graph(graph);
+    free_graph(graph);
+}

--- a/src/graph_traversals/graph_visualize.c
+++ b/src/graph_traversals/graph_visualize.c
@@ -76,8 +76,8 @@ void visualize_graph_demo(void)
 
             break;
         }
-    }
-    else
+    }  
+    else if(input_method==1)
     {
         while (1)
         {

--- a/src/utils/graph_io.c
+++ b/src/utils/graph_io.c
@@ -276,3 +276,24 @@ Graph* load_graph_from_csv(const char* path)
     printf("\nLoaded graph from '%s' (%d vertices, %d edges).\n", path, V, E);
     return graph;
 }
+
+// Prints an unweighted graph as an adjacency list, one vertex per line. Each
+// row reuses sll_printlist to show that vertex's neighbour list, mirroring how
+// the hash-table buckets are already visualized in separate chaining.
+void print_graph(const Graph* graph)
+{
+    if (!graph)
+    {
+        printf("\nNo graph to display.\n");
+        return;
+    }
+
+    printf("\nAdjacency list (%d vertices):\n", graph->V);
+
+    for (int i = 0; i < graph->V; i++)
+    {
+        printf("vertex %d: ", i);
+        sll_printlist(graph->array[i]);
+        printf("\n");
+    }
+}


### PR DESCRIPTION
Closes #137

## What this adds

A way to **visualize an unweighted graph as an adjacency list**, the same arrow style already used for linked lists and hash buckets.

- `print_graph(const Graph* graph)` in `src/utils/graph_io.c` — prints one line per vertex and reuses the existing `sll_printlist()` for each vertex's neighbour list (since `Graph.array[i]` is already a plain singly linked list of neighbour ids). Declared in `graph_traversals.h` next to `create_graph` / `add_edge_undirected` / `free_graph`.
- A standalone **"visualize graph"** option (8) in the graph-traversals menu (`visualize_graph_demo` in `src/graph_traversals/graph_visualize.c`). It builds a graph either manually or from a CSV file (reusing `load_graph_from_csv`) and then prints its structure. It shows the structure itself, kept separate from any traversal output.

Scope is the **unweighted `Graph` only**; the weighted `weightedGraph` (which needs `dest(weight)` formatting) is left for a separate follow-up to keep this PR small.

## Example

```
Adjacency list (4 vertices):
vertex 0: HEAD->1 ->3 ->NULL
vertex 1: HEAD->0 ->2 ->NULL
vertex 2: HEAD->1 ->3 ->NULL
vertex 3: HEAD->2 ->0 ->NULL
```

## Verification

- `make` clean under `-Wall -Wextra -Werror`.
- Drove `./dsa` through both the manual and CSV build paths and confirmed the adjacency list matches the entered edges (undirected, so each edge shows on both endpoints).
- `make test` — all suites pass.
- `make valgrind` — 0 errors / 0 leaks across all test binaries, and `valgrind ./dsa` on both visualize paths reports 0 leaks.
- `clang-format` clean on all changed files.
