### PR TITLE
Extend benchmark history logger to CPU scheduling algorithms

### DIFF
--- a/src/job_scheduling/fcfs.c
+++ b/src/job_scheduling/fcfs.c
@@ -1,9 +1,15 @@
+#include "history_logger.h"
 #include "job_scheduling.h"
 #include <stdio.h>
+#include <time.h>
 
 // First-Come-First-Served: run the processes in arrival order (ties broken by
 // the order they were entered). The CPU idles forward to the next arrival if it
 // would otherwise be free.
+// note: the time measured by clock() covers the scheduling computation only (it
+// starts after the process list is read and stops before the results are
+// printed). it is for demonstration only and must not be treated as a measure
+// of the algorithm's efficiency.
 void fcfs_demo(void)
 {
     Process procs[10];
@@ -14,6 +20,11 @@ void fcfs_demo(void)
         printf("\nExiting FCFS demo....\n");
         return;
     }
+
+    clock_t start_t, end_t;
+    double total_t;
+
+    start_t = clock();
 
     // selection-style ordering by arrival time, keeping input order on ties
     for (int i = 0; i < n - 1; i++)
@@ -60,6 +71,11 @@ void fcfs_demo(void)
         procs[i].waiting = procs[i].turnaround - procs[i].burst;
     }
 
+    end_t = clock();
+    total_t = (double)(end_t - start_t) / CLOCKS_PER_SEC;
+
     js_print_result(procs, n);
     js_print_gantt(segments, segment_count);
+    printf("\ntotal CPU time taken for FCFS scheduling:- %f seconds\n", total_t);
+    add_to_history("FCFS Scheduling", n, total_t);
 }

--- a/src/job_scheduling/preemptive_priority.c
+++ b/src/job_scheduling/preemptive_priority.c
@@ -1,11 +1,15 @@
+#include "history_logger.h"
 #include "job_scheduling.h"
 #include <stdio.h>
+#include <time.h>
 
 // Preemptive priority scheduling: at every time unit run the arrived,
 // unfinished job with the highest priority (lowest priority number) for one
 // tick, so a higher-priority arrival preempts the running job. Ties are broken
 // by earlier arrival, then input order, so an equal-priority arrival does not
 // preempt the running job.
+// note: the time measured by clock() covers the scheduling computation only and
+// is for demonstration only, not a measure of the algorithm's efficiency.
 void preemptive_priority_demo(void)
 {
     Process procs[10];
@@ -16,6 +20,11 @@ void preemptive_priority_demo(void)
         printf("\nExiting preemptive priority demo....\n");
         return;
     }
+
+    clock_t start_t, end_t;
+    double total_t;
+
+    start_t = clock();
 
     GanttSegment segments[JS_MAX_SEGMENTS];
     int segment_count = 0;
@@ -62,6 +71,11 @@ void preemptive_priority_demo(void)
         }
     }
 
+    end_t = clock();
+    total_t = (double)(end_t - start_t) / CLOCKS_PER_SEC;
+
     js_print_result(procs, n);
     js_print_gantt(segments, segment_count);
+    printf("\ntotal CPU time taken for preemptive priority scheduling:- %f seconds\n", total_t);
+    add_to_history("Preemptive Priority Scheduling", n, total_t);
 }

--- a/src/job_scheduling/priority_scheduling.c
+++ b/src/job_scheduling/priority_scheduling.c
@@ -1,9 +1,13 @@
+#include "history_logger.h"
 #include "job_scheduling.h"
 #include <stdio.h>
+#include <time.h>
 
 // Priority scheduling, non-preemptive: among the jobs that have arrived, run
 // the one with the highest priority (lowest priority number) to completion.
 // Ties are broken by earlier arrival.
+// note: the time measured by clock() covers the scheduling computation only and
+// is for demonstration only, not a measure of the algorithm's efficiency.
 void priority_scheduling_demo(void)
 {
     Process procs[10];
@@ -14,6 +18,11 @@ void priority_scheduling_demo(void)
         printf("\nExiting priority scheduling demo....\n");
         return;
     }
+
+    clock_t start_t, end_t;
+    double total_t;
+
+    start_t = clock();
 
     GanttSegment segments[JS_MAX_SEGMENTS];
     int segment_count = 0;
@@ -61,6 +70,11 @@ void priority_scheduling_demo(void)
         completed++;
     }
 
+    end_t = clock();
+    total_t = (double)(end_t - start_t) / CLOCKS_PER_SEC;
+
     js_print_result(procs, n);
     js_print_gantt(segments, segment_count);
+    printf("\ntotal CPU time taken for priority scheduling:- %f seconds\n", total_t);
+    add_to_history("Priority Scheduling", n, total_t);
 }

--- a/src/job_scheduling/round_robin.c
+++ b/src/job_scheduling/round_robin.c
@@ -1,10 +1,15 @@
+#include "history_logger.h"
 #include "job_scheduling.h"
 #include "safe_input.h"
 #include <stdio.h>
+#include <time.h>
 
 // Round Robin: processes share the CPU in fixed time slices (the quantum). A
 // job that does not finish within its slice goes to the back of the ready
 // queue. Jobs become ready at their arrival time; ties keep input order.
