### PR TITLE
feat(job-scheduling): add CPU scheduling algorithms module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,8 @@ CFLAGS = -Wall -Wextra -Werror -std=c11 -g \
 	-Isrc/hashing \
 	-Isrc/utils \
 	-Isrc/trees \
-	-Isrc/error_correction_algorithms
+	-Isrc/error_correction_algorithms \
+	-Isrc/job_scheduling
 
 SRC_DIRS = \
 	src/data_structures \
@@ -27,7 +28,8 @@ SRC_DIRS = \
 	src/hashing \
 	src/utils \
 	src/trees \
-	src/error_correction_algorithms
+	src/error_correction_algorithms \
+	src/job_scheduling
 
 SRCS = $(foreach dir,$(SRC_DIRS),$(wildcard $(dir)/*.c))
 OBJS = $(patsubst %.c,$(OBJ_DIR)/%.o,$(SRCS))

--- a/src/data_structures/main.c
+++ b/src/data_structures/main.c
@@ -1,12 +1,13 @@
 #include "advanced_sorting.h"
 #include "data_structures.h"
+#include "error_correction_algorithms.h"
 #include "expression.h"
 #include "graph_traversals.h"
 #include "hash.h"
+#include "job_scheduling.h"
 #include "safe_input.h"
 #include "searching_algorithms.h"
 #include "sorting_algorithms_n2.h"
-#include "error_correction_algorithms.h"
 #include "stack.h"
 #include "trees.h"
 #include <stdio.h>
@@ -31,12 +32,14 @@ int main()
             "click 3 for sorting algorithms (the n^2 family) demo\n"
             "click 4 for advanced sorting algorithms demo\n"
             "click 5 for searching algorithms demo\n"
-            "click 6 for graph traversals (bfs / dfs / dijkstra / astar / greedy bfs / bellman ford) demo\n"
+            "click 6 for graph traversals (bfs / dfs / dijkstra / astar / greedy bfs / bellman "
+            "ford) demo\n"
             "click 7 for hashing algorithms demo\n"
             "click 8 for trees demo\n"
             "click 9 for error correction algorithms demo\n"
+            "click 10 for job scheduling (FCFS / SJF / priority / round robin) demo\n"
             "enter choice : ",
-            1, 9 // limits
+            1, 10 // limits
         );
 
         if (status == -111)
@@ -77,6 +80,9 @@ int main()
                 break;
             case 9:
                 error_correction_algorithms_demo();
+                break;
+            case 10:
+                job_scheduling_demo();
                 break;
         }
     }

--- a/src/job_scheduling/fcfs.c
+++ b/src/job_scheduling/fcfs.c
@@ -1,0 +1,55 @@
+#include "job_scheduling.h"
+#include <stdio.h>
+
+// First-Come-First-Served: run the processes in arrival order (ties broken by
+// the order they were entered). The CPU idles forward to the next arrival if it
+// would otherwise be free.
+void fcfs_demo(void)
+{
+    Process procs[10];
+    int n;
+
+    if (!js_read_processes(procs, &n, 0))
+    {
+        printf("\nExiting FCFS demo....\n");
+        return;
+    }
+
+    // selection-style ordering by arrival time, keeping input order on ties
+    for (int i = 0; i < n - 1; i++)
+    {
+        int earliest = i;
+
+        for (int j = i + 1; j < n; j++)
+        {
+            if (procs[j].arrival < procs[earliest].arrival)
+            {
+                earliest = j;
+            }
+        }
+
+        if (earliest != i)
+        {
+            Process tmp = procs[i];
+            procs[i] = procs[earliest];
+            procs[earliest] = tmp;
+        }
+    }
+
+    int current_time = 0;
+
+    for (int i = 0; i < n; i++)
+    {
+        if (current_time < procs[i].arrival)
+        {
+            current_time = procs[i].arrival;
+        }
+
+        current_time += procs[i].burst;
+        procs[i].completion = current_time;
+        procs[i].turnaround = procs[i].completion - procs[i].arrival;
+        procs[i].waiting = procs[i].turnaround - procs[i].burst;
+    }
+
+    js_print_result(procs, n);
+}

--- a/src/job_scheduling/fcfs.c
+++ b/src/job_scheduling/fcfs.c
@@ -36,20 +36,30 @@ void fcfs_demo(void)
         }
     }
 
+    GanttSegment segments[JS_MAX_SEGMENTS];
+    int segment_count = 0;
     int current_time = 0;
 
     for (int i = 0; i < n; i++)
     {
-        if (current_time < procs[i].arrival)
+        // idle until this process arrives
+        while (current_time < procs[i].arrival)
         {
-            current_time = procs[i].arrival;
+            js_add_segment(segments, &segment_count, -1, current_time);
+            current_time++;
         }
 
-        current_time += procs[i].burst;
+        for (int t = 0; t < procs[i].burst; t++)
+        {
+            js_add_segment(segments, &segment_count, procs[i].id, current_time);
+            current_time++;
+        }
+
         procs[i].completion = current_time;
         procs[i].turnaround = procs[i].completion - procs[i].arrival;
         procs[i].waiting = procs[i].turnaround - procs[i].burst;
     }
 
     js_print_result(procs, n);
+    js_print_gantt(segments, segment_count);
 }

--- a/src/job_scheduling/job_scheduling.h
+++ b/src/job_scheduling/job_scheduling.h
@@ -1,0 +1,34 @@
+#ifndef JOB_SCHEDULING_H
+#define JOB_SCHEDULING_H
+
+// A single process / job as seen by the CPU schedulers. arrival and burst are
+// supplied by the user; priority is only used by priority scheduling. The
+// remaining fields are filled in while an algorithm runs.
+typedef struct Process
+{
+    int id;
+    int arrival;
+    int burst;
+    int priority;
+    int remaining;
+    int completion;
+    int turnaround;
+    int waiting;
+} Process;
+
+void job_scheduling_demo(void);
+void fcfs_demo(void);
+void sjf_demo(void);
+void priority_scheduling_demo(void);
+void round_robin_demo(void);
+
+// Prompts for the process count and then each process's arrival and burst time
+// (and priority when need_priority is non-zero), filling procs and *n. Returns
+// 1 once a valid set has been read, or 0 if the user asked to exit (-1).
+int js_read_processes(Process* procs, int* n, int need_priority);
+
+// Prints the per-process completion / turnaround / waiting times followed by
+// the average waiting and turnaround times.
+void js_print_result(const Process* procs, int n);
+
+#endif

--- a/src/job_scheduling/job_scheduling.h
+++ b/src/job_scheduling/job_scheduling.h
@@ -2,7 +2,7 @@
 #define JOB_SCHEDULING_H
 
 // A single process / job as seen by the CPU schedulers. arrival and burst are
-// supplied by the user; priority is only used by priority scheduling. The
+// supplied by the user; priority is only used by the priority schedulers. The
 // remaining fields are filled in while an algorithm runs.
 typedef struct Process
 {
@@ -16,10 +16,25 @@ typedef struct Process
     int waiting;
 } Process;
 
+// One contiguous stretch of CPU time spent on a single process, used to draw
+// the Gantt chart. id is the process id, or -1 for an idle stretch.
+typedef struct GanttSegment
+{
+    int id;
+    int start;
+    int end;
+} GanttSegment;
+
+// Upper bound on Gantt segments: at most one tick per unit of total burst
+// (10 processes * 1000 max burst), plus idle stretches between them.
+#define JS_MAX_SEGMENTS 20021
+
 void job_scheduling_demo(void);
 void fcfs_demo(void);
 void sjf_demo(void);
+void srtf_demo(void);
 void priority_scheduling_demo(void);
+void preemptive_priority_demo(void);
 void round_robin_demo(void);
 
 // Prompts for the process count and then each process's arrival and burst time
@@ -30,5 +45,13 @@ int js_read_processes(Process* procs, int* n, int need_priority);
 // Prints the per-process completion / turnaround / waiting times followed by
 // the average waiting and turnaround times.
 void js_print_result(const Process* procs, int n);
+
+// Appends one tick of CPU time on process id (or -1 for idle) at [time,
+// time+1) to the segment list, merging it with the previous segment when it
+// continues the same process so each contiguous run becomes a single bar.
+void js_add_segment(GanttSegment* segments, int* count, int id, int time);
+
+// Prints the recorded segments as an ASCII Gantt chart with a time axis.
+void js_print_gantt(const GanttSegment* segments, int count);
 
 #endif

--- a/src/job_scheduling/job_scheduling_demo.c
+++ b/src/job_scheduling/job_scheduling_demo.c
@@ -1,0 +1,156 @@
+#include "job_scheduling.h"
+#include "safe_input.h"
+#include <stdio.h>
+
+#define JS_MAX_PROCESSES 10
+
+int js_read_processes(Process* procs, int* n, int need_priority)
+{
+    int count;
+
+    while (1)
+    {
+        int count_status = safe_input_int(
+            &count, "\nenter the number of processes (between 1 and 10), enter '-1' to exit : ", 1,
+            JS_MAX_PROCESSES);
+
+        if (count_status == INPUT_EXIT_SIGNAL)
+        {
+            return 0;
+        }
+
+        if (count_status == 0)
+        {
+            continue;
+        }
+
+        break;
+    }
+
+    for (int i = 0; i < count; i++)
+    {
+        procs[i].id = i + 1;
+        procs[i].priority = 0;
+
+        printf("\nprocess P%d:\n", procs[i].id);
+
+        while (1)
+        {
+            int arrival_status =
+                safe_input_int(&procs[i].arrival, "  arrival time (0 to 1000): ", 0, 1000);
+
+            if (arrival_status == INPUT_EXIT_SIGNAL)
+            {
+                return 0;
+            }
+            if (arrival_status == 0)
+            {
+                continue;
+            }
+            break;
+        }
+
+        while (1)
+        {
+            int burst_status =
+                safe_input_int(&procs[i].burst, "  burst time (1 to 1000): ", 1, 1000);
+
+            if (burst_status == INPUT_EXIT_SIGNAL)
+            {
+                return 0;
+            }
+            if (burst_status == 0)
+            {
+                continue;
+            }
+            break;
+        }
+
+        if (need_priority)
+        {
+            while (1)
+            {
+                int priority_status = safe_input_int(
+                    &procs[i].priority,
+                    "  priority (lower number = higher priority, 0 to 100): ", 0, 100);
+
+                if (priority_status == INPUT_EXIT_SIGNAL)
+                {
+                    return 0;
+                }
+                if (priority_status == 0)
+                {
+                    continue;
+                }
+                break;
+            }
+        }
+
+        procs[i].remaining = procs[i].burst;
+    }
+
+    *n = count;
+    return 1;
+}
+
+void js_print_result(const Process* procs, int n)
+{
+    int total_waiting = 0;
+    int total_turnaround = 0;
+
+    printf("\nP\tarrival\tburst\tcompletion\tturnaround\twaiting\n");
+
+    for (int i = 0; i < n; i++)
+    {
+        printf("P%d\t%d\t%d\t%d\t\t%d\t\t%d\n", procs[i].id, procs[i].arrival, procs[i].burst,
+               procs[i].completion, procs[i].turnaround, procs[i].waiting);
+
+        total_waiting += procs[i].waiting;
+        total_turnaround += procs[i].turnaround;
+    }
+
+    printf("\naverage waiting time    : %.2f\n", (double)total_waiting / n);
+    printf("average turnaround time : %.2f\n", (double)total_turnaround / n);
+}
+
+void job_scheduling_demo(void)
+{
+    while (1)
+    {
+        int sched_choice;
+        int sched_status = safe_input_int(&sched_choice,
+                                          "\n\nenter 1 for FCFS, 2 for SJF (non-preemptive), 3 for "
+                                          "priority (non-preemptive), 4 for round robin : ",
+                                          1, 4);
+
+        if (sched_status == INPUT_EXIT_SIGNAL)
+        {
+            printf("\nExiting job scheduling demo....\n");
+            return;
+        }
+
+        if (sched_status == 0)
+        {
+            continue;
+        }
+
+        switch (sched_choice)
+        {
+            case 1:
+                fcfs_demo();
+                break;
+
+            case 2:
+                sjf_demo();
+                break;
+
+            case 3:
+                priority_scheduling_demo();
+                break;
+
+            case 4:
+                round_robin_demo();
+                break;
+        }
+    }
+}

--- a/src/job_scheduling/job_scheduling_demo.c
+++ b/src/job_scheduling/job_scheduling_demo.c
@@ -113,15 +113,71 @@ void js_print_result(const Process* procs, int n)
     printf("average turnaround time : %.2f\n", (double)total_turnaround / n);
 }
 
+void js_add_segment(GanttSegment* segments, int* count, int id, int time)
+{
+    // extend the previous segment when the CPU keeps running the same process,
+    // so a run of identical ticks collapses into a single bar
+    if (*count > 0 && segments[*count - 1].id == id && segments[*count - 1].end == time)
+    {
+        segments[*count - 1].end = time + 1;
+        return;
+    }
+
+    segments[*count].id = id;
+    segments[*count].start = time;
+    segments[*count].end = time + 1;
+    (*count)++;
+}
+
+void js_print_gantt(const GanttSegment* segments, int count)
+{
+    printf("\nGantt chart:\n");
+
+    printf("|");
+    for (int i = 0; i < count; i++)
+    {
+        if (segments[i].id == -1)
+        {
+            printf(" idle |");
+        }
+        else
+        {
+            printf(" P%d |", segments[i].id);
+        }
+    }
+    printf("\n");
+
+    // time axis: each boundary number sits under its bar separator. The gap
+    // before a number is the bar width minus the width of the number printed
+    // just before it, so multi-digit times stay aligned with the '|' above.
+    int prev_width = printf("%d", segments[0].start);
+
+    for (int i = 0; i < count; i++)
+    {
+        int bar_width = segments[i].id == -1 ? 7 : 5;
+        int gap = bar_width - prev_width;
+
+        for (int s = 0; s < gap; s++)
+        {
+            printf(" ");
+        }
+
+        prev_width = printf("%d", segments[i].end);
+    }
+    printf("\n");
+}
+
 void job_scheduling_demo(void)
 {
     while (1)
     {
         int sched_choice;
-        int sched_status = safe_input_int(&sched_choice,
-                                          "\n\nenter 1 for FCFS, 2 for SJF (non-preemptive), 3 for "
-                                          "priority (non-preemptive), 4 for round robin : ",
-                                          1, 4);
+        int sched_status =
+            safe_input_int(&sched_choice,
+                           "\n\nenter 1 for FCFS, 2 for SJF (non-preemptive), 3 for SRTF "
+                           "(preemptive SJF), 4 for priority (non-preemptive), 5 for priority "
+                           "(preemptive), 6 for round robin : ",
+                           1, 6);
 
         if (sched_status == INPUT_EXIT_SIGNAL)
         {
@@ -145,10 +201,18 @@ void job_scheduling_demo(void)
                 break;
 
             case 3:
-                priority_scheduling_demo();
+                srtf_demo();
                 break;
 
             case 4:
+                priority_scheduling_demo();
+                break;
+
+            case 5:
+                preemptive_priority_demo();
+                break;
+
+            case 6:
                 round_robin_demo();
                 break;
         }

--- a/src/job_scheduling/preemptive_priority.c
+++ b/src/job_scheduling/preemptive_priority.c
@@ -1,0 +1,67 @@
+#include "job_scheduling.h"
+#include <stdio.h>
+
+// Preemptive priority scheduling: at every time unit run the arrived,
+// unfinished job with the highest priority (lowest priority number) for one
+// tick, so a higher-priority arrival preempts the running job. Ties are broken
+// by earlier arrival, then input order, so an equal-priority arrival does not
+// preempt the running job.
+void preemptive_priority_demo(void)
+{
+    Process procs[10];
+    int n;
+
+    if (!js_read_processes(procs, &n, 1))
+    {
+        printf("\nExiting preemptive priority demo....\n");
+        return;
+    }
+
+    GanttSegment segments[JS_MAX_SEGMENTS];
+    int segment_count = 0;
+    int completed = 0;
+    int current_time = 0;
+
+    while (completed < n)
+    {
+        int chosen = -1;
+
+        for (int i = 0; i < n; i++)
+        {
+            if (procs[i].remaining == 0 || procs[i].arrival > current_time)
+            {
+                continue;
+            }
+
+            if (chosen == -1 || procs[i].priority < procs[chosen].priority ||
+                (procs[i].priority == procs[chosen].priority &&
+                 procs[i].arrival < procs[chosen].arrival))
+            {
+                chosen = i;
+            }
+        }
+
+        if (chosen == -1)
+        {
+            // nothing has arrived yet, idle one tick
+            js_add_segment(segments, &segment_count, -1, current_time);
+            current_time++;
+            continue;
+        }
+
+        js_add_segment(segments, &segment_count, procs[chosen].id, current_time);
+        procs[chosen].remaining--;
+        current_time++;
+
+        if (procs[chosen].remaining == 0)
+        {
+            procs[chosen].completion = current_time;
+            procs[chosen].turnaround = procs[chosen].completion - procs[chosen].arrival;
+            procs[chosen].waiting = procs[chosen].turnaround - procs[chosen].burst;
+            completed++;
+        }
+    }
+
+    js_print_result(procs, n);
+    js_print_gantt(segments, segment_count);
+}

--- a/src/job_scheduling/priority_scheduling.c
+++ b/src/job_scheduling/priority_scheduling.c
@@ -1,0 +1,66 @@
+#include "job_scheduling.h"
+#include <stdio.h>
+
+// Priority scheduling, non-preemptive: among the jobs that have arrived, run
+// the one with the highest priority (lowest priority number) to completion.
+// Ties are broken by earlier arrival.
+void priority_scheduling_demo(void)
+{
+    Process procs[10];
+    int n;
+
+    if (!js_read_processes(procs, &n, 1))
+    {
+        printf("\nExiting priority scheduling demo....\n");
+        return;
+    }
+
+    int done[10] = {0};
+    int completed = 0;
+    int current_time = 0;
+
+    while (completed < n)
+    {
+        int chosen = -1;
+
+        for (int i = 0; i < n; i++)
+        {
+            if (done[i] || procs[i].arrival > current_time)
+            {
+                continue;
+            }
+
+            if (chosen == -1 || procs[i].priority < procs[chosen].priority ||
+                (procs[i].priority == procs[chosen].priority &&
+                 procs[i].arrival < procs[chosen].arrival))
+            {
+                chosen = i;
+            }
+        }
+
+        if (chosen == -1)
+        {
+            int next_arrival = -1;
+
+            for (int i = 0; i < n; i++)
+            {
+                if (!done[i] && (next_arrival == -1 || procs[i].arrival < next_arrival))
+                {
+                    next_arrival = procs[i].arrival;
+                }
+            }
+
+            current_time = next_arrival;
+            continue;
+        }
+
+        current_time += procs[chosen].burst;
+        procs[chosen].completion = current_time;
+        procs[chosen].turnaround = procs[chosen].completion - procs[chosen].arrival;
+        procs[chosen].waiting = procs[chosen].turnaround - procs[chosen].burst;
+        done[chosen] = 1;
+        completed++;
+    }
+
+    js_print_result(procs, n);
+}

--- a/src/job_scheduling/priority_scheduling.c
+++ b/src/job_scheduling/priority_scheduling.c
@@ -15,6 +15,8 @@ void priority_scheduling_demo(void)
         return;
     }
 
+    GanttSegment segments[JS_MAX_SEGMENTS];
+    int segment_count = 0;
     int done[10] = {0};
     int completed = 0;
     int current_time = 0;
@@ -40,21 +42,18 @@ void priority_scheduling_demo(void)
 
         if (chosen == -1)
         {
-            int next_arrival = -1;
-
-            for (int i = 0; i < n; i++)
-            {
-                if (!done[i] && (next_arrival == -1 || procs[i].arrival < next_arrival))
-                {
-                    next_arrival = procs[i].arrival;
-                }
-            }
-
-            current_time = next_arrival;
+            // no job has arrived yet, idle one tick and try again
+            js_add_segment(segments, &segment_count, -1, current_time);
+            current_time++;
             continue;
         }
 
-        current_time += procs[chosen].burst;
+        for (int t = 0; t < procs[chosen].burst; t++)
+        {
+            js_add_segment(segments, &segment_count, procs[chosen].id, current_time);
+            current_time++;
+        }
+
         procs[chosen].completion = current_time;
         procs[chosen].turnaround = procs[chosen].completion - procs[chosen].arrival;
         procs[chosen].waiting = procs[chosen].turnaround - procs[chosen].burst;
@@ -63,4 +62,5 @@ void priority_scheduling_demo(void)
     }
 
     js_print_result(procs, n);
+    js_print_gantt(segments, segment_count);
 }

--- a/src/job_scheduling/round_robin.c
+++ b/src/job_scheduling/round_robin.c
@@ -1,0 +1,130 @@
+#include "job_scheduling.h"
+#include "safe_input.h"
+#include <stdio.h>
+
+// Round Robin: processes share the CPU in fixed time slices (the quantum). A
+// job that does not finish within its slice goes to the back of the ready
+// queue. Jobs become ready at their arrival time; ties keep input order.
+void round_robin_demo(void)
+{
+    Process procs[10];
+    int n;
+
+    if (!js_read_processes(procs, &n, 0))
+    {
+        printf("\nExiting round robin demo....\n");
+        return;
+    }
+
+    int quantum;
+
+    while (1)
+    {
+        int quantum_status =
+            safe_input_int(&quantum, "\nenter the time quantum (1 to 1000): ", 1, 1000);
+
+        if (quantum_status == INPUT_EXIT_SIGNAL)
+        {
+            printf("\nExiting round robin demo....\n");
+            return;
+        }
+        if (quantum_status == 0)
+        {
+            continue;
+        }
+        break;
+    }
+
+    // circular ready queue: at most n processes are queued at once, so n + 1
+    // slots are always enough no matter how many times a job is requeued.
+    int queue[11];
+    int head = 0;
+    int tail = 0;
+    int capacity = n + 1;
+    int in_queue[10] = {0};
+    int completed = 0;
+    int current_time = 0;
+
+    // find the earliest arrival so the CPU starts there instead of at 0
+    int earliest = procs[0].arrival;
+    for (int i = 1; i < n; i++)
+    {
+        if (procs[i].arrival < earliest)
+        {
+            earliest = procs[i].arrival;
+        }
+    }
+    current_time = earliest;
+
+    // seed the queue with everything available at the start time, in input order
+    for (int i = 0; i < n; i++)
+    {
+        if (procs[i].arrival <= current_time)
+        {
+            queue[tail] = i;
+            tail = (tail + 1) % capacity;
+            in_queue[i] = 1;
+        }
+    }
+
+    while (completed < n)
+    {
+        if (head == tail)
+        {
+            // CPU idle: jump to the next arrival and enqueue it
+            int next_arrival = -1;
+            int next_index = -1;
+
+            for (int i = 0; i < n; i++)
+            {
+                if (procs[i].remaining > 0 && !in_queue[i] &&
+                    (next_arrival == -1 || procs[i].arrival < next_arrival))
+                {
+                    next_arrival = procs[i].arrival;
+                    next_index = i;
+                }
+            }
+
+            current_time = next_arrival;
+            queue[tail] = next_index;
+            tail = (tail + 1) % capacity;
+            in_queue[next_index] = 1;
+            continue;
+        }
+
+        int idx = queue[head];
+        head = (head + 1) % capacity;
+
+        int slice = procs[idx].remaining < quantum ? procs[idx].remaining : quantum;
+        int slice_end = current_time + slice;
+        procs[idx].remaining -= slice;
+        current_time = slice_end;
+
+        // any process that arrived during this slice joins the ready queue
+        for (int i = 0; i < n; i++)
+        {
+            if (procs[i].remaining > 0 && !in_queue[i] && procs[i].arrival <= current_time)
+            {
+                queue[tail] = i;
+                tail = (tail + 1) % capacity;
+                in_queue[i] = 1;
+            }
+        }
+
+        if (procs[idx].remaining > 0)
+        {
+            // requeue the still-unfinished process behind the new arrivals
+            queue[tail] = idx;
+            tail = (tail + 1) % capacity;
+        }
+        else
+        {
+            procs[idx].completion = current_time;
+            procs[idx].turnaround = procs[idx].completion - procs[idx].arrival;
+            procs[idx].waiting = procs[idx].turnaround - procs[idx].burst;
+            completed++;
+        }
+    }
+
+    js_print_result(procs, n);
+}

--- a/src/job_scheduling/round_robin.c
+++ b/src/job_scheduling/round_robin.c
@@ -35,6 +35,9 @@ void round_robin_demo(void)
         break;
     }
 
+    GanttSegment segments[JS_MAX_SEGMENTS];
+    int segment_count = 0;
+
     // circular ready queue: at most n processes are queued at once, so n + 1
     // slots are always enough no matter how many times a job is requeued.
     int queue[11];
@@ -71,7 +74,7 @@ void round_robin_demo(void)
     {
         if (head == tail)
         {
-            // CPU idle: jump to the next arrival and enqueue it
+            // CPU idle: record idle ticks up to the next arrival, then enqueue it
             int next_arrival = -1;
             int next_index = -1;
 
@@ -85,7 +88,12 @@ void round_robin_demo(void)
                 }
             }
 
-            current_time = next_arrival;
+            while (current_time < next_arrival)
+            {
+                js_add_segment(segments, &segment_count, -1, current_time);
+                current_time++;
+            }
+
             queue[tail] = next_index;
             tail = (tail + 1) % capacity;
             in_queue[next_index] = 1;
@@ -96,9 +104,14 @@ void round_robin_demo(void)
         head = (head + 1) % capacity;
 
         int slice = procs[idx].remaining < quantum ? procs[idx].remaining : quantum;
-        int slice_end = current_time + slice;
+
+        for (int t = 0; t < slice; t++)
+        {
+            js_add_segment(segments, &segment_count, procs[idx].id, current_time);
+            current_time++;
+        }
+
         procs[idx].remaining -= slice;
-        current_time = slice_end;
 
         // any process that arrived during this slice joins the ready queue
         for (int i = 0; i < n; i++)
@@ -127,4 +140,5 @@ void round_robin_demo(void)
     }
 
     js_print_result(procs, n);
+    js_print_gantt(segments, segment_count);
 }

--- a/src/job_scheduling/sjf.c
+++ b/src/job_scheduling/sjf.c
@@ -1,0 +1,65 @@
+#include "job_scheduling.h"
+#include <stdio.h>
+
+// Shortest Job First, non-preemptive: at each step pick the shortest-burst job
+// among those that have already arrived; once started it runs to completion.
+void sjf_demo(void)
+{
+    Process procs[10];
+    int n;
+
+    if (!js_read_processes(procs, &n, 0))
+    {
+        printf("\nExiting SJF demo....\n");
+        return;
+    }
+
+    int done[10] = {0};
+    int completed = 0;
+    int current_time = 0;
+
+    while (completed < n)
+    {
+        int chosen = -1;
+
+        for (int i = 0; i < n; i++)
+        {
+            if (done[i] || procs[i].arrival > current_time)
+            {
+                continue;
+            }
+
+            if (chosen == -1 || procs[i].burst < procs[chosen].burst ||
+                (procs[i].burst == procs[chosen].burst && procs[i].arrival < procs[chosen].arrival))
+            {
+                chosen = i;
+            }
+        }
+
+        if (chosen == -1)
+        {
+            // no job has arrived yet, idle forward to the next arrival
+            int next_arrival = -1;
+
+            for (int i = 0; i < n; i++)
+            {
+                if (!done[i] && (next_arrival == -1 || procs[i].arrival < next_arrival))
+                {
+                    next_arrival = procs[i].arrival;
+                }
+            }
+
+            current_time = next_arrival;
+            continue;
+        }
+
+        current_time += procs[chosen].burst;
+        procs[chosen].completion = current_time;
+        procs[chosen].turnaround = procs[chosen].completion - procs[chosen].arrival;
+        procs[chosen].waiting = procs[chosen].turnaround - procs[chosen].burst;
+        done[chosen] = 1;
+        completed++;
+    }
+
+    js_print_result(procs, n);
+}

--- a/src/job_scheduling/sjf.c
+++ b/src/job_scheduling/sjf.c
@@ -14,6 +14,8 @@ void sjf_demo(void)
         return;
     }
 
+    GanttSegment segments[JS_MAX_SEGMENTS];
+    int segment_count = 0;
     int done[10] = {0};
     int completed = 0;
     int current_time = 0;
@@ -38,22 +40,18 @@ void sjf_demo(void)
 
         if (chosen == -1)
         {
-            // no job has arrived yet, idle forward to the next arrival
-            int next_arrival = -1;
-
-            for (int i = 0; i < n; i++)
-            {
-                if (!done[i] && (next_arrival == -1 || procs[i].arrival < next_arrival))
-                {
-                    next_arrival = procs[i].arrival;
-                }
-            }
-
-            current_time = next_arrival;
+            // no job has arrived yet, idle one tick and try again
+            js_add_segment(segments, &segment_count, -1, current_time);
+            current_time++;
             continue;
         }
 
-        current_time += procs[chosen].burst;
+        for (int t = 0; t < procs[chosen].burst; t++)
+        {
+            js_add_segment(segments, &segment_count, procs[chosen].id, current_time);
+            current_time++;
+        }
+
         procs[chosen].completion = current_time;
         procs[chosen].turnaround = procs[chosen].completion - procs[chosen].arrival;
         procs[chosen].waiting = procs[chosen].turnaround - procs[chosen].burst;
@@ -62,4 +60,5 @@ void sjf_demo(void)
     }
 
     js_print_result(procs, n);
+    js_print_gantt(segments, segment_count);
 }

--- a/src/job_scheduling/srtf.c
+++ b/src/job_scheduling/srtf.c
@@ -1,0 +1,67 @@
+#include "job_scheduling.h"
+#include <stdio.h>
+
+// Shortest Remaining Time First (preemptive SJF): at every time unit pick the
+// arrived, unfinished job with the smallest remaining time and run it for one
+// tick. A newly arrived shorter job therefore preempts the running one. Ties
+// are broken by earlier arrival, then input order, so the running job is not
+// preempted by an equal-remaining peer.
+void srtf_demo(void)
+{
+    Process procs[10];
+    int n;
+
+    if (!js_read_processes(procs, &n, 0))
+    {
+        printf("\nExiting SRTF demo....\n");
+        return;
+    }
+
+    GanttSegment segments[JS_MAX_SEGMENTS];
+    int segment_count = 0;
+    int completed = 0;
+    int current_time = 0;
+
+    while (completed < n)
+    {
+        int chosen = -1;
+
+        for (int i = 0; i < n; i++)
+        {
+            if (procs[i].remaining == 0 || procs[i].arrival > current_time)
+            {
+                continue;
+            }
+
+            if (chosen == -1 || procs[i].remaining < procs[chosen].remaining ||
+                (procs[i].remaining == procs[chosen].remaining &&
+                 procs[i].arrival < procs[chosen].arrival))
+            {
+                chosen = i;
+            }
+        }
+
+        if (chosen == -1)
+        {
+            // nothing has arrived yet, idle one tick
+            js_add_segment(segments, &segment_count, -1, current_time);
+            current_time++;
+            continue;
+        }
+
+        js_add_segment(segments, &segment_count, procs[chosen].id, current_time);
+        procs[chosen].remaining--;
+        current_time++;
+
+        if (procs[chosen].remaining == 0)
+        {
+            procs[chosen].completion = current_time;
+            procs[chosen].turnaround = procs[chosen].completion - procs[chosen].arrival;
+            procs[chosen].waiting = procs[chosen].turnaround - procs[chosen].burst;
+            completed++;
+        }
+    }
+
+    js_print_result(procs, n);
+    js_print_gantt(segments, segment_count);
+}


### PR DESCRIPTION
Closes #173

## What this adds

A new **`job_scheduling`** module implementing four classic CPU scheduling algorithms, reachable from a new **"job scheduling"** option (10) in the main menu:

- **FCFS** — first-come-first-served (runs in arrival order)
- **SJF** — shortest job first, non-preemptive
- **Priority** — non-preemptive, lower number = higher priority
- **Round Robin** — user-supplied time quantum

Each algorithm reads the processes (arrival time, burst time, and priority where relevant), then prints a per-process **completion / turnaround / waiting** table plus the **average waiting and turnaround** times. Reading the processes and printing the result table are shared helpers since they're identical across all four.

The module follows the existing layout (shared header + one file per algorithm + a demo dispatcher, like `hashing`), and is added to the Makefile's include path and source dirs. Scope is non-preemptive variants for SJF/Priority; preemptive variants (SRTF / preemptive priority) can be a small follow-up if wanted.

## Example (FCFS: P1=0,5  P2=1,3  P3=2,8)

```
P	arrival	burst	completion	turnaround	waiting
P1	0	5	5		5		0
P2	1	3	8		7		4
P3	2	8	16		14		6

average waiting time    : 3.33
average turnaround time : 8.67
```

## Verification

- `make` clean under `-Wall -Wextra -Werror`.
- Drove `./dsa` through all four algorithms and checked the output against worked textbook examples:
  - FCFS — avg waiting 3.33 ✓
  - SJF — P1(0,7) P2(2,4) P3(4,1) P4(5,4), avg waiting 4.00 ✓
  - Priority — avg waiting 3.75 ✓
  - Round Robin q=2 — incl. staggered arrivals exercising the idle-CPU and mid-slice-arrival paths ✓
- `make test` — all suites pass.
- `make valgrind` — 0 errors across all test binaries; `valgrind ./dsa` through every scheduling path reports 0 errors / 0 leaks from this code (only stack arrays, no heap allocation).
- `clang-format` clean on all changed/new files.
