### PR TITLE
Extend benchmark history logger to graph traversals (BFS / DFS)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -192,7 +192,7 @@ $(TEST_DIR)/test_deque$(EXE): $(OBJ_DIR)/src/data_structures/deque.o $(OBJ_DIR)/
 test_astar: $(TEST_DIR)/test_astar$(EXE)
 	$(TEST_DIR)/test_astar$(EXE)
 
-$(TEST_DIR)/test_astar$(EXE): $(OBJ_DIR)/src/graph_traversals/astar.o $(OBJ_DIR)/src/graph_traversals/dijkstra.o $(OBJ_DIR)/src/utils/graph_io.o $(OBJ_DIR)/src/graph_traversals/bfs.o $(OBJ_DIR)/src/data_structures/circular_queue.o $(OBJ_DIR)/src/data_structures/sll.o $(OBJ_DIR)/src/utils/safe_input_int.o tests/test_astar.c
+$(TEST_DIR)/test_astar$(EXE): $(OBJ_DIR)/src/graph_traversals/astar.o $(OBJ_DIR)/src/graph_traversals/dijkstra.o $(OBJ_DIR)/src/utils/graph_io.o $(OBJ_DIR)/src/graph_traversals/bfs.o $(OBJ_DIR)/src/data_structures/circular_queue.o $(OBJ_DIR)/src/data_structures/sll.o $(OBJ_DIR)/src/utils/safe_input_int.o $(OBJ_DIR)/src/utils/history_logger.o tests/test_astar.c
 	@$(call MKDIR_P,$(TEST_DIR))
 	$(CC) $(CFLAGS) $^ -o $@
 
@@ -220,7 +220,7 @@ $(TEST_DIR)/test_btree$(EXE): $(OBJ_DIR)/src/trees/btree.o $(OBJ_DIR)/src/utils/
 test_greedy_bfs: $(TEST_DIR)/test_greedy_bfs$(EXE)
 	$(TEST_DIR)/test_greedy_bfs$(EXE)
 
-$(TEST_DIR)/test_greedy_bfs$(EXE): $(OBJ_DIR)/src/graph_traversals/greedy_best_first_search.o $(OBJ_DIR)/src/graph_traversals/dijkstra.o $(OBJ_DIR)/src/utils/graph_io.o $(OBJ_DIR)/src/graph_traversals/bfs.o $(OBJ_DIR)/src/data_structures/circular_queue.o $(OBJ_DIR)/src/data_structures/sll.o $(OBJ_DIR)/src/utils/safe_input_int.o tests/test_greedy_best_first_search.c
+$(TEST_DIR)/test_greedy_bfs$(EXE): $(OBJ_DIR)/src/graph_traversals/greedy_best_first_search.o $(OBJ_DIR)/src/graph_traversals/dijkstra.o $(OBJ_DIR)/src/utils/graph_io.o $(OBJ_DIR)/src/graph_traversals/bfs.o $(OBJ_DIR)/src/data_structures/circular_queue.o $(OBJ_DIR)/src/data_structures/sll.o $(OBJ_DIR)/src/utils/safe_input_int.o $(OBJ_DIR)/src/utils/history_logger.o tests/test_greedy_best_first_search.c
 	@$(call MKDIR_P,$(TEST_DIR))
 	$(CC) $(CFLAGS) $^ -o $@
 

--- a/src/graph_traversals/bfs.c
+++ b/src/graph_traversals/bfs.c
@@ -1,11 +1,16 @@
 #include "data_structures.h"
 #include "graph_io.h"
 #include "graph_traversals.h"
+#include "history_logger.h"
 #include "safe_input.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <time.h>
 
+// note: the time measured by clock() includes the traversal computation and the printing of each
+// visited node. the CPU time is for demonstration only and must not be treated as a measure of the
+// algorithm's efficiency.
 void bfs(Graph* graph, int start)
 {
     int size = graph->V;
@@ -27,6 +32,11 @@ void bfs(Graph* graph, int start)
         printf("\nerror initializing queue. returning....");
         return;
     }
+
+    clock_t start_t, end_t;
+    double total_t;
+
+    start_t = clock();
 
     visited[start] = 1;
     enqueue(&nodes, start);
@@ -53,7 +63,12 @@ void bfs(Graph* graph, int start)
         }
     }
 
+    end_t = clock();
+    total_t = (double)(end_t - start_t) / CLOCKS_PER_SEC;
+
     printf("end\n");
+    printf("\ntotal CPU time taken for BFS traversal:- %f seconds\n", total_t);
+    add_to_history("BFS", size, total_t);
     destroy_circ_queue(&nodes);
 }
 

--- a/src/graph_traversals/dfs.c
+++ b/src/graph_traversals/dfs.c
@@ -1,9 +1,11 @@
 #include "graph_io.h"
 #include "graph_traversals.h"
+#include "history_logger.h"
 #include "safe_input.h"
 #include "stack.h"
 #include <stdio.h>
 #include <string.h>
+#include <time.h>
 
 void dfs(Graph* graph, int start);
 
@@ -198,6 +200,9 @@ void dfs_demo(void)
     dfs(graph, starting_node);
     free_graph(graph);
 }
+// note: the time measured by clock() includes the traversal computation and the printing of each
+// visited node. the CPU time is for demonstration only and must not be treated as a measure of the
+// algorithm's efficiency.
 void dfs(Graph* graph, int start)
 {
     int size = graph->V;
@@ -219,6 +224,11 @@ void dfs(Graph* graph, int start)
         printf("stack could not be initialized due to a malloc failure");
         return;
     }
+
+    clock_t start_t, end_t;
+    double total_t;
+
+    start_t = clock();
 
     visited[start] = 1;
     push(nodes, start);
@@ -245,7 +255,13 @@ void dfs(Graph* graph, int start)
             temp = temp->next;
         }
     }
+
+    end_t = clock();
+    total_t = (double)(end_t - start_t) / CLOCKS_PER_SEC;
+
     printf("end\n");
+    printf("\ntotal CPU time taken for DFS traversal:- %f seconds\n", total_t);
+    add_to_history("DFS", size, total_t);
     destroyStack(nodes);
     return;
 }


### PR DESCRIPTION
Closes #216

## What

Extends the benchmark history logger to the graph traversal algorithms. BFS and DFS now record their CPU time to `output/benchmark_history.csv`, consistent with the sorting and searching modules.

## Changes

- `src/graph_traversals/bfs.c`: time the traversal loop with `clock()`, print the CPU time, and call `add_to_history("BFS", graph->V, total_t)`.
- `src/graph_traversals/dfs.c`: same treatment, logging as `"DFS"`.
- `Makefile`: add `history_logger.o` to the link line of `test_astar` and `test_greedy_bfs` (both compile `bfs.o`, which now references `add_to_history`).

The number of vertices (`graph->V`) is used as the input size, mirroring how the sorting modules pass array length.

## Testing

- `make` builds clean with `-Werror`.
- `make test` — all tests pass.
- `make valgrind` — no leaks or errors.
- Drove the BFS and DFS demos interactively; verified rows are appended, e.g. `BFS,4,0.000005,<timestamp>` and `DFS,4,0.000003,<timestamp>`.
