### PR TITLE
Extend benchmark history logger to remaining graph algorithms

### DIFF
--- a/src/graph_traversals/astar.c
+++ b/src/graph_traversals/astar.c
@@ -1,10 +1,12 @@
 #include "graph_io.h"
 #include "graph_traversals.h"
+#include "history_logger.h"
 #include "safe_input.h"
 #include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <time.h>
 
 int astar_solve(weightedGraph* graph, int start, int dest, int h[], int parent[])
 {
@@ -103,6 +105,9 @@ int astar_solve(weightedGraph* graph, int start, int dest, int h[], int parent[]
     return result;
 }
 
+// note: the time measured by clock() covers the A* search computation only (the
+// astar_solve call); it excludes path reconstruction and printing. it is for
+// demonstration only and must not be treated as a measure of efficiency.
 void astar(weightedGraph* graph, int start, int dest, int h[])
 {
     int size = graph->V;
@@ -113,7 +118,16 @@ void astar(weightedGraph* graph, int start, int dest, int h[])
         return;
     }
 
+    clock_t start_t, end_t;
+    double total_t;
+
+    start_t = clock();
     int cost = astar_solve(graph, start, dest, h, parent);
+    end_t = clock();
+    total_t = (double)(end_t - start_t) / CLOCKS_PER_SEC;
+
+    printf("\ntotal CPU time taken for A* search:- %f seconds\n", total_t);
+    add_to_history("A* Search", size, total_t);
 
     if (cost == INT_MAX || cost < 0)
     {

--- a/src/graph_traversals/bellman_ford.c
+++ b/src/graph_traversals/bellman_ford.c
@@ -1,8 +1,13 @@
 #include "graph_traversals.h"
+#include "history_logger.h"
 #include "safe_input.h"
 #include <limits.h>
 #include <stdio.h>
+#include <time.h>
 
+// note: the time measured by clock() covers the shortest-path computation,
+// including the negative-cycle check, and stops before the distance table is
+// printed. it is for demonstration only and not a measure of efficiency.
 void bellman_ford(weightedGraph* graph, int start)
 {
     int size = graph->V;
@@ -13,6 +18,11 @@ void bellman_ford(weightedGraph* graph, int start)
         dist[i] = INT_MAX;
 
     dist[start] = 0;
+
+    clock_t start_t, end_t;
+    double total_t;
+
+    start_t = clock();
 
     for (int count = 0; count < size - 1; count++)
     {
@@ -43,13 +53,20 @@ void bellman_ford(weightedGraph* graph, int start)
             int weight = current->weight;
             if (dist[u] != INT_MAX && dist[u] + weight < dist[v])
             {
+                end_t = clock();
+                total_t = (double)(end_t - start_t) / CLOCKS_PER_SEC;
                 printf("Negative edge cycle detected. Graph is not suitable for bellman ford.\n");
+                printf("\ntotal CPU time taken for Bellman-Ford:- %f seconds\n", total_t);
+                add_to_history("Bellman-Ford", size, total_t);
                 return;
             }
 
             current = current->next;
         }
     }
+
+    end_t = clock();
+    total_t = (double)(end_t - start_t) / CLOCKS_PER_SEC;
 
     // Print vertex, distance stuff
     printf("Start -> Vertex  \t  Distance\n");
@@ -62,6 +79,9 @@ void bellman_ford(weightedGraph* graph, int start)
         else
             printf("    %d -> %d  \t             %d   \n", start, i, dist[i]);
     }
+
+    printf("\ntotal CPU time taken for Bellman-Ford:- %f seconds\n", total_t);
+    add_to_history("Bellman-Ford", size, total_t);
 }
 
 void bellman_ford_demo(void)

--- a/src/graph_traversals/dijkstra.c
+++ b/src/graph_traversals/dijkstra.c
@@ -1,10 +1,12 @@
 #include "graph_io.h"
 #include "graph_traversals.h"
+#include "history_logger.h"
 #include "safe_input.h"
 #include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <time.h>
 
 // Min-heap ordering for PQ_graph: a node has higher priority when its
 // "distance" (used as a generic priority: g+h for A*, h for Greedy, path
@@ -83,6 +85,9 @@ bool extractTop_pq_graph(PQ_graph* pq, PQ_graph_node* result)
     return true;
 }
 
