### PR TITLE
Fix stack out-of-bounds read (buffer underflow) in CRC Receiver

### DIFF
--- a/src/error_correction_algorithms/crc_receiver.c
+++ b/src/error_correction_algorithms/crc_receiver.c
@@ -59,6 +59,14 @@ void crc_receiver_demo(void)
             continue;
         }
 
+        int codeword_len = (int)strlen(received_codeword);
+        if (codeword_len < generator_len)
+        {
+            printf("\nError: codeword length (%d) must be at least as long as the generator polynomial (%d).\n", 
+                   codeword_len, generator_len);
+            continue;
+        }
+
         char dividend[(CHECKSUM_MAX_BITS * 2) + 1];
         strcpy(dividend, received_codeword);
 


### PR DESCRIPTION

***
resolves : #223 
## Description
This pull request fixes a critical stack out-of-bounds read (buffer underflow) vulnerability in the CRC receiver verification module that occurred when the received codeword was shorter than the generator polynomial.

## Key Changes
* **Validation Check**: Updated [crc_receiver.c](file:///Users/akshatshukla/Downloads/Work/open/C_DSA_interactive_suite.git/src/error_correction_algorithms/crc_receiver.c) to validate that the received codeword length is at least as long as the generator polynomial length before performing modulo-2 division or copying the remainder.
* **Error Handling**: When the validation check fails, the receiver displays a clean error message and continues to prompt instead of executing unsafe stack read operations.

## Verification & Testing
* Compiled the full project cleanly without errors or warnings.
* Ran the interactive demo (`./dsa`) and verified that inputting a codeword shorter than the generator polynomial is handled correctly and does not crash.