### PR TITLE
feat(error-correction): add checksum receiver-side verification

### DIFF
--- a/src/error_correction_algorithms/checksum.c
+++ b/src/error_correction_algorithms/checksum.c
@@ -1,0 +1,154 @@
+#include "error_correction_algorithms.h"
+#include "safe_input.h"
+#include <stdio.h>
+#include <string.h>
+
+// longest binary string accepted from the user (plus room for the '\0'). a checksum
+// demo never needs more than a few hundred bits, so a fixed buffer keeps things simple.
+#define CHECKSUM_MAX_BITS 1024
+
+// prints the low `bits` bits of value, most-significant bit first. local helper used
+// only for displaying k-bit words/checksums in this demo.
+static void print_binary(int value, int bits)
+{
+    for (int i = bits - 1; i >= 0; i--)
+    {
+        printf("%d", (value >> i) & 1);
+    }
+}
+
+// reads a line of binary data ('0'/'1' only) into buff. mirrors the string-input
+// convention used by the expression module (validate_infix_expr): returns 1 on a
+// valid non-empty binary string, 0 on EOF / invalid input (caller should re-prompt),
+// and INPUT_EXIT_SIGNAL when the user types 'X' to leave the demo.
+static int read_binary_string(char* buff, size_t size, const char* prompt)
+{
+    if (prompt)
+    {
+        printf("%s", prompt);
+        fflush(stdout);
+    }
+    if (!fgets(buff, size, stdin))
+    { // EOF or read error
+        clearerr(stdin);
+        printf("\ninput ended unexpectedly");
+        return 0;
+    }
+    buff[strcspn(buff, "\n")] = '\0';
+
+    if (buff[0] == 'X' && buff[1] == '\0')
+    { // user asked to leave the demo
+        return INPUT_EXIT_SIGNAL;
+    }
+    if (buff[0] == '\0')
+    {
+        printf("\ninvalid: empty input. enter a binary string like 1101001111\n");
+        return 0;
+    }
+
+    for (size_t i = 0; buff[i] != '\0'; i++)
+    {
+        if (buff[i] != '0' && buff[i] != '1')
+        {
+            printf("\ninvalid character: %c\nonly binary digits 0 and 1 are allowed.\n", buff[i]);
+            return 0;
+        }
+    }
+    return 1;
+}
+
+// checksum (sender side): the data is split into k-bit blocks and summed using
+// one's-complement (end-around carry) addition; the checksum is the one's complement
+// of that running sum. this is the value the sender appends to the data before
+// transmitting it. the receiver-side verification is a separate follow-up.
+void checksum_demo(void)
+{
+    while (1)
+    {
+        int k;
+        int k_status =
+            safe_input_int(&k,
+                           "\n\nchecksum (sender side)\nenter the block size k in bits (1 to 16), "
+                           "or -1 to exit:- ",
+                           1, 16);
+
+        if (k_status == INPUT_EXIT_SIGNAL)
+        {
+            printf("\nExiting checksum demo....");
+            return;
+        }
+        if (k_status == 0)
+        {
+            continue;
+        }
+
+        char data[CHECKSUM_MAX_BITS + 1];
+        int data_status = read_binary_string(
+            data, sizeof(data), "enter the binary data (digits 0/1 only), or 'X' to exit:- ");
+
+        if (data_status == INPUT_EXIT_SIGNAL)
+        {
+            printf("\nExiting checksum demo....");
+            return;
+        }
+        if (data_status == 0)
+        {
+            continue;
+        }
+
+        int len = (int)strlen(data);
+
+        // pad the length up to a whole number of k-bit blocks; the missing low-order
+        // bits of the last block are treated as 0 (we never write them into `data`).
+        int padded_len = len;
+        while (padded_len % k != 0)
+        {
+            padded_len++;
+        }
+
+        int mask = (1 << k) - 1; // keeps only the low k bits
+        int sum = 0;
+
+        printf("\ndata length = %d bit(s), block size k = %d, padded to %d bit(s) (%d block(s))\n",
+               len, k, padded_len, padded_len / k);
+
+        // process one k-bit block at a time
+        for (int i = 0; i < padded_len; i += k)
+        {
+            int word = 0;
+
+            // assemble the current block, padding with 0 once we pass the real data
+            for (int j = 0; j < k; j++)
+            {
+                word <<= 1;
+                if (i + j < len)
+                {
+                    word |= (data[i + j] - '0');
+                }
+            }
+
+            sum += word;
+
+            // one's-complement (end-around carry) fold: wrap any overflow above k bits
+            // back into the low k bits, e.g. for k=3: 111 + 001 = 1000 -> 000 + 1 = 001
+            while (sum > mask)
+            {
+                sum = (sum & mask) + (sum >> k);
+            }
+
+            printf("block %d: ", (i / k) + 1);
+            print_binary(word, k);
+            printf("  (value %d)  running sum = ", word);
+            print_binary(sum, k);
+            printf("\n");
+        }
+
+        int checksum = (~sum) & mask; // one's complement of the final sum, kept to k bits
+
+        printf("\nfinal sum       = ");
+        print_binary(sum, k);
+        printf("\nchecksum (~sum) = ");
+        print_binary(checksum, k);
+        printf("\n\nthe sender appends this checksum to the data before transmission.\n");
+    }
+}

