### PR TITLE
Fix silent error on empty input in postfix evaluation

### DIFF
--- a/src/expression_evaluation/postfix_evaluation.c
+++ b/src/expression_evaluation/postfix_evaluation.c
@@ -132,13 +132,22 @@ void postfix_evaluation_Demo(void)
             sleep_seconds(1);
         }
 
+        if (isEmpty(operands))
+        {
+            printf("\n[Error] Invalid or empty expression provided.\n");
+            destroyStack(operands);
+            continue;
+        }
+
         int final_result = pop(operands);
 
         if (!isEmpty(operands))
         {
+            printf("\n[Error] Malformed expression: Too many operands.\n");
             destroyStack(operands);
-            return;
+            continue;
         }
+
         destroyStack(operands);
         printf("\n===================================\n");
         printf("Final Evaluated Result : %d\n", final_result);


### PR DESCRIPTION
## Description
Fixes #230 
This PR fixes a logical flaw in the postfix expression evaluation demo (`src/expression_evaluation/postfix_evaluation.c`) where an empty or whitespace-only input would silently evaluate to `-1`.

Previously, if an empty string was provided, the main evaluation loop was skipped completely. The program then incorrectly assumed that popping from the empty `operands` stack (which returns `-1`) yielded a valid mathematical result and printed it without raising any errors.

## Changes Made
- Added a check using `isEmpty(operands)` immediately after the evaluation loop to verify if any operands actually exist before attempting to `pop` the final result.
- Added a validation check after popping the final result to catch cases where there are too many operands (i.e. the stack is still not empty).
- The program now gracefully logs an error and skips printing a bogus final result when it encounters malformed or empty inputs.

## Why is this important?
This improves the robustness of the interactive demo by preventing confusing, silent failures on invalid inputs. It ensures that only correctly formed postfix expressions return a final numerical result.
