### PR TITLE
fix(lrc): flush stdin after fgets to prevent buffer overflow skipping…

### DIFF
--- a/src/error_correction_algorithms/lrc.c
+++ b/src/error_correction_algorithms/lrc.c
@@ -42,12 +42,18 @@ void lrc_demo(void)
         printf("  Word %d: ", i + 1);
         fgets(data[i], sizeof(data[i]), stdin);
 
-        // Remove trailing newline
+        // Remove trailing newline; if absent, input exceeded buffer — flush stdin
         int len = strlen(data[i]);
         if (len > 0 && data[i][len - 1] == '\n')
         {
             data[i][len - 1] = '\0';
             len--;
+        }
+        else
+        {
+            int c;
+            while ((c = getchar()) != '\n' && c != EOF)
+                ;
         }
 
         /* validate: only '0' and '1' allowed */

--- a/src/error_correction_algorithms/lrc_receiver.c
+++ b/src/error_correction_algorithms/lrc_receiver.c
@@ -45,6 +45,12 @@ void lrc_receiver_demo(void)
             data[i][len - 1] = '\0';
             len--;
         }
+        else
+        {
+            int c;
+            while ((c = getchar()) != '\n' && c != EOF)
+                ;
+        }
 
         if (len == 0)
         {
@@ -84,6 +90,12 @@ void lrc_receiver_demo(void)
     {
         received_lrc[lrc_len - 1] = '\0';
         lrc_len--;
+    }
+    else
+    {
+        int c;
+        while ((c = getchar()) != '\n' && c != EOF)
+            ;
     }
 
     if (lrc_len != cols)


### PR DESCRIPTION
## Description

This PR fixes #224, a bug in the LRC implementation (`src/error_correction_algorithms/lrc.c` and `src/error_correction_algorithms/lrc_receiver.c`).

Previously, `fgets` was used to read data words into a buffer of size `LRC_MAX_COLS + 1` (65 bytes). When the user entered a string longer than 64 characters, `fgets` stored only the first 64 characters and left the remaining input — including the newline — in the `stdin` buffer. On the next loop iteration, `fgets` immediately consumed this leftover input instead of waiting for user input, silently skipping the prompt for the next word.

## Changes Made

- Added an `else` branch after the trailing-newline check in the `fgets` read loop in `lrc.c`.
- Added the same fix in two places in `lrc_receiver.c`: the data word input loop and the received LRC string read.
- When `fgets` fills the buffer without encountering a `\n`, a `getchar()` drain loop discards all remaining characters up to and including the next `\n` or `EOF`, ensuring `stdin` is clean before the next prompt.

## Why is this important?

While most input across this project is handled defensively via `safe_input_int()`, the LRC word-input paths used raw `fgets` without overflow protection. This patch ensures that entering a word longer than the buffer limit does not corrupt subsequent reads, preventing silent data corruption and unexpected demo behaviour under any input length.