### PR TITLE
feat(error-correction): add Hamming code receiver-side detection and correction

### DIFF
--- a/src/error_correction_algorithms/error_correction_algorithms.h
+++ b/src/error_correction_algorithms/error_correction_algorithms.h
@@ -14,6 +14,7 @@ void crc_demo(void);
 void lrc_demo(void);
 void vrc_demo(void);
 void hamming_demo(void);
+void hamming_receiver_demo(void);
 
 // shared checksum helpers (defined in checksum.c, reused by the receiver side)
 void checksum_print_binary(int value, int bits);

--- a/src/error_correction_algorithms/error_correction_algorithms_demo.c
+++ b/src/error_correction_algorithms/error_correction_algorithms_demo.c
@@ -16,9 +16,10 @@ void error_correction_algorithms_demo(void)
                                         "\nEnter 3 for CRC"
                                         "\nEnter 4 for LRC"
                                         "\nEnter 5 for VRC"
-                                        "\nEnter 6 for Hamming Code"
+                                        "\nEnter 6 for Hamming Code (sender)"
+                                        "\nEnter 7 for Hamming Code (receiver)"
                                         "\nEnter -1 to exit: ",
-                                        1, 6);
+                                        1, 7);
 
         if (ECA_status == INPUT_EXIT_SIGNAL)
         {
@@ -56,6 +57,10 @@ void error_correction_algorithms_demo(void)
 
             case 6:
                 hamming_demo();
+                break;
+
+            case 7:
+                hamming_receiver_demo();
                 break;
 
             default:

--- a/src/error_correction_algorithms/hamming_receiver.c
+++ b/src/error_correction_algorithms/hamming_receiver.c
@@ -1,0 +1,110 @@
+#include "error_correction_algorithms.h"
+#include "safe_input.h"
+#include <stdio.h>
+#include <string.h>
+
+// hamming code receiver (decoder). given a received codeword we recompute the parity
+// checks to form the syndrome: read as a binary number it is the 1-based position of a
+// single-bit error (0 means no error). flipping that bit corrects the codeword.
+void hamming_receiver_demo(void)
+{
+    while (1)
+    {
+        char frame[CHECKSUM_MAX_BITS + 1];
+
+        int frame_status =
+            checksum_read_binary(frame, sizeof(frame),
+                                 "\n\nHamming Code Receiver Demo\n"
+                                 "enter received Hamming codeword or 'X' to exit:- ");
+
+        if (frame_status == INPUT_EXIT_SIGNAL)
+        {
+            printf("\nExiting Hamming Code Receiver demo....");
+            return;
+        }
+
+        if (frame_status == 0)
+        {
+            continue;
+        }
+
+        int n = (int)strlen(frame);
+
+        // ham[1..n] is the received codeword in transmission order (1-based, MSB end).
+        int ham[CHECKSUM_MAX_BITS + 16];
+        for (int pos = 1; pos <= n; pos++)
+        {
+            ham[pos] = frame[pos - 1] - '0';
+        }
+
+        // number of parity bits r = count of power-of-2 positions that fit in n.
+        int r = 0;
+        while ((1 << r) <= n)
+        {
+            r++;
+        }
+
+        // build the syndrome: bit i is the even-parity check over every position whose
+        // index has bit i set (the parity bit itself is included in its own check).
+        int syndrome = 0;
+        for (int i = 0; i < r; i++)
+        {
+            int parity_pos = (1 << i);
+            int parity = 0;
+
+            for (int pos = 1; pos <= n; pos++)
+            {
+                if (pos & parity_pos)
+                {
+                    parity ^= ham[pos];
+                }
+            }
+
+            if (parity)
+            {
+                syndrome += parity_pos;
+            }
+        }
+
+        printf("\nReceived codeword    : %s", frame);
+        printf("\nCodeword length (n)  : %d", n);
+        printf("\nParity bits (r)      : %d", r);
+        printf("\nSyndrome value       : %d", syndrome);
+
+        if (syndrome == 0)
+        {
+            printf("\nResult               : no error detected -- data accepted");
+        }
+        else if (syndrome > n)
+        {
+            // the syndrome points past the frame: more than a single-bit error, which a
+            // basic Hamming code cannot reliably locate.
+            printf("\nResult               : syndrome %d is out of range -- "
+                   "multiple-bit error, cannot correct",
+                   syndrome);
+        }
+        else
+        {
+            printf("\nResult               : error detected at position %d -- correcting",
+                   syndrome);
+            ham[syndrome] ^= 1;
+
+            printf("\nCorrected codeword   : ");
+            for (int pos = 1; pos <= n; pos++)
+            {
+                printf("%d", ham[pos]);
+            }
+        }
+
+        // recover the data bits (every position that is not a power of two).
+        printf("\nRecovered data bits  : ");
+        for (int pos = 1; pos <= n; pos++)
+        {
+            if ((pos & (pos - 1)) != 0)
+            {
+                printf("%d", ham[pos]);
+            }
+        }
+        printf("\n");
+    }
+}


### PR DESCRIPTION
Closes #205

Adds Hamming code receiver / decoder (single-bit error detection + correction) to the `error_correction_algorithms` module. Follow-up to the sender-side generator in #200.

> Stacked on #200 (`feature/hamming-code`). Until #200 merges this diff also shows the sender commit; once #200 lands on `main` it auto-narrows to the receiver-only file + dispatcher option.

## What it does
- New `src/error_correction_algorithms/hamming_receiver.c` exposing `hamming_receiver_demo()`, reusing the shared `checksum_read_binary` input helper (`X` to exit, loops on invalid/empty input).
- Reads a received codeword and recomputes the parity checks to form the **syndrome** (even parity over each `2^i` group, including the parity bit itself).
- Syndrome `0` → no error, data accepted.
- Syndrome in `1..n` → single-bit error at that 1-based position; flips the bit to **correct** it and prints the corrected codeword.
- Syndrome `> n` → points past the frame, i.e. a multiple-bit error a basic Hamming code can't locate; reported rather than mis-corrected.
- Always recovers and prints the data bits (non power-of-2 positions).
- Declared in `error_correction_algorithms.h`, wired into the dispatcher as option 7 (option 6 = Hamming sender).

## Examples
- `0110011` → syndrome 0, accepted, data `1011`.
- `0110111` (bit 5 flipped) → syndrome 5, corrected to `0110011`, data `1011`.
- `001100` (two bits flipped, n=6) → syndrome 7 out of range, reported as multiple-bit error.

## Verification
- `make` clean under `-Wall -Wextra -Werror`.
- Drove `./dsa` interactively for all three branches above plus `X` exit.
- `make test` all pass.
- `valgrind --leak-check=full` on the receiver paths: 0 errors, 0 leaks.
- `clang-format` clean.
