### PR TITLE
fix(crc): remove duplicate crc_xor_operation definition

### DIFF
--- a/src/error_correction_algorithms/crc.c
+++ b/src/error_correction_algorithms/crc.c
@@ -3,7 +3,7 @@
 #include <stdio.h>
 #include <string.h>
 
-static void crc_xor_operation(char* dividend, const char* divisor, int pos)
+void crc_xor_operation(char* dividend, const char* divisor, int pos)
 {
     int n = (int)strlen(divisor);
 

--- a/src/error_correction_algorithms/crc_receiver.c
+++ b/src/error_correction_algorithms/crc_receiver.c
@@ -3,16 +3,6 @@
 #include <stdio.h>
 #include <string.h>
 
-static void crc_xor_operation(char* dividend, const char* divisor, int pos)
-{
-    int n = (int)strlen(divisor);
-
-    for (int i = 0; i < n; i++)
-    {
-        dividend[pos + i] = (dividend[pos + i] == divisor[i]) ? '0' : '1';
-    }
-}
-
 void crc_receiver_demo(void)
 {
     while (1)

--- a/src/error_correction_algorithms/error_correction_algorithms.h
+++ b/src/error_correction_algorithms/error_correction_algorithms.h
@@ -45,4 +45,7 @@ int checksum_read_binary(char* buff, size_t size, const char* prompt);
 int checksum_add(int sum, int word, int k);
 int checksum_block_sum(const char* data, int len, int k);
 
+
+void crc_xor_operation(char* dividend, const char* divisor, int pos);
+
 #endif /* ERROR_CORRECTION_ALGORITHMS_H */


### PR DESCRIPTION
- Removed duplicate crc_xor_operation definition from crc_receiver.c
- Kept shared implementation in crc.c
- Added declaration in error_correction_algorithms.h
- Fixes assigned issue

Closes #233