+// note: the time measured by clock() covers the scheduling computation only (it
+// starts after the quantum is read) and is for demonstration only, not a
+// measure of the algorithm's efficiency.
 void round_robin_demo(void)
 {
     Process procs[10];
@@ -34,6 +39,11 @@ void round_robin_demo(void)
         }
         break;
     }
+
+    clock_t start_t, end_t;
+    double total_t;
+
+    start_t = clock();
 
     GanttSegment segments[JS_MAX_SEGMENTS];
     int segment_count = 0;
@@ -139,6 +149,11 @@ void round_robin_demo(void)
         }
     }
 
+    end_t = clock();
+    total_t = (double)(end_t - start_t) / CLOCKS_PER_SEC;
+
     js_print_result(procs, n);
     js_print_gantt(segments, segment_count);
+    printf("\ntotal CPU time taken for round robin scheduling:- %f seconds\n", total_t);
+    add_to_history("Round Robin Scheduling", n, total_t);
 }

--- a/src/job_scheduling/sjf.c
+++ b/src/job_scheduling/sjf.c
@@ -1,8 +1,12 @@
+#include "history_logger.h"
 #include "job_scheduling.h"
 #include <stdio.h>
+#include <time.h>
 
 // Shortest Job First, non-preemptive: at each step pick the shortest-burst job
 // among those that have already arrived; once started it runs to completion.
+// note: the time measured by clock() covers the scheduling computation only and
+// is for demonstration only, not a measure of the algorithm's efficiency.
 void sjf_demo(void)
 {
     Process procs[10];
@@ -13,6 +17,11 @@ void sjf_demo(void)
         printf("\nExiting SJF demo....\n");
         return;
     }
+
+    clock_t start_t, end_t;
+    double total_t;
+
+    start_t = clock();
 
     GanttSegment segments[JS_MAX_SEGMENTS];
     int segment_count = 0;
@@ -59,6 +68,11 @@ void sjf_demo(void)
         completed++;
     }
 
+    end_t = clock();
+    total_t = (double)(end_t - start_t) / CLOCKS_PER_SEC;
+
     js_print_result(procs, n);
     js_print_gantt(segments, segment_count);
+    printf("\ntotal CPU time taken for SJF scheduling:- %f seconds\n", total_t);
+    add_to_history("SJF Scheduling", n, total_t);
 }

--- a/src/job_scheduling/srtf.c
+++ b/src/job_scheduling/srtf.c
@@ -1,11 +1,15 @@
+#include "history_logger.h"
 #include "job_scheduling.h"
 #include <stdio.h>
+#include <time.h>
 
 // Shortest Remaining Time First (preemptive SJF): at every time unit pick the
 // arrived, unfinished job with the smallest remaining time and run it for one
 // tick. A newly arrived shorter job therefore preempts the running one. Ties
 // are broken by earlier arrival, then input order, so the running job is not
 // preempted by an equal-remaining peer.
+// note: the time measured by clock() covers the scheduling computation only and
+// is for demonstration only, not a measure of the algorithm's efficiency.
 void srtf_demo(void)
 {
     Process procs[10];
@@ -16,6 +20,11 @@ void srtf_demo(void)
         printf("\nExiting SRTF demo....\n");
         return;
     }
+
+    clock_t start_t, end_t;
+    double total_t;
+
+    start_t = clock();
 
     GanttSegment segments[JS_MAX_SEGMENTS];
     int segment_count = 0;
@@ -62,6 +71,11 @@ void srtf_demo(void)
         }
     }
 
+    end_t = clock();
+    total_t = (double)(end_t - start_t) / CLOCKS_PER_SEC;
+
     js_print_result(procs, n);
     js_print_gantt(segments, segment_count);
+    printf("\ntotal CPU time taken for SRTF scheduling:- %f seconds\n", total_t);
+    add_to_history("SRTF Scheduling", n, total_t);
 }


### PR DESCRIPTION
Closes #219

## What

Extends the benchmark history logger to the CPU scheduling algorithms. All six schedulers now record their CPU time to `output/benchmark_history.csv`, consistent with the sorting and searching modules.

## Changes

Each scheduler times its scheduling computation with `clock()` and calls `add_to_history(name, n, total_t)` with the process count as the input size:

- `fcfs.c` → `"FCFS Scheduling"`
- `sjf.c` → `"SJF Scheduling"`
- `srtf.c` → `"SRTF Scheduling"`
- `priority_scheduling.c` → `"Priority Scheduling"`
- `preemptive_priority.c` → `"Preemptive Priority Scheduling"`
- `round_robin.c` → `"Round Robin Scheduling"`

Timing starts after the process list is read (and after the quantum is read, for round robin) and stops before the results / Gantt chart are printed, so user input time is excluded from the measurement.

## Testing

- `make` builds clean with `-Werror`.
- `make test` — all tests pass.
- `make valgrind` — no leaks or errors.
- Drove the FCFS and round robin demos interactively; verified rows are appended, e.g. `FCFS Scheduling,2,0.000001,<timestamp>` and `Round Robin Scheduling,2,0.000001,<timestamp>`.
