### PR TITLE
feat: add logging to checksum functions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -257,7 +257,7 @@ TEST_BINS = test_circ_queue test_bst test_search test_hash_func \
             test_priority_queue test_scll test_simple_queue \
             test_deque test_astar test_avl \
             test_greedy_bfs test_sorting_n2 test_advanced_sorting \
-            test_history_logger test_shell_sort test_trie test_btree test_bplus_tree test_parity_bit
+test_history_logger test_shell_sort test_trie test_btree test_bplus_tree test_parity_bit
 
 test_bplus_tree: $(TEST_DIR)/test_bplus_tree$(EXE)
 	$(TEST_DIR)/test_bplus_tree$(EXE)
@@ -277,5 +277,12 @@ $(TEST_DIR)/test_parity_bit$(EXE): \
 	$(CC) $(CFLAGS) $^ -o $@
 
 test: $(TEST_BINS)
+
+test_parity_bit: $(TEST_DIR)/test_parity_bit$(EXE)
+	$(TEST_DIR)/test_parity_bit$(EXE)
+
+$(TEST_DIR)/test_parity_bit$(EXE): $(OBJ_DIR)/src/error_correction_algorithms/parity_bit.o $(OBJ_DIR)/src/error_correction_algorithms/checksum.o $(OBJ_DIR)/src/utils/safe_input_int.o $(OBJ_DIR)/src/utils/history_logger.o tests/test_parity_bit.c
+	@$(call MKDIR_P,$(TEST_DIR))
+	$(CC) $(CFLAGS) $^ -o $@
 
 .PHONY: run fmt clean valgrind

--- a/src/error_correction_algorithms/checksum.c
+++ b/src/error_correction_algorithms/checksum.c
@@ -1,7 +1,9 @@
 #include "error_correction_algorithms.h"
+#include "history_logger.h"
 #include "safe_input.h"
 #include <stdio.h>
 #include <string.h>
+#include <time.h>
 
 // prints the low `bits` bits of value, most-significant bit first. shared helper
 // used for displaying k-bit words/checksums in the sender and receiver demos.
@@ -109,6 +111,26 @@ int checksum_block_sum(const char* data, int len, int k)
     return sum;
 }
 
+// Wrapper function with timing and logging for checksum_block_sum
+int checksum_block_sum_with_logging(const char* data, int len, int k)
+{
+    clock_t start_t, end_t;
+    double total_t;
+    
+    start_t = clock();
+    
+    // Call the original function
+    int result = checksum_block_sum(data, len, k);
+    
+    end_t = clock();
+    total_t = (double)(end_t - start_t) / CLOCKS_PER_SEC;
+    
+    // Log to CSV - use "Checksum Sender" as algorithm name
+    add_to_history("Checksum Sender", len, total_t);
+    
+    return result;
+}
+
 // checksum (sender side): the data is split into k-bit blocks and summed using
 // one's-complement (end-around carry) addition; the checksum is the one's complement
 // of that running sum. this is the value the sender appends to the data before
@@ -151,7 +173,7 @@ void checksum_demo(void)
         int len = (int)strlen(data);
         int mask = (1 << k) - 1; // keeps only the low k bits
 
-        int sum = checksum_block_sum(data, len, k);
+        int sum = checksum_block_sum_with_logging(data, len, k);
         int checksum = (~sum) & mask; // one's complement of the final sum, kept to k bits
 
         printf("\nfinal sum       = ");

--- a/src/error_correction_algorithms/checksum.c
+++ b/src/error_correction_algorithms/checksum.c
@@ -111,26 +111,6 @@ int checksum_block_sum(const char* data, int len, int k)
     return sum;
 }
 
-// Wrapper function with timing and logging for checksum_block_sum
-int checksum_block_sum_with_logging(const char* data, int len, int k)
-{
-    clock_t start_t, end_t;
-    double total_t;
-    
-    start_t = clock();
-    
-    // Call the original function
-    int result = checksum_block_sum(data, len, k);
-    
-    end_t = clock();
-    total_t = (double)(end_t - start_t) / CLOCKS_PER_SEC;
-    
-    // Log to CSV - use "Checksum Sender" as algorithm name
-    add_to_history("Checksum Sender", len, total_t);
-    
-    return result;
-}
-
 // checksum (sender side): the data is split into k-bit blocks and summed using
 // one's-complement (end-around carry) addition; the checksum is the one's complement
 // of that running sum. this is the value the sender appends to the data before
