### PR TITLE
feat(error-correction): add Hamming code generation

### DIFF
--- a/src/error_correction_algorithms/error_correction_algorithms.h
+++ b/src/error_correction_algorithms/error_correction_algorithms.h
@@ -13,6 +13,7 @@ void checksum_receiver_demo(void);
 void crc_demo(void);
 void lrc_demo(void);
 void vrc_demo(void);
+void hamming_demo(void);
 
 // shared checksum helpers (defined in checksum.c, reused by the receiver side)
 void checksum_print_binary(int value, int bits);

--- a/src/error_correction_algorithms/error_correction_algorithms_demo.c
+++ b/src/error_correction_algorithms/error_correction_algorithms_demo.c
@@ -10,14 +10,15 @@ void error_correction_algorithms_demo(void)
     {
         int ECA_choice;
         /*Change the prompt and the range accordingly when new functions get added*/
-        int ECA_status = safe_input_int(
-            &ECA_choice,
-            "\nEnter 1 for checksum (sender)"
-            "\nEnter 2 for checksum (receiver)"
-            "\nEnter 3 for CRC"
-            "\nEnter 4 for LRC"
-            "\nEnter 5 for VRC"
-            "\nEnter -1 to exit: ", 1, 5);
+        int ECA_status = safe_input_int(&ECA_choice,
+                                        "\nEnter 1 for checksum (sender)"
+                                        "\nEnter 2 for checksum (receiver)"
+                                        "\nEnter 3 for CRC"
+                                        "\nEnter 4 for LRC"
+                                        "\nEnter 5 for VRC"
+                                        "\nEnter 6 for Hamming Code"
+                                        "\nEnter -1 to exit: ",
+                                        1, 6);
 
         if (ECA_status == INPUT_EXIT_SIGNAL)
         {
@@ -40,7 +41,7 @@ void error_correction_algorithms_demo(void)
             case 2:
                 checksum_receiver_demo();
                 break;
-            
+
             case 3:
                 crc_demo();
                 break;
@@ -51,6 +52,10 @@ void error_correction_algorithms_demo(void)
 
             case 5:
                 vrc_demo();
+                break;
+
+            case 6:
+                hamming_demo();
                 break;
 
             default:

--- a/src/error_correction_algorithms/hamming.c
+++ b/src/error_correction_algorithms/hamming.c
@@ -1,0 +1,110 @@
+#include "error_correction_algorithms.h"
+#include "safe_input.h"
+#include <stdio.h>
+#include <string.h>
+
+// hamming code generation (sender side). the user supplies the binary data bits and
+// we build the (n, k) codeword by inserting r even-parity bits at the power-of-2
+// positions (1, 2, 4, 8, ...). a 1-based layout keeps the parity maths readable.
+void hamming_demo(void)
+{
+    while (1)
+    {
+        char data[CHECKSUM_MAX_BITS + 1];
+
+        int data_status = checksum_read_binary(data, sizeof(data),
+                                               "\n\nHamming Code Demo\n"
+                                               "enter binary data bits or 'X' to exit:- ");
+
+        if (data_status == INPUT_EXIT_SIGNAL)
+        {
+            printf("\nExiting Hamming Code demo....");
+            return;
+        }
+
+        if (data_status == 0)
+        {
+            continue;
+        }
+
+        int k = (int)strlen(data);
+
+        // number of parity bits r: the smallest r with 2^r >= k + r + 1, so that every
+        // codeword position (data + parity) can be addressed by the r parity checks.
+        int r = 0;
+        while ((1 << r) < (k + r + 1))
+        {
+            r++;
+        }
+
+        int n = k + r;
+
+        // ham[1..n] is the codeword in transmission order (position 1 is the MSB end).
+        int ham[CHECKSUM_MAX_BITS + 16];
+
+        // lay out the frame: power-of-2 positions are parity placeholders (filled below),
+        // every other position takes the next data bit in order.
+        int data_index = 0;
+        for (int pos = 1; pos <= n; pos++)
+        {
+            if ((pos & (pos - 1)) == 0) // pos is a power of two -> parity position
+            {
+                ham[pos] = 0;
+            }
+            else
+            {
+                ham[pos] = data[data_index] - '0';
+                data_index++;
+            }
+        }
+
+        // compute each parity bit (even parity) over the positions it covers: parity bit
+        // at position p = 2^i covers every position whose index has bit i set.
+        for (int i = 0; i < r; i++)
+        {
+            int parity_pos = (1 << i);
+            int parity = 0;
+
+            for (int pos = 1; pos <= n; pos++)
+            {
+                if ((pos & parity_pos) && pos != parity_pos)
+                {
+                    parity ^= ham[pos];
+                }
+            }
+
+            ham[parity_pos] = parity;
+        }
+
+        printf("\nData bits (k)        : %d", k);
+        printf("\nParity bits (r)      : %d", r);
+        printf("\nCodeword length (n)  : %d", n);
+
+        printf("\nParity bit values    :");
+        for (int i = 0; i < r; i++)
+        {
+            int parity_pos = (1 << i);
+            printf(" P%d=%d", parity_pos, ham[parity_pos]);
+        }
+
+        printf("\nHamming Code (P=parity, transmitted left to right):\n");
+        for (int pos = 1; pos <= n; pos++)
+        {
+            if ((pos & (pos - 1)) == 0)
+            {
+                printf("P%d=%d ", pos, ham[pos]);
+            }
+            else
+            {
+                printf("D%d=%d ", pos, ham[pos]);
+            }
+        }
+
+        printf("\nGenerated Hamming Code (%d,%d): ", n, k);
+        for (int pos = 1; pos <= n; pos++)
+        {
+            printf("%d", ham[pos]);
+        }
+        printf("\n");
+    }
+}


### PR DESCRIPTION
Closes #200

Adds Hamming code generation (sender side) to the `error_correction_algorithms` module.

## What it does
- New `src/error_correction_algorithms/hamming.c` exposing `hamming_demo()`, following the existing one-`<algo>.c`-per-algorithm convention.
- Reads binary data bits via the shared `checksum_read_binary` helper (`X` to exit, loops on invalid/empty input).
- Computes the number of parity bits `r` as the smallest value with `2^r >= k + r + 1`.
- Lays out the codeword 1-based, placing parity bits at the power-of-2 positions (1, 2, 4, 8, ...) and data bits in the remaining positions.
- Computes each parity bit with even parity over the positions it covers, then prints `k`, `r`, `n`, the individual parity bit values, the labelled frame, and the final generated `(n,k)` Hamming code.
- Declared in `error_correction_algorithms.h` and wired into the demo dispatcher as option 6.

## Example
Data `1011` -> `(7,4)` codeword `0110011` (P1=0, P2=1, P4=0).

## Verification
- `make` clean under `-Wall -Wextra -Werror`.
- Drove `./dsa` interactively (generation, invalid input, `X` exit).
- `make test` all pass.
- `valgrind --leak-check=full` on the Hamming path: 0 errors, 0 leaks.
- `clang-format` clean.

Receiver-side single-bit error detection + correction will follow as a separate issue/PR.
