### PR TITLE
refactor: extract array/child helpers and add stress tests for B-Tree

### DIFF
--- a/src/trees/btree.c
+++ b/src/trees/btree.c
@@ -3,6 +3,30 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+static void shift_keys_right(btreeNode* node, int from)
+{
+    for (int i = node->num_keys - 1; i >= from; i--)
+        node->keys[i + 1] = node->keys[i];
+}
+
+static void shift_keys_left(btreeNode* node, int from)
+{
+    for (int i = from + 1; i < node->num_keys; i++)
+        node->keys[i - 1] = node->keys[i];
+}
+
+static void shift_children_right(btreeNode* node, int from)
+{
+    for (int i = node->num_keys; i >= from; i--)
+        node->children[i + 1] = node->children[i];
+}
+
+static void shift_children_left(btreeNode* node, int from)
+{
+    for (int i = from + 1; i <= node->num_keys; i++)
+        node->children[i - 1] = node->children[i];
+}
+
 btreeNode* btree_create_node(int is_leaf)
 {
     btreeNode* node = malloc(sizeof(btreeNode));
@@ -52,13 +76,11 @@ static void btree_split_child(btreeNode* parent, int i, btreeNode* child, int t)
 
     child->num_keys = t - 1;
 
-    for (int j = parent->num_keys; j >= i + 1; j--)
-        parent->children[j + 1] = parent->children[j];
+    shift_children_right(parent, i + 1);
 
     parent->children[i + 1] = new_node;
 
-    for (int j = parent->num_keys - 1; j >= i; j--)
-        parent->keys[j + 1] = parent->keys[j];
+    shift_keys_right(parent, i);
 
     parent->keys[i]  = child->keys[t - 1];
     parent->num_keys = parent->num_keys + 1;
@@ -70,13 +92,12 @@ static void btree_insert_nonfull(btreeNode* node, int key, int t)
 
     if (node->is_leaf)
     {
-        while (i >= 0 && node->keys[i] > key)
-        {
-            node->keys[i + 1] = node->keys[i];
-            i--;
-        }
-        node->keys[i + 1] = key;
-        node->num_keys     = node->num_keys + 1;
+        int pos = 0;
+        while (pos < node->num_keys && node->keys[pos] < key)
+            pos++;
+        shift_keys_right(node, pos);
+        node->keys[pos]  = key;
+        node->num_keys   = node->num_keys + 1;
     }
     else
     {
@@ -145,14 +166,10 @@ static void btree_borrow_from_prev(btreeNode* node, int idx)
     btreeNode* child   = node->children[idx];
     btreeNode* sibling = node->children[idx - 1];
 
-    for (int i = child->num_keys - 1; i >= 0; i--)
-        child->keys[i + 1] = child->keys[i];
+    shift_keys_right(child, 0);
 
     if (!child->is_leaf)
-    {
-        for (int i = child->num_keys; i >= 0; i--)
-            child->children[i + 1] = child->children[i];
-    }
+        shift_children_right(child, 0);
 
     child->keys[0] = node->keys[idx - 1];
 
@@ -176,14 +193,10 @@ static void btree_borrow_from_next(btreeNode* node, int idx)
 
     node->keys[idx] = sibling->keys[0];
 
-    for (int i = 1; i < sibling->num_keys; i++)
-        sibling->keys[i - 1] = sibling->keys[i];
+    shift_keys_left(sibling, 0);
 
     if (!sibling->is_leaf)
-    {
-        for (int i = 1; i <= sibling->num_keys; i++)
-            sibling->children[i - 1] = sibling->children[i];
-    }
+        shift_children_left(sibling, 0);
 
     child->num_keys++;
     sibling->num_keys--;
@@ -205,16 +218,13 @@ static void btree_merge(btreeNode* node, int idx, int t)
             child->children[t + i] = sibling->children[i];
     }
 
-    for (int i = idx + 1; i < node->num_keys; i++)
-        node->keys[i - 1] = node->keys[i];
+        shift_keys_left(node, idx);
+        shift_children_left(node, idx + 1);
 
-    for (int i = idx + 2; i <= node->num_keys; i++)
-        node->children[i - 1] = node->children[i];
+        child->num_keys += sibling->num_keys + 1;
+        node->num_keys--;
 
-    child->num_keys += sibling->num_keys + 1;
-    node->num_keys--;
-
-    free(sibling);
+        free(sibling);
 }
 
 static void btree_fill(btreeNode* node, int idx, int t)