+// note: the time measured by clock() covers the shortest-path computation only
+// (it stops before the distance table is printed). it is for demonstration only
+// and must not be treated as a measure of the algorithm's efficiency.
 void dijkstra(weightedGraph* graph, int start)
 {
     int size = graph->V;
@@ -95,6 +100,12 @@ void dijkstra(weightedGraph* graph, int start)
 
     PQ_graph pq;
     pq.size = 0;
+
+    clock_t start_t, end_t;
+    double total_t;
+
+    start_t = clock();
+
     insert_pq_graph(&pq, start, 0);
 
     PQ_graph_node currentNode;
@@ -122,6 +133,9 @@ void dijkstra(weightedGraph* graph, int start)
         }
     }
 
+    end_t = clock();
+    total_t = (double)(end_t - start_t) / CLOCKS_PER_SEC;
+
     printf("Start -> Vertex  \t  Distance\n");
     printf("---------------  \t  --------\n");
 
@@ -132,6 +146,9 @@ void dijkstra(weightedGraph* graph, int start)
         else
             printf("    %d -> %d  \t             %d   \n", start, i, dist[i]);
     }
+
+    printf("\ntotal CPU time taken for Dijkstra's algorithm:- %f seconds\n", total_t);
+    add_to_history("Dijkstra", size, total_t);
 }
 
 weightedGraph* create_weightedGraph(int V)

--- a/src/graph_traversals/greedy_best_first_search.c
+++ b/src/graph_traversals/greedy_best_first_search.c
@@ -1,10 +1,12 @@
 #include "graph_io.h"
 #include "graph_traversals.h"
+#include "history_logger.h"
 #include "safe_input.h"
 #include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <time.h>
 
 int greedy_best_first_search_solve(weightedGraph* graph, int start, int dest, int h[], int parent[],
                                    int traversal_order[], int* traversal_len)
@@ -71,6 +73,9 @@ int greedy_best_first_search_solve(weightedGraph* graph, int start, int dest, in
     return found;
 }
 
+// note: the time measured by clock() covers the search computation only (the
+// greedy_best_first_search_solve call); it excludes path reconstruction and
+// printing. it is for demonstration only and not a measure of efficiency.
 void greedy_best_first_search(weightedGraph* graph, int start, int dest, int h[])
 {
     int size = graph->V;
@@ -86,8 +91,17 @@ void greedy_best_first_search(weightedGraph* graph, int start, int dest, int h[]
         return;
     }
 
+    clock_t start_t, end_t;
+    double total_t;
+
+    start_t = clock();
     int found = greedy_best_first_search_solve(graph, start, dest, h, parent, traversal_order,
                                                &traversal_len);
+    end_t = clock();
+    total_t = (double)(end_t - start_t) / CLOCKS_PER_SEC;
+
+    printf("\ntotal CPU time taken for greedy best-first search:- %f seconds\n", total_t);
+    add_to_history("Greedy Best-First Search", size, total_t);
 
     printf("Traversal Order: ");
     for (int i = 0; i < traversal_len; i++)


### PR DESCRIPTION
Closes #221

## What

Completes benchmark history logging for the graph algorithms. Building on the merged BFS/DFS logging, the remaining graph algorithms now record their CPU time to `output/benchmark_history.csv`.

## Changes

Each algorithm times its core computation with `clock()` and calls `add_to_history(name, graph->V, total_t)` with the vertex count as the input size:

- `dijkstra.c` → `"Dijkstra"`
- `astar.c` → `"A* Search"` (times the `astar_solve` call)
- `greedy_best_first_search.c` → `"Greedy Best-First Search"` (times the `_solve` call)
- `bellman_ford.c` → `"Bellman-Ford"`

Timing brackets the shortest-path / search computation and stops before the result table or path is printed, so printing and interactive input are excluded. For Bellman-Ford, the negative-cycle early-return path also logs before returning, so every run is recorded.

`floyd_warshall.c` is intentionally excluded — it is not wired into any menu/header and has been removed.

## Testing

- `make` builds clean with `-Werror`.
- `make test` — all tests pass (includes `test_astar` and `test_greedy_bfs`, which exercise the A* and greedy code).
- `make valgrind` — no leaks or errors.
- Drove Dijkstra, A* and Bellman-Ford demos interactively; verified rows are appended, e.g. `Dijkstra,3,...`, `A* Search,3,...`, `Bellman-Ford,3,...`.
