### PR TITLE
feat(graph): visualize a weighted graph as an adjacency list

### DIFF
--- a/src/graph_traversals/graph_traversals.h
+++ b/src/graph_traversals/graph_traversals.h
@@ -58,6 +58,7 @@ weightedGraph* create_weightedGraph(int V);
 void add_edge_directed(weightedGraph* graph, int src, int dest, int wt);
 int edge_insertAtEnd(Edge** head, int dest, int weight);
 void free_weightedGraph(weightedGraph* graph);
+void print_weightedGraph(const weightedGraph* graph);
 
 // ------------------For A* search algorithm-----------------------
 

--- a/src/graph_traversals/graph_visualize.c
+++ b/src/graph_traversals/graph_visualize.c
@@ -77,7 +77,7 @@ static void visualize_weighted_graph(void)
             break;
         }
     }
-    else
+    else if(input_method == 1)
     {
         while (1)
         {

--- a/src/graph_traversals/graph_visualize.c
+++ b/src/graph_traversals/graph_visualize.c
@@ -1,19 +1,233 @@
 #include "graph_io.h"
 #include "graph_traversals.h"
 #include "safe_input.h"
+#include <limits.h>
 #include <stdio.h>
 #include <string.h>
 
-// Standalone "visualize graph" demo: builds an unweighted graph the same two
-// ways the traversal demos do (manual entry or CSV import) and then prints it
-// as an adjacency list. It deliberately shows the structure itself, separate
-// from any traversal output.
+// Builds a weighted graph (manual entry or CSV import) the same way the weighted
+// search demos do, then prints it as an adjacency list. Kept separate from the
+// unweighted path so each flow stays easy to follow.
+static void visualize_weighted_graph(void)
+{
+    int edges;
+    int graph_capacity;
+    int input_method;
+    weightedGraph* graph = NULL;
+
+    while (1)
+    {
+        int method_status = safe_input_int(&input_method,
+                                           "\nenter 1 to build the graph manually, 2 to load it "
+                                           "from a CSV file, enter '-1' to exit : ",
+                                           1, 2);
+
+        if (method_status == INPUT_EXIT_SIGNAL)
+        {
+            printf("\nExiting graph visualization.....\n");
+            return;
+        }
+
+        if (method_status == 0)
+        {
+            continue;
+        }
+
+        break;
+    }
+
+    if (input_method == 2)
+    {
+        while (1)
+        {
+            char path[256];
+            printf("\nenter the path to the CSV file, enter '-1' to exit : ");
+            fflush(stdout);
+
+            if (!fgets(path, sizeof(path), stdin))
+            {
+                printf("\ninput ended unexpectedly\n");
+                clearerr(stdin);
+                return;
+            }
+
+            size_t len = strlen(path);
+            while (len > 0 && (path[len - 1] == '\n' || path[len - 1] == '\r'))
+                path[--len] = '\0';
+
+            if (strcmp(path, "-1") == 0)
+            {
+                printf("\nExiting graph visualization.....\n");
+                return;
+            }
+
+            if (len == 0)
+            {
+                continue;
+            }
+
+            graph = load_weightedGraph_from_csv(path);
+
+            if (!graph)
+            {
+                // error already reported by the loader, let the user retry
+                continue;
+            }
+
+            break;
+        }
+    }
+    else
+    {
+        while (1)
+        {
+            int graph_capacity_status =
+                safe_input_int(&graph_capacity,
+                               "\nenter the number of vertices in the graph, "
+                               "(between 1 and 10), enter '-1' to exit : ",
+                               1, 10);
+
+            if (graph_capacity_status == INPUT_EXIT_SIGNAL)
+            {
+                printf("\nExiting graph visualization.....\n");
+                return;
+            }
+
+            if (graph_capacity_status == 0)
+            {
+                continue;
+            }
+
+            graph = create_weightedGraph(graph_capacity);
+
+            if (!graph)
+            {
+                printf("\nmalloc allocation failed\n");
+                return;
+            }
+
+            break;
+        }
+
+        while (1)
+        {
+            int edges_capacity_status = safe_input_int(
+                &edges, "\nenter number of edges (between 1 and 100), enter '-1' to exit :", 1,
+                100);
+
+            if (edges_capacity_status == INPUT_EXIT_SIGNAL)
+            {
+                printf("\nExiting graph visualization\n");
+                free_weightedGraph(graph);
+                return;
+            }
+
+            if (edges_capacity_status == 0)
+            {
+                continue;
+            }
+
+            break;
+        }
+
+        printf("\nenter edges (src dest weight) (vertices from 0 to %d, enter '-1' to exit):\n",
+               graph_capacity - 1);
+
+        for (int i = 0; i < edges; i++)
+        {
+            int src_status;
+            int dest_status;
+            int wt_status;
+            int src;
+            int dest;
+            int wt;
+
+        retry:
+            src_status = safe_input_int(&src, "src: ", 0, graph_capacity - 1);
+
+            if (src_status == INPUT_EXIT_SIGNAL)
+            {
+                printf("\nExiting graph visualization\n");
+                free_weightedGraph(graph);
+                return;
+            }
+            if (src_status == 0)
+            {
+                goto retry;
+            }
+
+            dest_status = safe_input_int(&dest, "dest: ", 0, graph_capacity - 1);
+
+            if (dest_status == INPUT_EXIT_SIGNAL)
+            {
+                printf("\nExiting graph visualization\n");
+                free_weightedGraph(graph);
+                return;
+            }
+            if (dest_status == 0)
+            {
+                goto retry;
+            }
+
+            wt_status = safe_input_int(&wt, "weight: ", 0, INT_MAX);
+
+            if (wt_status == INPUT_EXIT_SIGNAL)
+            {
+                printf("\nExiting graph visualization\n");
+                free_weightedGraph(graph);
+                return;
+            }
+            if (wt_status == 0)
+            {
+                goto retry;
+            }
+
+            add_edge_directed(graph, src, dest, wt);
+        }
+    }
+
+    print_weightedGraph(graph);
+    free_weightedGraph(graph);
+}
+
+// Standalone "visualize graph" demo: first asks whether to visualize an
+// unweighted or weighted graph, then builds it the same two ways the traversal
+// demos do (manual entry or CSV import) and prints it as an adjacency list. It
+// deliberately shows the structure itself, separate from any traversal output.
 void visualize_graph_demo(void)
 {
     int edges;
     int graph_capacity;
     int input_method;
     Graph* graph = NULL;
+
+    int graph_type;
+    while (1)
+    {
+        int type_status = safe_input_int(&graph_type,
+                                         "\nenter 1 to visualize an unweighted graph, 2 for a "
+                                         "weighted graph, enter '-1' to exit : ",
+                                         1, 2);
+
+        if (type_status == INPUT_EXIT_SIGNAL)
+        {
+            printf("\nExiting graph visualization.....\n");
+            return;
+        }
+
+        if (type_status == 0)
+        {
+            continue;
+        }
+
+        break;
+    }
+
+    if (graph_type == 2)
+    {
+        visualize_weighted_graph();
+        return;
+    }
 
     while (1)
     {
@@ -76,8 +290,8 @@ void visualize_graph_demo(void)
 
             break;
         }
-    }  
-    else if(input_method==1)
+    }
+    else if (input_method == 1)
     {
         while (1)
         {

--- a/src/utils/graph_io.c
+++ b/src/utils/graph_io.c
@@ -297,3 +297,29 @@ void print_graph(const Graph* graph)
         printf("\n");
     }
 }
+
+// Prints a weighted graph as an adjacency list, one vertex per line. Mirrors the
+// unweighted print_graph / sll_printlist style but walks the Edge list so each
+// neighbour is shown as dest(weight).
+void print_weightedGraph(const weightedGraph* graph)
+{
+    if (!graph)
+    {
+        printf("\nNo graph to display.\n");
+        return;
+    }
+
+    printf("\nAdjacency list (%d vertices):\n", graph->V);
+
+    for (int i = 0; i < graph->V; i++)
+    {
+        printf("vertex %d: HEAD->", i);
+
+        for (const Edge* edge = graph->array[i]; edge != NULL; edge = edge->next)
+        {
+            printf("%d(%d) ->", edge->destination, edge->weight);
+        }
+
+        printf("NULL\n");
+    }
+}


### PR DESCRIPTION
Closes #208

Adds adjacency-list visualization for the **weighted** graph, the follow-up to the unweighted visualization merged in #177.

## What it does
- New `print_weightedGraph(const weightedGraph* graph)` in `src/utils/graph_io.c` (declared in `graph_traversals.h`), alongside the existing `print_graph`. It walks each vertex's `Edge` list and prints every neighbour as `dest(weight)`, in the same `HEAD-> ... ->NULL` style as the unweighted `sll_printlist`.
- The standalone "visualize graph" demo (menu 6 → 8) now first asks **unweighted (1)** or **weighted (2)**. The weighted path builds the graph the same two ways the weighted search demos do — manual entry (`create_weightedGraph` + `add_edge_directed`, prompting src/dest/weight) or CSV import (the existing `load_weightedGraph_from_csv`) — then prints it and frees it. The unweighted path is unchanged.

## Example
CSV `4 4 / 0,1,5 / 0,2,3 / 1,3,2 / 2,3,7`:
```
Adjacency list (4 vertices):
vertex 0: HEAD->1(5) ->2(3) ->NULL
vertex 1: HEAD->3(2) ->NULL
vertex 2: HEAD->3(7) ->NULL
vertex 3: HEAD->NULL
```

## Verification
- `make` clean under `-Wall -Wextra -Werror`.
- Drove `./dsa` for the weighted manual path, weighted CSV path, and the unchanged unweighted path; plus `-1`/exit at each prompt.
- `make test` all pass.
- `valgrind --leak-check=full` on the weighted manual + CSV paths: 0 errors, 0 leaks.
- `clang-format` clean.
