### PR TITLE
refactor: extract shared B-Tree/B+ Tree utilities into mwst_utils

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -262,7 +262,7 @@ TEST_BINS = test_circ_queue test_bst test_search test_hash_func \
 test_bplus_tree: $(TEST_DIR)/test_bplus_tree$(EXE)
 	$(TEST_DIR)/test_bplus_tree$(EXE)
 
-$(TEST_DIR)/test_bplus_tree$(EXE): $(OBJ_DIR)/src/trees/bplus_tree.o $(OBJ_DIR)/src/utils/safe_input_int.o tests/test_bplus_tree.c
+$(TEST_DIR)/test_bplus_tree$(EXE): $(OBJ_DIR)/src/trees/bplus_tree.o $(OBJ_DIR)/src/trees/mwst_utils.o $(OBJ_DIR)/src/utils/safe_input_int.o tests/test_bplus_tree.c
 	@$(call MKDIR_P,$(TEST_DIR))
 	$(CC) $(CFLAGS) $^ -o $@
 

--- a/src/trees/bplus_tree.c
+++ b/src/trees/bplus_tree.c
@@ -1,52 +1,14 @@
 #include "trees.h"
+#include "mwst_utils.h"
 #include "safe_input.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdbool.h>
 #include <string.h>
 
-/* Allocate a new B+ Tree node */
-static BPlusNode* create_node(int order, bool is_leaf) {
-    BPlusNode* node = malloc(sizeof(BPlusNode));
-    if (!node) return NULL;
-    node->is_leaf = is_leaf;
-    node->num_keys = 0;
-    node->keys = calloc(order, sizeof(int));
-    if (is_leaf) {
-        node->values = calloc(order, sizeof(int));
-        node->children = NULL;
-    } else {
-        node->values = NULL;
-        node->children = calloc(order + 1, sizeof(BPlusNode*));
-    }
-    node->next = NULL;
-    node->prev = NULL;
-    return node;
-}
-
-/* Free a B+ Tree node */
-static void free_node(BPlusNode* node) {
-    if (!node) return;
-    if (node->keys) free(node->keys);
-    if (node->values) free(node->values);
-    if (node->children) free(node->children);
-    free(node);
-}
-
-/* Recursive node destruction */
-static void destroy_node_recursive(BPlusNode* node) {
-    if (!node) return;
-    if (!node->is_leaf) {
-        for (int i = 0; i <= node->num_keys; i++) {
-            destroy_node_recursive(node->children[i]);
-        }
-    }
-    free_node(node);
-}
-
 /* Create an empty B+ Tree */
 BPlusTree* bplus_tree_create(int order) {
-    if (order < 3) return NULL; // Min order is 3
+    if (order < 3) return NULL;
     BPlusTree* tree = malloc(sizeof(BPlusTree));
     if (!tree) return NULL;
     tree->root = NULL;
@@ -57,7 +19,7 @@ BPlusTree* bplus_tree_create(int order) {
 /* Destroy the B+ Tree */
 void bplus_tree_destroy(BPlusTree* tree) {
     if (!tree) return;
-    destroy_node_recursive(tree->root);
+    bplus_node_destroy_recursive(tree->root);
     free(tree);
 }
 
@@ -106,53 +68,49 @@ static void bplus_update_key(BPlusNode* node, int old_key, int new_key) {
 /* Recursive insert helper */
 static BPlusNode* insert_recurse(BPlusTree* tree, BPlusNode* current, int key, int value, int* promo_key, BPlusNode** promo_node) {
     if (current->is_leaf) {
-        // Check for duplicates
         for (int i = 0; i < current->num_keys; i++) {
             if (current->keys[i] == key) {
                 *promo_node = NULL;
-                return NULL; // Duplicate found, insertion ignored
+                return NULL;
             }
         }
 
-        // Insert in sorted order
         int idx = 0;
         while (idx < current->num_keys && current->keys[idx] < key) {
             idx++;
         }
-        for (int i = current->num_keys; i > idx; i--) {
-            current->keys[i] = current->keys[i - 1];
+        mwst_shift_keys_right(current->keys, current->num_keys, idx);
+        /* shift values right manually since values is int*, not part of mwst */
+        for (int i = current->num_keys; i > idx; i--)
             current->values[i] = current->values[i - 1];
-        }
         current->keys[idx] = key;
         current->values[idx] = value;
         current->num_keys++;
 
-        // Split if overflows
         if (current->num_keys == tree->order) {
-            BPlusNode* right = create_node(tree->order, true);
-            int left_size = (tree->order + 1) / 2;
+            BPlusNode* right = bplus_node_create(tree->order, true);
+            int left_size  = (tree->order + 1) / 2;
             int right_size = tree->order - left_size;
 
             for (int i = 0; i < right_size; i++) {
-                right->keys[i] = current->keys[left_size + i];
+                right->keys[i]   = current->keys[left_size + i];
                 right->values[i] = current->values[left_size + i];
             }
             current->num_keys = left_size;
-            right->num_keys = right_size;
+            right->num_keys   = right_size;
 
             right->next = current->next;
             right->prev = current;
             if (current->next) current->next->prev = right;
             current->next = right;
 
-            *promo_key = right->keys[0];
+            *promo_key  = right->keys[0];
             *promo_node = right;
             return right;
         }
         *promo_node = NULL;
         return NULL;
     } else {
-        // Internal node: find child
         int idx = 0;
         while (idx < current->num_keys && key >= current->keys[idx]) {
             idx++;
@@ -160,42 +118,34 @@ static BPlusNode* insert_recurse(BPlusTree* tree, BPlusNode* current, int key, i
 
         BPlusNode* child_split = insert_recurse(tree, current->children[idx], key, value, promo_key, promo_node);
         if (child_split) {
-            int new_key = *promo_key;
+            int new_key        = *promo_key;
             BPlusNode* new_child = *promo_node;
 
-            // Insert into current internal node
             int ins_idx = 0;
             while (ins_idx < current->num_keys && current->keys[ins_idx] < new_key) {
                 ins_idx++;
             }
-            for (int i = current->num_keys; i > ins_idx; i--) {
-                current->keys[i] = current->keys[i - 1];
-            }
-            for (int i = current->num_keys + 1; i > ins_idx + 1; i--) {
-                current->children[i] = current->children[i - 1];
-            }
-            current->keys[ins_idx] = new_key;
-            current->children[ins_idx + 1] = new_child;
+            mwst_shift_keys_right(current->keys, current->num_keys, ins_idx);
+            mwst_shift_children_right((void **)current->children, current->num_keys, ins_idx + 1);
+            current->keys[ins_idx]          = new_key;
+            current->children[ins_idx + 1]  = new_child;
             current->num_keys++;
 
-            // Split if internal overflows
             if (current->num_keys == tree->order) {
-                BPlusNode* right = create_node(tree->order, false);
-                int left_size = tree->order / 2;
-                int right_size = tree->order - left_size - 1;
-                int pushed_up_key = current->keys[left_size];
+                BPlusNode* right     = bplus_node_create(tree->order, false);
+                int left_size        = tree->order / 2;
+                int right_size       = tree->order - left_size - 1;
+                int pushed_up_key    = current->keys[left_size];
 
-                for (int i = 0; i < right_size; i++) {
+                for (int i = 0; i < right_size; i++)
                     right->keys[i] = current->keys[left_size + 1 + i];
-                }
-                for (int i = 0; i <= right_size; i++) {
+                for (int i = 0; i <= right_size; i++)
                     right->children[i] = current->children[left_size + 1 + i];
-                }
 
                 current->num_keys = left_size;
-                right->num_keys = right_size;
+                right->num_keys   = right_size;
 
-                *promo_key = pushed_up_key;
+                *promo_key  = pushed_up_key;
                 *promo_node = right;
                 return right;
             }
@@ -208,17 +158,13 @@ static BPlusNode* insert_recurse(BPlusTree* tree, BPlusNode* current, int key, i
 /* Insert a key-value pair into the B+ Tree */
 bool bplus_tree_insert(BPlusTree* tree, int key, int value) {
     if (!tree) return false;
-    
-    // Check if duplicate key
-    if (bplus_tree_search(tree, key, NULL)) {
-        return false;
-    }
+    if (bplus_tree_search(tree, key, NULL)) return false;
 
     if (!tree->root) {
-        tree->root = create_node(tree->order, true);
-        tree->root->keys[0] = key;
+        tree->root = bplus_node_create(tree->order, true);
+        tree->root->keys[0]   = key;
         tree->root->values[0] = value;
-        tree->root->num_keys = 1;
+        tree->root->num_keys  = 1;
         return true;
     }
 
@@ -227,161 +173,121 @@ bool bplus_tree_insert(BPlusTree* tree, int key, int value) {
     insert_recurse(tree, tree->root, key, value, &promo_key, &promo_node);
 
     if (promo_node) {
-        // Root split
-        BPlusNode* new_root = create_node(tree->order, false);
-        new_root->keys[0] = promo_key;
-        new_root->children[0] = tree->root;
-        new_root->children[1] = promo_node;
-        new_root->num_keys = 1;
-        tree->root = new_root;
+        BPlusNode* new_root      = bplus_node_create(tree->order, false);
+        new_root->keys[0]        = promo_key;
+        new_root->children[0]    = tree->root;
+        new_root->children[1]    = promo_node;
+        new_root->num_keys       = 1;
+        tree->root               = new_root;
     }
     return true;
 }
 
 /* Recursive delete helper */
-/* Returns: 0 = not found, 1 = deleted without underflow, 2 = deleted and node underflowed */
 static int delete_recurse(BPlusTree* tree, BPlusNode* current, int key) {
     if (current->is_leaf) {
         int idx = -1;
         for (int i = 0; i < current->num_keys; i++) {
-            if (current->keys[i] == key) {
-                idx = i;
-                break;
-            }
+            if (current->keys[i] == key) { idx = i; break; }
         }
-        if (idx == -1) return 0; // Not found
+        if (idx == -1) return 0;
 
         int old_first_key = current->keys[0];
-
-        // Shift keys/values left to delete
-        for (int i = idx; i < current->num_keys - 1; i++) {
-            current->keys[i] = current->keys[i + 1];
+        mwst_shift_keys_left(current->keys, current->num_keys, idx);
+        for (int i = idx; i < current->num_keys - 1; i++)
             current->values[i] = current->values[i + 1];
-        }
         current->num_keys--;
 
-        // If first key changed, update routing key in ancestor index nodes
-        if (idx == 0 && current->num_keys > 0) {
+        if (idx == 0 && current->num_keys > 0)
             bplus_update_key(tree->root, old_first_key, current->keys[0]);
-        }
 
         if (current == tree->root) {
             if (current->num_keys == 0) {
                 tree->root = NULL;
-                free_node(current);
+                bplus_node_free(current);
             }
             return 1;
         }
-
         int leaf_min = tree->order / 2;
         return (current->num_keys < leaf_min) ? 2 : 1;
     } else {
-        // Internal node: find child
         int idx = 0;
-        while (idx < current->num_keys && key >= current->keys[idx]) {
-            idx++;
-        }
+        while (idx < current->num_keys && key >= current->keys[idx]) idx++;
 
         int res = delete_recurse(tree, current->children[idx], key);
-        if (res != 2) return res; // No underflow of child
+        if (res != 2) return res;
 
-        // Handle child underflow
         BPlusNode* child_node = current->children[idx];
-        BPlusNode* left_sib = (idx > 0) ? current->children[idx - 1] : NULL;
-        BPlusNode* right_sib = (idx < current->num_keys) ? current->children[idx + 1] : NULL;
+        BPlusNode* left_sib   = (idx > 0)                  ? current->children[idx - 1] : NULL;
+        BPlusNode* right_sib  = (idx < current->num_keys)  ? current->children[idx + 1] : NULL;
 
         if (child_node->is_leaf) {
             int leaf_min = tree->order / 2;
 
-            // 1. Borrow from left sibling
             if (left_sib && left_sib->num_keys > leaf_min) {
-                for (int i = child_node->num_keys; i > 0; i--) {
-                    child_node->keys[i] = child_node->keys[i - 1];
+                mwst_shift_keys_right(child_node->keys, child_node->num_keys, 0);
+                for (int i = child_node->num_keys; i > 0; i--)
                     child_node->values[i] = child_node->values[i - 1];
-                }
-                child_node->keys[0] = left_sib->keys[left_sib->num_keys - 1];
+                child_node->keys[0]   = left_sib->keys[left_sib->num_keys - 1];
                 child_node->values[0] = left_sib->values[left_sib->num_keys - 1];
                 left_sib->num_keys--;
                 child_node->num_keys++;
-
                 current->keys[idx - 1] = child_node->keys[0];
                 return 1;
             }
 
-            // 2. Borrow from right sibling
             if (right_sib && right_sib->num_keys > leaf_min) {
-                child_node->keys[child_node->num_keys] = right_sib->keys[0];
+                child_node->keys[child_node->num_keys]   = right_sib->keys[0];
                 child_node->values[child_node->num_keys] = right_sib->values[0];
                 child_node->num_keys++;
-
                 int old_r_key = right_sib->keys[0];
-                for (int i = 0; i < right_sib->num_keys - 1; i++) {
-                    right_sib->keys[i] = right_sib->keys[i + 1];
+                mwst_shift_keys_left(right_sib->keys, right_sib->num_keys, 0);
+                for (int i = 0; i < right_sib->num_keys - 1; i++)
                     right_sib->values[i] = right_sib->values[i + 1];
-                }
                 right_sib->num_keys--;
-
                 current->keys[idx] = right_sib->keys[0];
-                // Also update any other routing key occurrences of old_r_key
                 bplus_update_key(tree->root, old_r_key, right_sib->keys[0]);
                 return 1;
             }
 
-            // 3. Merge leaves
             if (left_sib) {
-                // Merge child_node into left_sib
                 for (int i = 0; i < child_node->num_keys; i++) {
-                    left_sib->keys[left_sib->num_keys + i] = child_node->keys[i];
+                    left_sib->keys[left_sib->num_keys + i]   = child_node->keys[i];
                     left_sib->values[left_sib->num_keys + i] = child_node->values[i];
                 }
                 left_sib->num_keys += child_node->num_keys;
                 left_sib->next = child_node->next;
                 if (child_node->next) child_node->next->prev = left_sib;
 
-                // Remove child_node pointer from current
-                for (int i = idx - 1; i < current->num_keys - 1; i++) {
-                    current->keys[i] = current->keys[i + 1];
-                }
-                for (int i = idx; i < current->num_keys; i++) {
-                    current->children[i] = current->children[i + 1];
-                }
+                mwst_shift_keys_left(current->keys, current->num_keys, idx - 1);
+                mwst_shift_children_left((void **)current->children, current->num_keys, idx);
                 current->num_keys--;
-                free_node(child_node);
+                bplus_node_free(child_node);
 
-                if (current == tree->root) {
-                    if (current->num_keys == 0) {
-                        tree->root = left_sib;
-                        free_node(current);
-                    }
+                if (current == tree->root && current->num_keys == 0) {
+                    tree->root = left_sib;
+                    bplus_node_free(current);
                     return 1;
                 }
                 int int_min = (tree->order + 1) / 2 - 1;
                 return (current->num_keys < int_min) ? 2 : 1;
             } else if (right_sib) {
-                // Merge right_sib into child_node
                 for (int i = 0; i < right_sib->num_keys; i++) {
-                    child_node->keys[child_node->num_keys + i] = right_sib->keys[i];
+                    child_node->keys[child_node->num_keys + i]   = right_sib->keys[i];
                     child_node->values[child_node->num_keys + i] = right_sib->values[i];
                 }
                 child_node->num_keys += right_sib->num_keys;
                 child_node->next = right_sib->next;
                 if (right_sib->next) right_sib->next->prev = child_node;
 
-                // Remove right_sib pointer from current
-                for (int i = idx; i < current->num_keys - 1; i++) {
-                    current->keys[i] = current->keys[i + 1];
-                }
-                for (int i = idx + 1; i < current->num_keys; i++) {
-                    current->children[i] = current->children[i + 1];
-                }
+                mwst_shift_keys_left(current->keys, current->num_keys, idx);
+                mwst_shift_children_left((void **)current->children, current->num_keys, idx + 1);
                 current->num_keys--;
-                free_node(right_sib);
+                bplus_node_free(right_sib);
 
-                if (current == tree->root) {
-                    if (current->num_keys == 0) {
-                        tree->root = child_node;
-                        free_node(current);
-                    }
+                if (current == tree->root && current->num_keys == 0) {
+                    tree->root = child_node;
+                    bplus_node_free(current);
                     return 1;
                 }
                 int int_min = (tree->order + 1) / 2 - 1;
@@ -390,100 +296,65 @@ static int delete_recurse(BPlusTree* tree, BPlusNode* current, int key) {
         } else {
             int int_min = (tree->order + 1) / 2 - 1;
 
-            // 1. Borrow from left sibling (internal)
             if (left_sib && left_sib->num_keys > int_min) {
-                for (int i = child_node->num_keys; i > 0; i--) {
-                    child_node->keys[i] = child_node->keys[i - 1];
-                }
-                for (int i = child_node->num_keys + 1; i > 0; i--) {
-                    child_node->children[i] = child_node->children[i - 1];
-                }
-                child_node->keys[0] = current->keys[idx - 1];
+                mwst_shift_keys_right(child_node->keys, child_node->num_keys, 0);
+                mwst_shift_children_right((void **)child_node->children, child_node->num_keys, 0);
+                child_node->keys[0]     = current->keys[idx - 1];
                 child_node->children[0] = left_sib->children[left_sib->num_keys];
                 child_node->num_keys++;
-
                 current->keys[idx - 1] = left_sib->keys[left_sib->num_keys - 1];
                 left_sib->num_keys--;
                 return 1;
             }
 
-            // 2. Borrow from right sibling (internal)
             if (right_sib && right_sib->num_keys > int_min) {
-                child_node->keys[child_node->num_keys] = current->keys[idx];
-                child_node->children[child_node->num_keys + 1] = right_sib->children[0];
+                child_node->keys[child_node->num_keys]             = current->keys[idx];
+                child_node->children[child_node->num_keys + 1]     = right_sib->children[0];
                 child_node->num_keys++;
-
                 current->keys[idx] = right_sib->keys[0];
-                for (int i = 0; i < right_sib->num_keys - 1; i++) {
-                    right_sib->keys[i] = right_sib->keys[i + 1];
-                }
-                for (int i = 0; i < right_sib->num_keys; i++) {
-                    right_sib->children[i] = right_sib->children[i + 1];
-                }
+                mwst_shift_keys_left(right_sib->keys, right_sib->num_keys, 0);
+                mwst_shift_children_left((void **)right_sib->children, right_sib->num_keys, 0);
                 right_sib->num_keys--;
                 return 1;
             }
 
-            // 3. Merge internals
             if (left_sib) {
-                // Merge child_node into left_sib
                 left_sib->keys[left_sib->num_keys] = current->keys[idx - 1];
                 left_sib->num_keys++;
-
-                for (int i = 0; i < child_node->num_keys; i++) {
+                for (int i = 0; i < child_node->num_keys; i++)
                     left_sib->keys[left_sib->num_keys + i] = child_node->keys[i];
-                }
-                for (int i = 0; i <= child_node->num_keys; i++) {
+                for (int i = 0; i <= child_node->num_keys; i++)
                     left_sib->children[left_sib->num_keys + i] = child_node->children[i];
-                }
                 left_sib->num_keys += child_node->num_keys;
 
-                // Remove child_node pointer from current
-                for (int i = idx - 1; i < current->num_keys - 1; i++) {
-                    current->keys[i] = current->keys[i + 1];
-                }
-                for (int i = idx; i < current->num_keys; i++) {
-                    current->children[i] = current->children[i + 1];
-                }
+                mwst_shift_keys_left(current->keys, current->num_keys, idx - 1);
+                mwst_shift_children_left((void **)current->children, current->num_keys, idx);
                 current->num_keys--;
-                free_node(child_node);
+                bplus_node_free(child_node);
 
-                if (current == tree->root) {
-                    if (current->num_keys == 0) {
-                        tree->root = left_sib;
-                        free_node(current);
-                    }
+                if (current == tree->root && current->num_keys == 0) {
+                    tree->root = left_sib;
+                    bplus_node_free(current);
                     return 1;
                 }
                 return (current->num_keys < int_min) ? 2 : 1;
             } else if (right_sib) {
-                // Merge right_sib into child_node
                 child_node->keys[child_node->num_keys] = current->keys[idx];
                 child_node->num_keys++;
-
-                for (int i = 0; i < right_sib->num_keys; i++) {
+                for (int i = 0; i < right_sib->num_keys; i++)
                     child_node->keys[child_node->num_keys + i] = right_sib->keys[i];
-                }
-                for (int i = 0; i <= right_sib->num_keys; i++) {
+                for (int i = 0; i <= right_sib->num_keys; i++)
                     child_node->children[child_node->num_keys + i] = right_sib->children[i];
-                }
                 child_node->num_keys += right_sib->num_keys;
 
-                // Remove right_sib pointer from current
-                for (int i = idx; i < current->num_keys - 1; i++) {
-                    current->keys[i] = current->keys[i + 1];
-                }
-                for (int i = idx + 1; i < current->num_keys; i++) {
-                    current->children[i] = current->children[i + 1];
-                }
+                mwst_shift_keys_left(current->keys, current->num_keys, idx);
+                mwst_shift_children_left((void **)current->children, current->num_keys, idx + 1);
                 current->num_keys--;
-                free_node(right_sib);
+                bplus_node_free(right_sib);
 
-                if (current == tree->root) {
-                    if (current->num_keys == 0) {
-                        tree->root = child_node;
-                        free_node(current);
-                    }
+                if (current == tree->root && current->num_keys == 0) {
+                    tree->root = child_node;
+                    bplus_node_free(current);
                     return 1;
                 }
                 return (current->num_keys < int_min) ? 2 : 1;
@@ -496,16 +367,12 @@ static int delete_recurse(BPlusTree* tree, BPlusNode* current, int key) {
 /* Delete a key from the B+ Tree */
 bool bplus_tree_delete(BPlusTree* tree, int key) {
     if (!tree || !tree->root) return false;
-    int res = delete_recurse(tree, tree->root, key);
-    return res != 0;
+    return delete_recurse(tree, tree->root, key) != 0;
 }
 
 /* Range queries on B+ Tree */
 void bplus_tree_range_query(BPlusTree* tree, int lower, int upper) {
-    if (!tree || !tree->root) {
-        printf("Tree is empty\n");
-        return;
-    }
+    if (!tree || !tree->root) { printf("Tree is empty\n"); return; }
     BPlusNode* leaf = find_leaf(tree->root, lower);
     bool found = false;
     while (leaf) {
@@ -514,16 +381,11 @@ void bplus_tree_range_query(BPlusTree* tree, int lower, int upper) {
                 printf("[%d: %d] ", leaf->keys[i], leaf->values[i]);
                 found = true;
             }
-            if (leaf->keys[i] > upper) {
-                leaf = NULL;
-                break;
-            }
+            if (leaf->keys[i] > upper) { leaf = NULL; break; }
         }
         if (leaf) leaf = leaf->next;
     }
-    if (!found) {
-        printf("No records found in range [%d, %d]", lower, upper);
-    }
+    if (!found) printf("No records found in range [%d, %d]", lower, upper);
     printf("\n");
 }
 
@@ -551,35 +413,23 @@ static void print_level(BPlusNode* node, int current_level, int target_level) {
         return;
     }
     if (!node->is_leaf) {
-        for (int i = 0; i <= node->num_keys; i++) {
+        for (int i = 0; i <= node->num_keys; i++)
             print_level(node->children[i], current_level + 1, target_level);
-        }
     }
 }
 
 /* Print visual level-order structure of the B+ Tree */
 void bplus_tree_print(BPlusTree* tree) {
-    if (!tree || !tree->root) {
-        printf("Empty B+ Tree\n");
-        return;
-    }
+    if (!tree || !tree->root) { printf("Empty B+ Tree\n"); return; }
     int height = get_height(tree->root);
     for (int i = 1; i <= height; i++) {
-        if (i == height) {
-            printf("Level %d (Leaves): ", i);
-        } else {
-            printf("Level %d (Internal): ", i);
-        }
+        printf(i == height ? "Level %d (Leaves): " : "Level %d (Internal): ", i);
         print_level(tree->root, 1, i);
         printf("\n");
     }
-
-    // Print leaf linked list traversal
     printf("Leaf Linked List: ");
     BPlusNode* leaf = tree->root;
-    while (leaf && !leaf->is_leaf) {
-        leaf = leaf->children[0];
-    }
+    while (leaf && !leaf->is_leaf) leaf = leaf->children[0];
     while (leaf) {
         printf("[");
         for (int i = 0; i < leaf->num_keys; i++) {
@@ -598,18 +448,13 @@ void bplus_tree_demo(void) {
     int order;
     while (1) {
         int status = safe_input_int(&order, "\nEnter B+ Tree order (minimum 3, maximum 10), enter '-1' to exit: ", 3, 10);
-        if (status == INPUT_EXIT_SIGNAL) {
-            return;
-        }
+        if (status == INPUT_EXIT_SIGNAL) return;
         if (status == 0) continue;
         break;
     }
 
     BPlusTree* tree = bplus_tree_create(order);
-    if (!tree) {
-        printf("Failed to create B+ Tree\n");
-        return;
-    }
+    if (!tree) { printf("Failed to create B+ Tree\n"); return; }
 
     while (1) {
         int choice;
@@ -624,7 +469,6 @@ void bplus_tree_demo(void) {
             "Enter choice: ",
             1, 5
         );
-
         if (status == INPUT_EXIT_SIGNAL) {
             printf("Exiting B+ Tree demo...\n");
             bplus_tree_destroy(tree);
@@ -639,18 +483,16 @@ void bplus_tree_demo(void) {
                     int s = safe_input_int(&key, "Enter key to insert (positive integer): ", 1, 10000);
                     if (s == INPUT_EXIT_SIGNAL) break;
                     if (s == 0) continue;
-                    
                     while (1) {
                         int s2 = safe_input_int(&val, "Enter corresponding value (positive integer): ", 1, 10000);
                         if (s2 == INPUT_EXIT_SIGNAL) break;
                         if (s2 == 0) continue;
                         break;
                     }
-                    if (bplus_tree_insert(tree, key, val)) {
+                    if (bplus_tree_insert(tree, key, val))
                         printf("Successfully inserted [%d: %d]\n", key, val);
-                    } else {
+                    else
                         printf("Insertion failed! Key %d may already exist.\n", key);
-                    }
                     break;
                 }
                 break;
@@ -661,12 +503,10 @@ void bplus_tree_demo(void) {
                     int s = safe_input_int(&key, "Enter key to delete: ", 1, 10000);
                     if (s == INPUT_EXIT_SIGNAL) break;
                     if (s == 0) continue;
-                    
-                    if (bplus_tree_delete(tree, key)) {
+                    if (bplus_tree_delete(tree, key))
                         printf("Successfully deleted key %d\n", key);
-                    } else {
+                    else
                         printf("Key %d not found in tree.\n", key);
-                    }
                     break;
                 }
                 break;
@@ -677,12 +517,10 @@ void bplus_tree_demo(void) {
                     int s = safe_input_int(&key, "Enter key to search: ", 1, 10000);
                     if (s == INPUT_EXIT_SIGNAL) break;
                     if (s == 0) continue;
-                    
-                    if (bplus_tree_search(tree, key, &val)) {
+                    if (bplus_tree_search(tree, key, &val))
                         printf("Found key %d with value: %d\n", key, val);
-                    } else {
+                    else
                         printf("Key %d not found.\n", key);
-                    }
                     break;
                 }
                 break;
@@ -693,7 +531,6 @@ void bplus_tree_demo(void) {
                     int s = safe_input_int(&lower, "Enter lower bound key: ", 1, 10000);
                     if (s == INPUT_EXIT_SIGNAL) break;
                     if (s == 0) continue;
-                    
                     while (1) {
                         int s2 = safe_input_int(&upper, "Enter upper bound key: ", lower, 10000);
                         if (s2 == INPUT_EXIT_SIGNAL) break;

--- a/src/trees/mwst_utils.c
+++ b/src/trees/mwst_utils.c
@@ -1,0 +1,103 @@
+#include "mwst_utils.h"
+#include <stdlib.h>
+#include <stdbool.h>
+
+/* Shift keys right from index 'from' to make room for a new key */
+void mwst_shift_keys_right(int *keys, int num_keys, int from)
+{
+    for (int i = num_keys - 1; i >= from; i--)
+        keys[i + 1] = keys[i];
+}
+
+/* Shift keys left from index 'from' to fill a deleted key */
+void mwst_shift_keys_left(int *keys, int num_keys, int from)
+{
+    for (int i = from + 1; i < num_keys; i++)
+        keys[i - 1] = keys[i];
+}
+
+/* Shift child pointers right from index 'from' */
+void mwst_shift_children_right(void **children, int num_keys, int from)
+{
+    for (int i = num_keys; i >= from; i--)
+        children[i + 1] = children[i];
+}
+
+/* Shift child pointers left from index 'from' */
+void mwst_shift_children_left(void **children, int num_keys, int from)
+{
+    for (int i = from + 1; i <= num_keys; i++)
+        children[i - 1] = children[i];
+}
+
+/* Allocate a new B+ Tree node */
+BPlusNode *bplus_node_create(int order, bool is_leaf)
+{
+    BPlusNode *node = malloc(sizeof(BPlusNode));
+    if (!node) return NULL;
+    node->is_leaf  = is_leaf;
+    node->num_keys = 0;
+    node->keys     = calloc(order, sizeof(int));
+    if (is_leaf) {
+        node->values   = calloc(order, sizeof(int));
+        node->children = NULL;
+    } else {
+        node->values   = NULL;
+        node->children = calloc(order + 1, sizeof(BPlusNode *));
+    }
+    node->next = NULL;
+    node->prev = NULL;
+    return node;
+}
+
+/* Free a single B+ Tree node (does not touch children) */
+void bplus_node_free(BPlusNode *node)
+{
+    if (!node) return;
+    if (node->keys)     free(node->keys);
+    if (node->values)   free(node->values);
+    if (node->children) free(node->children);
+    free(node);
+}
+
+/* Recursively destroy a B+ Tree node and all its descendants */
+void bplus_node_destroy_recursive(BPlusNode *node)
+{
+    if (!node) return;
+    if (!node->is_leaf) {
+        for (int i = 0; i <= node->num_keys; i++)
+            bplus_node_destroy_recursive(node->children[i]);
+    }
+    bplus_node_free(node);
+}
+
+/* Validate that keys in a node are in strictly ascending order */
+bool bplus_validate_key_ordering(BPlusNode *node)
+{
+    if (!node) return true;
+    for (int i = 0; i < node->num_keys - 1; i++) {
+        if (node->keys[i] >= node->keys[i + 1])
+            return false;
+    }
+    return true;
+}
+
+/* Validate that an internal node has exactly num_keys + 1 children */
+bool bplus_validate_child_count(BPlusNode *node)
+{
+    if (!node || node->is_leaf) return true;
+    for (int i = 0; i <= node->num_keys; i++) {
+        if (!node->children[i])
+            return false;
+    }
+    return true;
+}
+
+/* Validate that leaf linked list prev/next pointers are consistent */
+bool bplus_validate_leaf_links(BPlusNode *node)
+{
+    if (!node) return true;
+    if (node->next && node->next->prev != node) return false;
+    if (node->prev && node->prev->next != node) return false;
+    return true;
+}

--- a/src/trees/mwst_utils.h
+++ b/src/trees/mwst_utils.h
@@ -1,0 +1,29 @@
+#ifndef MWST_UTILS_H
+#define MWST_UTILS_H
+
+#include "trees.h"
+
+/* -------------------------------------------------------
+ * Shared utilities for multi-way search trees
+ * Used by both B-Tree (btree.c) and B+ Tree (bplus_tree.c)
+ * ------------------------------------------------------- */
+
+/* Key array shifts */
+void mwst_shift_keys_right(int *keys, int num_keys, int from);
+void mwst_shift_keys_left(int *keys, int num_keys, int from);
+
+/* Child pointer array shifts (for internal nodes) */
+void mwst_shift_children_right(void **children, int num_keys, int from);
+void mwst_shift_children_left(void **children, int num_keys, int from);
+
+/* B+ Tree node allocation / destruction */
+BPlusNode *bplus_node_create(int order, bool is_leaf);
+void       bplus_node_free(BPlusNode *node);
+void       bplus_node_destroy_recursive(BPlusNode *node);
+
+/* B+ Tree invariant validators (debug builds) */
+bool bplus_validate_key_ordering(BPlusNode *node);
+bool bplus_validate_child_count(BPlusNode *node);
+bool bplus_validate_leaf_links(BPlusNode *node);
+
+#endif


### PR DESCRIPTION
Closes #180

## What this PR does
Extracts shared multi-way search tree utilities from bplus_tree.c into a new mwst_utils.h/c file to prevent code duplication with the upcoming B-Tree implementation.

## Changes
- Added mwst_utils.h/c with shared key and child pointer shift helpers
- Added bplus_node_create, bplus_node_free, bplus_node_destroy_recursive
- Added invariant validators for key ordering, child count, and leaf linked list consistency
- Refactored bplus_tree.c to use shared helpers instead of inline loops

## Testing
- Compiled with -Wall -Wextra -Werror, zero warnings
- Manually tested insert, delete, search, range query on B+ Tree
- Verified with Valgrind: 0 errors, 0 memory leaks