### PR TITLE
feat(error-correction): add checksum (sender) algorithm

### DIFF
--- a/src/error_correction_algorithms/checksum.c
+++ b/src/error_correction_algorithms/checksum.c
@@ -1,0 +1,154 @@
+#include "error_correction_algorithms.h"
+#include "safe_input.h"
+#include <stdio.h>
+#include <string.h>
+
+// longest binary string accepted from the user (plus room for the '\0'). a checksum
+// demo never needs more than a few hundred bits, so a fixed buffer keeps things simple.
+#define CHECKSUM_MAX_BITS 1024
+
+// prints the low `bits` bits of value, most-significant bit first. local helper used
+// only for displaying k-bit words/checksums in this demo.
+static void print_binary(int value, int bits)
+{
+    for (int i = bits - 1; i >= 0; i--)
+    {
+        printf("%d", (value >> i) & 1);
+    }
+}
+
+// reads a line of binary data ('0'/'1' only) into buff. mirrors the string-input
+// convention used by the expression module (validate_infix_expr): returns 1 on a
+// valid non-empty binary string, 0 on EOF / invalid input (caller should re-prompt),
+// and INPUT_EXIT_SIGNAL when the user types 'X' to leave the demo.
+static int read_binary_string(char* buff, size_t size, const char* prompt)
+{
+    if (prompt)
+    {
+        printf("%s", prompt);
+        fflush(stdout);
+    }
+    if (!fgets(buff, size, stdin))
+    { // EOF or read error
+        clearerr(stdin);
+        printf("\ninput ended unexpectedly");
+        return 0;
+    }
+    buff[strcspn(buff, "\n")] = '\0';
+
+    if (buff[0] == 'X' && buff[1] == '\0')
+    { // user asked to leave the demo
+        return INPUT_EXIT_SIGNAL;
+    }
+    if (buff[0] == '\0')
+    {
+        printf("\ninvalid: empty input. enter a binary string like 1101001111\n");
+        return 0;
+    }
+
+    for (size_t i = 0; buff[i] != '\0'; i++)
+    {
+        if (buff[i] != '0' && buff[i] != '1')
+        {
+            printf("\ninvalid character: %c\nonly binary digits 0 and 1 are allowed.\n", buff[i]);
+            return 0;
+        }
+    }
+    return 1;
+}
+
+// checksum (sender side): the data is split into k-bit blocks and summed using
+// one's-complement (end-around carry) addition; the checksum is the one's complement
+// of that running sum. this is the value the sender appends to the data before
+// transmitting it. the receiver-side verification is a separate follow-up.
+void checksum_demo(void)
+{
+    while (1)
+    {
+        int k;
+        int k_status =
+            safe_input_int(&k,
+                           "\n\nchecksum (sender side)\nenter the block size k in bits (1 to 16), "
+                           "or -1 to exit:- ",
+                           1, 16);
+
+        if (k_status == INPUT_EXIT_SIGNAL)
+        {
+            printf("\nExiting checksum demo....");
+            return;
+        }
+        if (k_status == 0)
+        {
+            continue;
+        }
+
+        char data[CHECKSUM_MAX_BITS + 1];
+        int data_status = read_binary_string(
+            data, sizeof(data), "enter the binary data (digits 0/1 only), or 'X' to exit:- ");
+
+        if (data_status == INPUT_EXIT_SIGNAL)
+        {
+            printf("\nExiting checksum demo....");
+            return;
+        }
+        if (data_status == 0)
+        {
+            continue;
+        }
+
+        int len = (int)strlen(data);
+
+        // pad the length up to a whole number of k-bit blocks; the missing low-order
+        // bits of the last block are treated as 0 (we never write them into `data`).
+        int padded_len = len;
+        while (padded_len % k != 0)
+        {
+            padded_len++;
+        }
+
+        int mask = (1 << k) - 1; // keeps only the low k bits
+        int sum = 0;
+
+        printf("\ndata length = %d bit(s), block size k = %d, padded to %d bit(s) (%d block(s))\n",
+               len, k, padded_len, padded_len / k);
+
+        // process one k-bit block at a time
+        for (int i = 0; i < padded_len; i += k)
+        {
+            int word = 0;
+
+            // assemble the current block, padding with 0 once we pass the real data
+            for (int j = 0; j < k; j++)
+            {
+                word <<= 1;
+                if (i + j < len)
+                {
+                    word |= (data[i + j] - '0');
+                }
+            }
+
+            sum += word;
+
+            // one's-complement (end-around carry) fold: wrap any overflow above k bits
+            // back into the low k bits, e.g. for k=3: 111 + 001 = 1000 -> 000 + 1 = 001
+            while (sum > mask)
+            {
+                sum = (sum & mask) + (sum >> k);
+            }
+
+            printf("block %d: ", (i / k) + 1);
+            print_binary(word, k);
+            printf("  (value %d)  running sum = ", word);
+            print_binary(sum, k);
+            printf("\n");
+        }
+
+        int checksum = (~sum) & mask; // one's complement of the final sum, kept to k bits
+
+        printf("\nfinal sum       = ");
+        print_binary(sum, k);
+        printf("\nchecksum (~sum) = ");
+        print_binary(checksum, k);
+        printf("\n\nthe sender appends this checksum to the data before transmission.\n");
+    }
+}

