### PR TITLE
Add time complexity for graph algorithms

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,11 +174,10 @@ Quadratic Probing resolves collisions by using quadratic increments (i²) to red
 * BFS: **O(V+E)**
 * DFS: **O(V+E)**
 * Dijkstra's Algorithm: **O((V+E)log V)**
-
-### Threaded Binary Tree (TBT)
-* Binary tree with threads replacing NULL pointers
-* Enables efficient inorder traversal without recursion or stack
-* Search, insertion, and deletion remain O(h), similar to BST
+* A* Search: **O((V+E)log V)**
+* Greedy Best-First Search: **O((V+E)log V)**
+* Bellman-Ford: **O(V·E)**
+* Topological Sort (Kahn's Algorithm): **O(V+E)**
 
 ---
 


### PR DESCRIPTION
Closes #215

## What

Updates the **Time Complexity** section of the README for the graph algorithms.

## Changes

- Added time complexities for the graph algorithms that were missing from the list:
  - A* Search: **O((V+E)log V)**
  - Greedy Best-First Search: **O((V+E)log V)**
  - Bellman-Ford: **O(V·E)**
  - Topological Sort (Kahn's Algorithm): **O(V+E)**
- Removed the Threaded Binary Tree (TBT) block from the Time Complexity section, as requested in the issue.

Only the algorithms actually exposed through the graph traversals demo menu (bfs, dfs, dijkstra, astar, greedy-bfs, bellman-ford, topological-sort) are listed.