@@ -244,11 +254,10 @@ btreeNode* btree_delete(btreeNode* root, int key, int t)
     if (idx < root->num_keys && root->keys[idx] == key)
     {
         if (root->is_leaf)
-        {
-            for (int i = idx + 1; i < root->num_keys; i++)
-                root->keys[i - 1] = root->keys[i];
-            root->num_keys--;
-        }
+            {
+                shift_keys_left(root, idx);
+                root->num_keys--;
+            }
         else
         {
             if (root->children[idx]->num_keys >= t)
@@ -297,7 +306,7 @@ btreeNode* btree_delete(btreeNode* root, int key, int t)
         free(old_root);
     }
 
-    return root;
+return root;
 }
 
 void btree_destroy(btreeNode* root)

--- a/tests/test_btree.c
+++ b/tests/test_btree.c
@@ -2,6 +2,54 @@
 #include <assert.h>
 #include <stdio.h>
 
+static int btree_validate_keys(const btreeNode* node)
+{
+    if (node == NULL)
+        return 1;
+
+    for (int i = 0; i < node->num_keys - 1; i++)
+    {
+        if (node->keys[i] >= node->keys[i + 1])
+            return 0;
+    }
+
+    if (!node->is_leaf)
+    {
+        for (int i = 0; i <= node->num_keys; i++)
+        {
+            if (!btree_validate_keys(node->children[i]))
+                return 0;
+        }
+    }
+
+    return 1;
+}
+
+static int btree_validate_invariants(const btreeNode* node, int t, int is_root)
+{
+    if (node == NULL)
+        return 1;
+
+    if (node->num_keys > 2 * t - 1)
+        return 0;
+
+    if (!is_root && node->num_keys < t - 1)
+        return 0;
+
+    if (!node->is_leaf)
+    {
+        for (int i = 0; i <= node->num_keys; i++)
+        {
+            if (node->children[i] == NULL)
+                return 0;
+            if (!btree_validate_invariants(node->children[i], t, 0))
+                return 0;
+        }
+    }
+
+    return 1;
+}
+
 void test_insert_and_search()
 {
     btreeNode* root = NULL;
@@ -137,6 +185,32 @@ void test_traverse()
     printf("btree traverse test passed\n");
 }
 
+void test_stress()
+{
+    btreeNode* root = NULL;
+    int t = 3;
+
+    for (int i = 1; i <= 10000; i++)
+        assert(btree_insert(&root, i, t) == 1);
+
+    for (int i = 1; i <= 10000; i++)
+        assert(btree_search(root, i) == 1);
+
+    for (int i = 1; i <= 10000; i += 2)
+        root = btree_delete(root, i, t);
+
+    for (int i = 1; i <= 10000; i += 2)
+        assert(btree_search(root, i) == 0);
+
+    for (int i = 2; i <= 10000; i += 2)
+        assert(btree_search(root, i) == 1);
+
+    assert(btree_validate_keys(root));
+    assert(btree_validate_invariants(root, t, 1));
+    btree_destroy(root);
+    printf("btree stress test passed\n");
+}
+
 int main()
 {
     test_insert_and_search();
@@ -147,6 +221,7 @@ int main()
     test_delete_nonexistent();
     test_delete_internal_key();
     test_traverse();
+    test_stress();
 
     printf("All btree tests passed\n");
     return 0;


### PR DESCRIPTION
## Description
Closes #187 

Addresses review feedback on #178 , refactors B-Tree implementation for clarity and adds validation + stress test coverage.

## Changes

- `src/trees/btree.c` — extracted repeated key and child array manipulation into static helpers: `shift_keys_right`, `shift_keys_left`, `shift_children_right`, `shift_children_left`; used across split, insert, borrow and merge operations
- `tests/test_btree.c` — added `btree_validate_keys`, `btree_validate_invariants` debug helpers and `test_stress` covering 10000 sequential inserts, odd-key deletes, and even-key searches with invariant checks after operations

## What was addressed

- Generic sorted-array helpers extracted and used across all key shift operations
- Generic child-pointer helpers extracted and used across all child shift operations
- `btree_split_child`, `btree_merge`, `btree_borrow_from_prev`, `btree_borrow_from_next`, `btree_fill` are all separate named helpers
- `btree_delete` broken down — borrow left, borrow right, merge, fill each their own function
- `btree_split_child` handles insert split logic as a dedicated helper
- `btree_validate_keys` and `btree_validate_invariants` added in test file with invariant checks after stress operations

## Not in scope

- Common tree visualization framework — requires changes across BST/AVL files
- Common search abstraction — requires interface changes across all tree structures
- Shared B-Tree/B+ Tree infrastructure — requires modifying `bplus_tree.c`
- `validate_leaf_links` — B+ Tree specific, not applicable to B-Tree
- Memory allocation failure tests — not feasible without mock malloc

Evryhting is working file as previous - checked and verified, no broken code, no logic change.