--- a/src/error_correction_algorithms/checksum.c
+++ b/src/error_correction_algorithms/checksum.c
@@ -3,13 +3,9 @@
 #include <stdio.h>
 #include <string.h>
 
-// longest binary string accepted from the user (plus room for the '\0'). a checksum
-// demo never needs more than a few hundred bits, so a fixed buffer keeps things simple.
-#define CHECKSUM_MAX_BITS 1024
-
-// prints the low `bits` bits of value, most-significant bit first. local helper used
-// only for displaying k-bit words/checksums in this demo.
-static void print_binary(int value, int bits)
+// prints the low `bits` bits of value, most-significant bit first. shared helper
+// used for displaying k-bit words/checksums in the sender and receiver demos.
+void checksum_print_binary(int value, int bits)
 {
     for (int i = bits - 1; i >= 0; i--)
     {
@@ -21,7 +17,7 @@ static void print_binary(int value, int bits)
 // convention used by the expression module (validate_infix_expr): returns 1 on a
 // valid non-empty binary string, 0 on EOF / invalid input (caller should re-prompt),
 // and INPUT_EXIT_SIGNAL when the user types 'X' to leave the demo.
-static int read_binary_string(char* buff, size_t size, const char* prompt)
+int checksum_read_binary(char* buff, size_t size, const char* prompt)
 {
     if (prompt)
     {
@@ -57,10 +53,66 @@ static int read_binary_string(char* buff, size_t size, const char* prompt)
     return 1;
 }
 
+// one's-complement (end-around carry) addition of a single k-bit word into the
+// running sum: any overflow above k bits is wrapped back into the low k bits,
+// e.g. for k=3: 111 + 001 = 1000 -> 000 + 1 = 001.
+int checksum_add(int sum, int word, int k)
+{
+    int mask = (1 << k) - 1;
+    sum += word;
+    while (sum > mask)
+    {
+        sum = (sum & mask) + (sum >> k);
+    }
+    return sum;
+}
+
+// splits the `len`-bit binary string `data` into k-bit blocks (padding the final
+// block with trailing 0s) and accumulates them with one's-complement addition,
+// printing each block and the running sum. returns the final k-bit folded sum.
+int checksum_block_sum(const char* data, int len, int k)
+{
+    // pad the length up to a whole number of k-bit blocks; the missing low-order
+    // bits of the last block are treated as 0 (we never read past `len`).
+    int padded_len = len;
+    while (padded_len % k != 0)
+    {
+        padded_len++;
+    }
+
+    printf("\ndata length = %d bit(s), block size k = %d, padded to %d bit(s) (%d block(s))\n", len,
+           k, padded_len, padded_len / k);
+
+    int sum = 0;
+    for (int i = 0; i < padded_len; i += k)
+    {
+        int word = 0;
+
+        // assemble the current block, padding with 0 once we pass the real data
+        for (int j = 0; j < k; j++)
+        {
+            word <<= 1;
+            if (i + j < len)
+            {
+                word |= (data[i + j] - '0');
+            }
+        }
+
+        sum = checksum_add(sum, word, k);
+
+        printf("block %d: ", (i / k) + 1);
+        checksum_print_binary(word, k);
+        printf("  (value %d)  running sum = ", word);
+        checksum_print_binary(sum, k);
+        printf("\n");
+    }
+    return sum;
+}
+
 // checksum (sender side): the data is split into k-bit blocks and summed using
 // one's-complement (end-around carry) addition; the checksum is the one's complement
 // of that running sum. this is the value the sender appends to the data before
-// transmitting it. the receiver-side verification is a separate follow-up.
+// transmitting it. the receiver-side verification lives in checksum_receiver.c.
 void checksum_demo(void)
 {
     while (1)
@@ -83,7 +135,7 @@ void checksum_demo(void)
         }
 
         char data[CHECKSUM_MAX_BITS + 1];
-        int data_status = read_binary_string(
+        int data_status = checksum_read_binary(
             data, sizeof(data), "enter the binary data (digits 0/1 only), or 'X' to exit:- ");
 
         if (data_status == INPUT_EXIT_SIGNAL)
@@ -97,58 +149,15 @@ void checksum_demo(void)
         }
 
         int len = (int)strlen(data);
-
-        // pad the length up to a whole number of k-bit blocks; the missing low-order
-        // bits of the last block are treated as 0 (we never write them into `data`).
-        int padded_len = len;
-        while (padded_len % k != 0)
-        {
-            padded_len++;
-        }
-
         int mask = (1 << k) - 1; // keeps only the low k bits
-        int sum = 0;
 
-        printf("\ndata length = %d bit(s), block size k = %d, padded to %d bit(s) (%d block(s))\n",
-               len, k, padded_len, padded_len / k);
-
-        // process one k-bit block at a time
-        for (int i = 0; i < padded_len; i += k)
-        {
-            int word = 0;
-
-            // assemble the current block, padding with 0 once we pass the real data
-            for (int j = 0; j < k; j++)
-            {
-                word <<= 1;
-                if (i + j < len)
-                {
-                    word |= (data[i + j] - '0');
-                }
-            }
-
-            sum += word;
-
-            // one's-complement (end-around carry) fold: wrap any overflow above k bits
-            // back into the low k bits, e.g. for k=3: 111 + 001 = 1000 -> 000 + 1 = 001
-            while (sum > mask)
-            {
-                sum = (sum & mask) + (sum >> k);
-            }
-
-            printf("block %d: ", (i / k) + 1);
-            print_binary(word, k);
-            printf("  (value %d)  running sum = ", word);
-            print_binary(sum, k);
-            printf("\n");
-        }
-
+        int sum = checksum_block_sum(data, len, k);
         int checksum = (~sum) & mask; // one's complement of the final sum, kept to k bits
 
         printf("\nfinal sum       = ");
-        print_binary(sum, k);
+        checksum_print_binary(sum, k);
         printf("\nchecksum (~sum) = ");
-        print_binary(checksum, k);
+        checksum_print_binary(checksum, k);
         printf("\n\nthe sender appends this checksum to the data before transmission.\n");
     }
 }

--- a/src/error_correction_algorithms/checksum_receiver.c
+++ b/src/error_correction_algorithms/checksum_receiver.c
@@ -1,0 +1,110 @@
+#include "error_correction_algorithms.h"
+#include "safe_input.h"
+#include <stdio.h>
+#include <string.h>
+
+// converts a k-bit binary string into its integer value. the caller guarantees the
+// string contains only '0'/'1' and is exactly k characters long.
+static int checksum_bits_to_int(const char* bits, int k)
+{
+    int value = 0;
+    for (int i = 0; i < k; i++)
+    {
+        value = (value << 1) | (bits[i] - '0');
+    }
+    return value;
+}
+
+// checksum (receiver side): re-runs the one's-complement block sum over the received
+// data, then folds in the received checksum block. if the one's complement of the
+// total is all zeros the frame is accepted, otherwise an error is detected. this is
+// the verification counterpart to the sender in checksum.c.
+void checksum_receiver_demo(void)
+{
+    while (1)
+    {
+        int k;
+        int k_status = safe_input_int(
+            &k,
+            "\n\nchecksum (receiver side)\nenter the block size k in bits (1 to 16), "
+            "or -1 to exit:- ",
+            1, 16);
+
+        if (k_status == INPUT_EXIT_SIGNAL)
+        {
+            printf("\nExiting checksum receiver demo....");
+            return;
+        }
+        if (k_status == 0)
+        {
+            continue;
+        }
+
+        char data[CHECKSUM_MAX_BITS + 1];
+        int data_status = checksum_read_binary(
+            data, sizeof(data),
+            "enter the received binary data (digits 0/1 only), or 'X' to exit:- ");
+
+        if (data_status == INPUT_EXIT_SIGNAL)
+        {
+            printf("\nExiting checksum receiver demo....");
+            return;
+        }
+        if (data_status == 0)
+        {
+            continue;
+        }
+
+        char check[CHECKSUM_MAX_BITS + 1];
+        int check_status =
+            checksum_read_binary(check, sizeof(check),
+                                 "enter the received checksum (exactly k bits), or 'X' to exit:- ");
+
+        if (check_status == INPUT_EXIT_SIGNAL)
+        {
+            printf("\nExiting checksum receiver demo....");
+            return;
+        }
+        if (check_status == 0)
+        {
+            continue;
+        }
+
+        if ((int)strlen(check) != k)
+        {
+            printf("\ninvalid: the checksum must be exactly %d bit(s) long.\n", k);
+            continue;
+        }
+
+        int len = (int)strlen(data);
+        int mask = (1 << k) - 1;
+
+        // sum the data blocks (same as the sender), then fold in the received checksum
+        int sum = checksum_block_sum(data, len, k);
+        int checkword = checksum_bits_to_int(check, k);
+        sum = checksum_add(sum, checkword, k);
+
+        printf("checksum: ");
+        checksum_print_binary(checkword, k);
+        printf("  (value %d)  running sum = ", checkword);
+        checksum_print_binary(sum, k);
+        printf("\n");
+
+        int complement = (~sum) & mask;
+
+        printf("\nfinal sum  = ");
+        checksum_print_binary(sum, k);
+        printf("\ncomplement = ");
+        checksum_print_binary(complement, k);
+
+        // a clean frame sums to all ones, so its complement is all zeros
+        if (complement == 0)
+        {
+            printf("\n\nresult: no error detected -- data accepted.\n");
+        }
+        else
+        {
+            printf("\n\nresult: error detected -- data rejected.\n");
+        }
+    }
+}

--- a/src/error_correction_algorithms/error_correction_algorithms.h
+++ b/src/error_correction_algorithms/error_correction_algorithms.h
@@ -1,7 +1,20 @@
 #ifndef ERROR_CORRECTION_ALGORITHMS_H
 #define ERROR_CORRECTION_ALGORITHMS_H
 
+#include <stddef.h>
+
+// longest binary string accepted from the user (plus room for the '\0'). a checksum
+// demo never needs more than a few hundred bits, so a fixed buffer keeps things simple.
+#define CHECKSUM_MAX_BITS 1024
+
 void error_correction_algorithms_demo(void);
 void checksum_demo(void);
+void checksum_receiver_demo(void);
+
+// shared checksum helpers (defined in checksum.c, reused by the receiver side)
+void checksum_print_binary(int value, int bits);
+int checksum_read_binary(char* buff, size_t size, const char* prompt);
+int checksum_add(int sum, int word, int k);
+int checksum_block_sum(const char* data, int len, int k);
 
 #endif

--- a/src/error_correction_algorithms/error_correction_algorithms.h
+++ b/src/error_correction_algorithms/error_correction_algorithms.h
@@ -2,5 +2,6 @@
 #define ERROR_CORRECTION_ALGORITHMS_H
 
 void error_correction_algorithms_demo(void);
+void checksum_demo(void);
 
 #endif

--- a/src/error_correction_algorithms/error_correction_algorithms_demo.c
+++ b/src/error_correction_algorithms/error_correction_algorithms_demo.c
@@ -10,8 +10,9 @@ void error_correction_algorithms_demo(void)
     {
         int ECA_choice;
         /*Change the prompt and the range accordingly when new functions get added*/
-        int ECA_status =
-            safe_input_int(&ECA_choice, "\nEnter 1 for checksum. Enter -1 to exit: ", 1, 1);
+        int ECA_status = safe_input_int(
+            &ECA_choice,
+            "\nEnter 1 for checksum (sender), 2 for checksum (receiver). Enter -1 to exit: ", 1, 2);
 
         if (ECA_status == INPUT_EXIT_SIGNAL)
         {
@@ -29,6 +30,10 @@ void error_correction_algorithms_demo(void)
 
             case 1:
                 checksum_demo();
+                break;
+
+            case 2:
+                checksum_receiver_demo();
                 break;
 
             default:

--- a/src/error_correction_algorithms/error_correction_algorithms_demo.c
+++ b/src/error_correction_algorithms/error_correction_algorithms_demo.c
@@ -1,6 +1,6 @@
-#include <stdio.h>
-#include <error_correction_algorithms.h>
 #include "safe_input.h"
+#include <error_correction_algorithms.h>
+#include <stdio.h>
 
 /*New functions come here*/
 
@@ -10,21 +10,26 @@ void error_correction_algorithms_demo(void)
     {
         int ECA_choice;
         /*Change the prompt and the range accordingly when new functions get added*/
-        int ECA_status = safe_input_int(&ECA_choice, "\nAlgorithms yet to be added. Enter -1 to exit: ",0 , 0);
+        int ECA_status =
+            safe_input_int(&ECA_choice, "\nEnter 1 for checksum. Enter -1 to exit: ", 1, 1);
 
-        if(ECA_status == INPUT_EXIT_SIGNAL)
+        if (ECA_status == INPUT_EXIT_SIGNAL)
         {
             printf("Exiting Error Correction Algorithm Demo....");
             return;
         }
 
-        if(ECA_status == 0)
+        if (ECA_status == 0)
             continue;
-        
-        switch(ECA_choice)
+
+        switch (ECA_choice)
         {
 
-            /*Newly implemented functions will be called here*/
+                /*Newly implemented functions will be called here*/
+
+            case 1:
+                checksum_demo();
+                break;
 
             default:
                 printf("Wrong choice entered");


### PR DESCRIPTION
Closes #185

> **Note:** builds on #184 (checksum sender side). Until #184 is merged, this PR's diff also includes the sender commit; once #184 lands on `main`, only the receiver-side changes remain.

### Summary
Adds the **receiver-side** checksum verification, the counterpart to the sender in #184. Given the received data plus the appended checksum, the receiver re-runs the one's-complement (end-around carry) sum over the data blocks, folds in the received checksum block, and takes the one's complement of the total:
- all zeros → no error detected, data accepted;
- non-zero → error detected, data rejected.

### What's included
- `src/error_correction_algorithms/checksum_receiver.c` — `checksum_receiver_demo()`: reads `k`, the received data, and the received `k`-bit checksum (validated to be exactly `k` bits), then prints the step-by-step block sums, the final sum/complement, and the verdict.
- Refactored `checksum.c` to **share** its logic instead of duplicating it: `checksum_print_binary`, `checksum_read_binary`, `checksum_add` (single-word end-around-carry fold), and `checksum_block_sum` (prints data blocks + running sum, returns the folded k-bit sum) are now reused by both sides. The sender output is unchanged.
- Module dispatcher: option **1 = checksum (sender)**, **2 = checksum (receiver)**.

No Makefile change — the module is already listed and the build auto-globs new `.c` files.

### Verification
- No error: data `1101001111`, checksum `000`, k=3 → **accepted**.
- Detected error: same data, checksum `001` → complement `110` → **rejected**.
- Forouzan 8-bit example: data + checksum `11011010` → sum `11111111` → **accepted**.
- Checksum-length-mismatch guard, `X`-exit, and sender regression all verified.
- `make` clean with `-Werror`; `make test` passes; `make valgrind` 0 errors / no leaks; clang-format clean.