--- a/src/error_correction_algorithms/error_correction_algorithms.h
+++ b/src/error_correction_algorithms/error_correction_algorithms.h
@@ -2,5 +2,6 @@
 #define ERROR_CORRECTION_ALGORITHMS_H
 
 void error_correction_algorithms_demo(void);
+void checksum_demo(void);
 
 #endif

--- a/src/error_correction_algorithms/error_correction_algorithms_demo.c
+++ b/src/error_correction_algorithms/error_correction_algorithms_demo.c
@@ -1,6 +1,6 @@
-#include <stdio.h>
-#include <error_correction_algorithms.h>
 #include "safe_input.h"
+#include <error_correction_algorithms.h>
+#include <stdio.h>
 
 /*New functions come here*/
 
@@ -10,21 +10,26 @@ void error_correction_algorithms_demo(void)
     {
         int ECA_choice;
         /*Change the prompt and the range accordingly when new functions get added*/
-        int ECA_status = safe_input_int(&ECA_choice, "\nAlgorithms yet to be added. Enter -1 to exit: ",0 , 0);
+        int ECA_status =
+            safe_input_int(&ECA_choice, "\nEnter 1 for checksum. Enter -1 to exit: ", 1, 1);
 
-        if(ECA_status == INPUT_EXIT_SIGNAL)
+        if (ECA_status == INPUT_EXIT_SIGNAL)
         {
             printf("Exiting Error Correction Algorithm Demo....");
             return;
         }
 
-        if(ECA_status == 0)
+        if (ECA_status == 0)
             continue;
-        
-        switch(ECA_choice)
+
+        switch (ECA_choice)
         {
 
-            /*Newly implemented functions will be called here*/
+                /*Newly implemented functions will be called here*/
+
+            case 1:
+                checksum_demo();
+                break;
 
             default:
                 printf("Wrong choice entered");


### PR DESCRIPTION
Closes #168

### Summary
Adds the **checksum** algorithm (sender side) as the first algorithm in the `error_correction_algorithms` module. The binary data is split into k-bit blocks and accumulated using one's-complement (end-around carry) addition; the checksum is the one's complement of the final sum — the value the sender appends to the data before transmission.

### What's included
- `src/error_correction_algorithms/checksum.c` — `checksum_demo()` with step-by-step output (per-block value, running sum, final sum, checksum), plus two local helpers: a binary-string reader (accepts `0`/`1` only, `X` to exit; mirrors the expression module's `validate_infix_expr` input convention) and a k-bit binary printer.
- Declared `checksum_demo()` in `error_correction_algorithms.h`.
- Wired into the module dispatcher (`error_correction_algorithms_demo.c`) as option 1.

No Makefile change needed — the module is already listed and the build auto-globs new `.c` files.

### Verification
- Issue's example `1101001111`, k=3 → checksum `000`.
- Forouzan 8-bit example `10011001 11100010 00100100 10000100` → checksum `11011010`.
- Edge cases handled: invalid characters, empty input, end-around carry wrap, `X`-exit.
- `make` clean with `-Werror`; `make test` passes; `make valgrind` reports 0 errors / no leaks; clang-format clean.

### Follow-up
Receiver-side verification (re-sum data + checksum, report error vs. no-error) will follow as a separate PR.
