### PR TITLE
Fix missing malloc NULL check in merge sort

### DIFF
--- a/src/advanced_sorting_algorithms/merge_sort.c
+++ b/src/advanced_sorting_algorithms/merge_sort.c
@@ -13,6 +13,14 @@ static void merge(int arr[], int left, int mid, int right)
     int* left_array = malloc(sizeof(int) * left_length);
     int* right_array = malloc(sizeof(int) * right_length);
 
+    if (left_array == NULL || right_array == NULL)
+    {
+        printf("\nMemory allocation failed during merge sort.\n");
+        if (left_array) free(left_array);
+        if (right_array) free(right_array);
+        return;
+    }
+
     for (int i = 0; i < left_length; i++) // copy left half into temp malloc'd array
     {
         left_array[i] = arr[left + i];


### PR DESCRIPTION
## Description
This PR fixes #228  a critical memory management issue in the Merge Sort implementation (`src/advanced_sorting_algorithms/merge_sort.c`). 

Previously, memory was dynamically allocated for the `left_array` and `right_array` temporary buffers, but the return values of these `malloc` calls were never checked for `NULL`. If the system ran out of memory, dereferencing these `NULL` pointers would lead to an immediate segmentation fault.

## Changes Made
- Added a `NULL` check immediately following the `malloc` calls for `left_array` and `right_array`.
- If either allocation fails, the function now prints an error message, safely frees any partially allocated memory, and exits gracefully to prevent a crash.

## Why is this important?
While most data structures in this project responsibly check for memory allocation failures (e.g. `bst.c`), this validation was missing in the Merge Sort algorithm. This patch ensures that sorting operations fail safely instead of crashing the program under heavy memory load.
