### PR TITLE
refactor: probing-based search in linear_probing demo (#238)

### DIFF
--- a/src/hashing/linear_probing.c
+++ b/src/hashing/linear_probing.c
@@ -1,6 +1,5 @@
 #include "data_structures.h"
 #include "hash.h"
-#include "searching_algorithms.h"
 #include <safe_input.h>
 #include <stdbool.h>
 #include <stdio.h>
@@ -115,7 +114,27 @@ void linear_probing_demo(void)
                 continue;
             }
 
-            int res = linear_search(arr, search_val, length_of_array);
+            // search uses the SAME probing sequence as insertion: start at the hash location and
+            // walk forward with wrap-around. instead of placing the value, we record the index
+            // where it is found. this reflects the real cost of a hash-table lookup.
+            int hash_location = hash_function(search_val, length_of_array);
+            int res = -1;
+            int start = hash_location;
+
+            do
+            {
+                if (!arr[hash_location])
+                {
+                    break; // empty slot ends the probe sequence: value is not present
+                }
+                if (arr[hash_location] == search_val)
+                {
+                    res = hash_location; // value found, record its index
+                    break;
+                }
+                hash_location = (hash_location + 1) % length_of_array;
+            } while (hash_location != start); // wrapped all the way around: value is not present
+
             if (res != -1)
             {
                 printf("\nValue %d found in the hash table at index %d.", search_val, res);


### PR DESCRIPTION
Closes #238

Refactors the search functionality in `linear_probing.c`.

Previously the demo's search step called `linear_search()` from the
`searching_algorithms` module, which scans the array sequentially from
index 0. That gives no insight into the actual cost of a hash-table
lookup, since it ignores the hash location and the probe sequence.

This PR replaces that call with a probing loop that mirrors the
insertion logic: it computes the hash location with `hash_function()`
and walks forward with wrap-around (the same modulo arithmetic used when
inserting). Instead of placing the value, it records the index where the
value is found and reports it through the existing output structure. The
probe stops early on an empty slot (value absent) or after wrapping all
the way around.

As a result the `#include "searching_algorithms.h"` dependency is no
longer needed and has been removed.

Verified manually:
- values placed at their home slot are found there
- values displaced by collisions are found at their probed index
  (e.g. three values hashing to the same slot are found at the home
  slot and the two wrapped probe slots)
- absent values are correctly reported as not found

`make`, `make test`, and `make valgrind` all pass clean.
