### PR TITLE
Fix Dijkstra Priority Queue Overflow via Dynamic Resizing

### DIFF
--- a/src/graph_traversals/astar.c
+++ b/src/graph_traversals/astar.c
@@ -14,14 +14,10 @@ int astar_solve(weightedGraph* graph, int start, int dest, int h[], int parent[]
     int* visited = calloc(size, sizeof(int));
     int* dist = malloc(size * sizeof(int));
     int* fScore = malloc(size * sizeof(int));
+    int result = INT_MAX;
 
     if (!visited || !dist || !fScore)
-    {
-        free(visited);
-        free(dist);
-        free(fScore);
-        return -1;
-    }
+        goto cleanup;
 
     for (int i = 0; i < size; i++)
     {
@@ -39,11 +35,12 @@ int astar_solve(weightedGraph* graph, int start, int dest, int h[], int parent[]
     PQ_graph pq;
     init_pq_graph(&pq, 10);
 
+    if (!pq.heap)
+        goto cleanup;
+
     dist[start] = 0;
     fScore[start] = h[start];
     insert_pq_graph(&pq, start, fScore[start]);
-
-    int result = INT_MAX;
 
     PQ_graph_node popped;
     while (extractTop_pq_graph(&pq, &popped))
@@ -100,6 +97,9 @@ int astar_solve(weightedGraph* graph, int start, int dest, int h[], int parent[]
     }
 
     free_pq_graph(&pq);
+
+cleanup:
+    free(visited);
     free(dist);
     free(fScore);
     return result;

--- a/src/graph_traversals/astar.c
+++ b/src/graph_traversals/astar.c
@@ -37,7 +37,7 @@ int astar_solve(weightedGraph* graph, int start, int dest, int h[], int parent[]
     // "distance" field, which here carries the f-score (f = g + h). Duplicate
     // entries are handled lazily via the visited[] check on pop.
     PQ_graph pq;
-    pq.size = 0;
+    init_pq_graph(&pq, 10);
 
     dist[start] = 0;
     fScore[start] = h[start];
@@ -99,7 +99,7 @@ int astar_solve(weightedGraph* graph, int start, int dest, int h[], int parent[]
         }
     }
 
-    free(visited);
+    free_pq_graph(&pq);
     free(dist);
     free(fScore);
     return result;

--- a/src/graph_traversals/dijkstra.c
+++ b/src/graph_traversals/dijkstra.c
@@ -19,10 +19,39 @@ static int pq_graph_higher_priority(PQ_graph_node a, PQ_graph_node b)
     return a.vertex < b.vertex;
 }
 
+void init_pq_graph(PQ_graph* pq, int initial_capacity)
+{
+    if (pq == NULL)
+        return;
+    pq->size = 0;
+    pq->capacity = initial_capacity > 0 ? initial_capacity : 10;
+    pq->heap = malloc(pq->capacity * sizeof(PQ_graph_node));
+}
+
+void free_pq_graph(PQ_graph* pq)
+{
+    if (pq == NULL)
+        return;
+    free(pq->heap);
+    pq->heap = NULL;
+    pq->size = 0;
+    pq->capacity = 0;
+}
+
 int insert_pq_graph(PQ_graph* pq, int vertex, int distance)
 {
-    if (pq == NULL || pq->size == HEAP_CAPACITY)
+    if (pq == NULL || pq->heap == NULL)
         return 0;
+
+    if (pq->size == pq->capacity)
+    {
+        int new_capacity = pq->capacity * 2;
+        PQ_graph_node* new_heap = realloc(pq->heap, new_capacity * sizeof(PQ_graph_node));
+        if (new_heap == NULL)
+            return 0;
+        pq->heap = new_heap;
+        pq->capacity = new_capacity;
+    }
 
     int i = pq->size;
     pq->heap[i].distance = distance;
@@ -47,7 +76,7 @@ int insert_pq_graph(PQ_graph* pq, int vertex, int distance)
 
 bool extractTop_pq_graph(PQ_graph* pq, PQ_graph_node* result)
 {
-    if (pq == NULL || result == NULL || pq->size == 0)
+    if (pq == NULL || result == NULL || pq->size == 0 || pq->heap == NULL)
         return false;
 
     int topIndex = 0;
@@ -99,7 +128,7 @@ void dijkstra(weightedGraph* graph, int start)
     dist[start] = 0;
 
     PQ_graph pq;
-    pq.size = 0;
+    init_pq_graph(&pq, 10);
 
     clock_t start_t, end_t;
     double total_t;
@@ -135,6 +164,8 @@ void dijkstra(weightedGraph* graph, int start)
 
     end_t = clock();
     total_t = (double)(end_t - start_t) / CLOCKS_PER_SEC;
+
+    free_pq_graph(&pq);
 
     printf("Start -> Vertex  \t  Distance\n");
     printf("---------------  \t  --------\n");

--- a/src/graph_traversals/graph_traversals.h
+++ b/src/graph_traversals/graph_traversals.h
@@ -41,8 +41,12 @@ typedef struct
 typedef struct
 {
     int size;
-    PQ_graph_node heap[HEAP_CAPACITY];
+    int capacity;
+    PQ_graph_node* heap;
 } PQ_graph;
+
+void init_pq_graph(PQ_graph* pq, int initial_capacity);
+void free_pq_graph(PQ_graph* pq);
 int insert_pq_graph(PQ_graph* pq, int vertex, int distance);
 bool extractTop_pq_graph(PQ_graph* pq, PQ_graph_node* result);
 

--- a/src/graph_traversals/greedy_best_first_search.c
+++ b/src/graph_traversals/greedy_best_first_search.c
@@ -22,7 +22,7 @@ int greedy_best_first_search_solve(weightedGraph* graph, int start, int dest, in
     // "distance" field, which here carries the heuristic h. Duplicate entries
     // are handled lazily via the visited[] check on pop.
     PQ_graph pq;
-    pq.size = 0;
+    init_pq_graph(&pq, 10);
 
     for (int i = 0; i < size; i++)
     {
@@ -69,7 +69,7 @@ int greedy_best_first_search_solve(weightedGraph* graph, int start, int dest, in
         }
     }
 
-    free(visited);
+    free_pq_graph(&pq);
     return found;
 }
 

--- a/src/graph_traversals/greedy_best_first_search.c
+++ b/src/graph_traversals/greedy_best_first_search.c
@@ -13,9 +13,14 @@ int greedy_best_first_search_solve(weightedGraph* graph, int start, int dest, in
 {
     int size = graph->V;
     int* visited = calloc(size, sizeof(int));
+    int found = 0;
+
     if (!visited)
+        goto cleanup;
+
+    for (int i = 0; i < size; i++)
     {
-        return 0;
+        parent[i] = -1;
     }
 
     // Reuse the shared graph priority queue: a min-heap keyed on the node's
@@ -24,14 +29,11 @@ int greedy_best_first_search_solve(weightedGraph* graph, int start, int dest, in
     PQ_graph pq;
     init_pq_graph(&pq, 10);
 
-    for (int i = 0; i < size; i++)
-    {
-        parent[i] = -1;
-    }
+    if (!pq.heap)
+        goto cleanup;
 
     insert_pq_graph(&pq, start, h[start]);
 
-    int found = 0;
     *traversal_len = 0;
 
     PQ_graph_node popped;
@@ -70,6 +72,9 @@ int greedy_best_first_search_solve(weightedGraph* graph, int start, int dest, in
     }
 
     free_pq_graph(&pq);
+
+cleanup:
+    free(visited);
     return found;
 }
 


### PR DESCRIPTION
This PR resolves a critical bug where Dijkstra's algorithm (and other graph traversals like A* and Greedy BFS) would fail or produce incorrect results on dense or large graphs due to a fixed-size priority queue (`HEAP_CAPACITY = 100`).

The `PQ_graph` structure has been refactored to use dynamic memory allocation, allowing the priority queue to grow as needed during execution.

Closes #240 

## 🛠️ Changes Made
- **`graph_traversals.h`**: 
    - Updated `PQ_graph` struct to use a dynamic `PQ_graph_node* heap` instead of a static array.
    - Added `capacity` field to track heap size.
    - Declared `init_pq_graph` and `free_pq_graph` for memory management.
- **`dijkstra.c`**:
    - Implemented `init_pq_graph` and `free_pq_graph`.
    - Modified `insert_pq_graph` to detect overflow and double the heap capacity using `realloc`.
    - Updated `dijkstra` function to handle PQ lifecycle.
- **`astar.c`**: Updated `astar_solve` to use dynamic PQ initialization and cleanup.
- **`greedy_best_first_search.c`**: Updated `greedy_best_first_search_solve` to use dynamic PQ initialization and cleanup.

## 🧪 Testing & Validation
- **Compilation**: Verified successful build with GCC.
- **Unit Tests**: Ran `test_astar` and `test_greedy_bfs`. Both passed successfully.
- **Logic Verification**: The priority queue now doubles its capacity automatically, allowing it to handle more than 100 entries without data loss.

## ⚠️ Potential Impact
- Users must now ensure `free_pq_graph` is called to avoid memory leaks (already implemented in all core algorithms).
- Memory usage will scale with graph density rather than being capped.

## ✅ Checklist
- [x] Code follows project naming conventions.
- [x] Memory management (malloc/free) is handled correctly.
- [x] Existing tests pass.
- [x] No breaking changes to the public Demo API.