### PR TITLE
fix(readme): render Hashing Algorithms bullet list correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,10 +134,10 @@ Both BFS and DFS are implemented **iteratively** (no recursion).
 
 
 #### Hashing Algorithms
--Linear Probing (with built-in linear search for demo)
--Separate Chaining
--Double Hashing
--Quadratic Probing
+- Linear Probing (with built-in linear search for demo)
+- Separate Chaining
+- Double Hashing
+- Quadratic Probing
 
 Linear Probing uses modulo arithmetic to wrap-around the hash table/array when last index is full, optimizing resources and using the full array. 
 


### PR DESCRIPTION
### Summary

The **Hashing Algorithms** items under *Project Overview* were written as `-Linear Probing` (no space after the hyphen), so Markdown rendered them as a single run of plain text instead of a bullet list. This adds the missing space after the hyphen on all four entries so they render as a proper list, consistent with the other algorithm sections.

### Changes
- `README.md`: fix the four Hashing Algorithms bullets so they render as a list.

Documentation-only; no functional changes.
