### PR TITLE
Fix missing memory allocation checks in B+ Tree node allocation

### DIFF
--- a/src/trees/mwst_utils.c
+++ b/src/trees/mwst_utils.c
@@ -38,16 +38,35 @@ BPlusNode* bplus_node_create(int order, bool is_leaf)
         return NULL;
     node->is_leaf = is_leaf;
     node->num_keys = 0;
+    
     node->keys = calloc(order, sizeof(int));
+    if (!node->keys)
+    {
+        free(node);
+        return NULL;
+    }
+
     if (is_leaf)
     {
         node->values = calloc(order, sizeof(int));
+        if (!node->values)
+        {
+            free(node->keys);
+            free(node);
+            return NULL;
+        }
         node->children = NULL;
     }
     else
     {
         node->values = NULL;
         node->children = calloc(order + 1, sizeof(BPlusNode*));
+        if (!node->children)
+        {
+            free(node->keys);
+            free(node);
+            return NULL;
+        }
     }
     node->next = NULL;
     node->prev = NULL;


### PR DESCRIPTION

***
Resolves #226
# Fix missing memory allocation checks in B+ Tree node allocation

## Description
This pull request adds memory allocation validation checks and safety cleanup code to the B+ Tree node creation utility function [bplus_node_create](file:///Users/akshatshukla/Downloads/Work/open/C_DSA_interactive_suite.git/src/trees/mwst_utils.c#L34) in [mwst_utils.c](file:///Users/akshatshukla/Downloads/Work/open/C_DSA_interactive_suite.git/src/trees/mwst_utils.c). 

Previously, if system memory was exhausted and any `calloc` call failed, the function would return a partially initialized node where pointers (such as `keys`, `values`, or `children`) were `NULL`. This would lead to subsequent null-pointer dereferences (e.g. `tree->root->keys[0] = key;`) and segmentation faults during tree operations.

## Key Changes
* **Validation**: Updated [bplus_node_create](file:///Users/akshatshukla/Downloads/Work/open/C_DSA_interactive_suite.git/src/trees/mwst_utils.c#L34) to explicitly check that memory allocations for `keys`, `values`, and `children` arrays succeed.
* **Cleanup on Failure**: In the event of an allocation failure, any already allocated structures for that node are freed, and `NULL` is returned to indicate failure.

## Verification & Testing
* Compiled the full project cleanly under `-Werror`.
* Ran all B+ Tree unit tests (and the full test suite), verifying they pass successfully.