@@ -173,7 +153,11 @@ void checksum_demo(void)
         int len = (int)strlen(data);
         int mask = (1 << k) - 1; // keeps only the low k bits
 
-        int sum = checksum_block_sum_with_logging(data, len, k);
+        clock_t start_t = clock();
+        int sum = checksum_block_sum(data, len, k);
+        clock_t end_t = clock();
+        double total_t = (double)(end_t - start_t) / CLOCKS_PER_SEC;
+        add_to_history("Checksum Sender", len, total_t);
         int checksum = (~sum) & mask; // one's complement of the final sum, kept to k bits
 
         printf("\nfinal sum       = ");

--- a/src/error_correction_algorithms/checksum_receiver.c
+++ b/src/error_correction_algorithms/checksum_receiver.c
@@ -1,17 +1,30 @@
 #include "error_correction_algorithms.h"
+#include "history_logger.h"
 #include "safe_input.h"
 #include <stdio.h>
 #include <string.h>
+#include <time.h>
 
-// converts a k-bit binary string into its integer value. the caller guarantees the
-// string contains only '0'/'1' and is exactly k characters long.
-static int checksum_bits_to_int(const char* bits, int k)
+// converts a k-bit binary string into its integer value with timing and logging
+int checksum_bits_to_int(const char* bits, int k)
 {
+    clock_t start_t, end_t;
+    double total_t;
+    
+    start_t = clock();
+    
     int value = 0;
     for (int i = 0; i < k; i++)
     {
         value = (value << 1) | (bits[i] - '0');
     }
+    
+    end_t = clock();
+    total_t = (double)(end_t - start_t) / CLOCKS_PER_SEC;
+    
+    // Log to CSV - use "Checksum Receiver" as algorithm name
+    add_to_history("Checksum Receiver", k, total_t);
+    
     return value;
 }
 

--- a/src/error_correction_algorithms/checksum_receiver.c
+++ b/src/error_correction_algorithms/checksum_receiver.c
@@ -5,29 +5,16 @@
 #include <string.h>
 #include <time.h>
 
-// converts a k-bit binary string into its integer value with timing and logging
+// converts a k-bit binary string into its integer value
 int checksum_bits_to_int(const char* bits, int k)
 {
-    clock_t start_t, end_t;
-    double total_t;
-    
-    start_t = clock();
-    
     int value = 0;
     for (int i = 0; i < k; i++)
     {
         value = (value << 1) | (bits[i] - '0');
     }
-    
-    end_t = clock();
-    total_t = (double)(end_t - start_t) / CLOCKS_PER_SEC;
-    
-    // Log to CSV - use "Checksum Receiver" as algorithm name
-    add_to_history("Checksum Receiver", k, total_t);
-    
     return value;
 }
-
 // checksum (receiver side): re-runs the one's-complement block sum over the received
 // data, then folds in the received checksum block. if the one's complement of the
 // total is all zeros the frame is accepted, otherwise an error is detected. this is
@@ -94,7 +81,11 @@ void checksum_receiver_demo(void)
 
         // sum the data blocks (same as the sender), then fold in the received checksum
         int sum = checksum_block_sum(data, len, k);
+        clock_t start_t = clock();
         int checkword = checksum_bits_to_int(check, k);
+        clock_t end_t = clock();
+        double total_t = (double)(end_t - start_t) / CLOCKS_PER_SEC;
+        add_to_history("Checksum Receiver", k, total_t);
         sum = checksum_add(sum, checkword, k);
 
         printf("checksum: ");


### PR DESCRIPTION
## Linked issue
Closes #232

## What this PR does
Adds logging functionality to checksum.c and checksum_receiver.c:
- Wraps `checksum_block_sum()` with timing and `add_to_history()`
- Wraps `checksum_bits_to_int()` with timing and `add_to_history()`
- Logs as "Checksum Sender" and "Checksum Receiver"


