### PR TITLE
Refactor: rename checksum_read_binary to safe_input_binary_string

### DIFF
--- a/src/error_correction_algorithms/checksum.c
+++ b/src/error_correction_algorithms/checksum.c
@@ -19,7 +19,7 @@ void checksum_print_binary(int value, int bits)
 // convention used by the expression module (validate_infix_expr): returns 1 on a
 // valid non-empty binary string, 0 on EOF / invalid input (caller should re-prompt),
 // and INPUT_EXIT_SIGNAL when the user types 'X' to leave the demo.
-int checksum_read_binary(char* buff, size_t size, const char* prompt)
+int safe_input_binary_string(char* buff, size_t size, const char* prompt)
 {
     if (prompt)
     {
@@ -137,7 +137,7 @@ void checksum_demo(void)
         }
 
         char data[CHECKSUM_MAX_BITS + 1];
-        int data_status = checksum_read_binary(
+        int data_status = safe_input_binary_string(
             data, sizeof(data), "enter the binary data (digits 0/1 only), or 'X' to exit:- ");
 
         if (data_status == INPUT_EXIT_SIGNAL)

--- a/src/error_correction_algorithms/checksum_receiver.c
+++ b/src/error_correction_algorithms/checksum_receiver.c
@@ -41,7 +41,7 @@ void checksum_receiver_demo(void)
         }
 
         char data[CHECKSUM_MAX_BITS + 1];
-        int data_status = checksum_read_binary(
+        int data_status = safe_input_binary_string(
             data, sizeof(data),
             "enter the received binary data (digits 0/1 only), or 'X' to exit:- ");
 
@@ -57,7 +57,7 @@ void checksum_receiver_demo(void)
 
         char check[CHECKSUM_MAX_BITS + 1];
         int check_status =
-            checksum_read_binary(check, sizeof(check),
+            safe_input_binary_string(check, sizeof(check),
                                  "enter the received checksum (exactly k bits), or 'X' to exit:- ");
 
         if (check_status == INPUT_EXIT_SIGNAL)

--- a/src/error_correction_algorithms/crc.c
+++ b/src/error_correction_algorithms/crc.c
@@ -18,7 +18,7 @@ void crc_demo(void)
     while (1)
     {
         char data[CHECKSUM_MAX_BITS + 1];
-        int data_status = checksum_read_binary(data, sizeof(data),
+        int data_status = safe_input_binary_string(data, sizeof(data),
                                                "\n\nCRC Demo\nEnter binary data or 'X' to exit:- ");
 
         if (data_status == INPUT_EXIT_SIGNAL)
@@ -33,7 +33,7 @@ void crc_demo(void)
         }
 
         char generator[CHECKSUM_MAX_BITS + 1];
-        int generator_status = checksum_read_binary(generator, sizeof(generator),
+        int generator_status = safe_input_binary_string(generator, sizeof(generator),
                                                     "Enter generator polynomial or 'X' to exit:- ");
 
         if (generator_status == INPUT_EXIT_SIGNAL)

--- a/src/error_correction_algorithms/crc_receiver.c
+++ b/src/error_correction_algorithms/crc_receiver.c
@@ -10,7 +10,7 @@ void crc_receiver_demo(void)
         char received_codeword[(CHECKSUM_MAX_BITS * 2) + 1];
 
         int codeword_status =
-            checksum_read_binary(received_codeword, sizeof(received_codeword),
+            safe_input_binary_string(received_codeword, sizeof(received_codeword),
                                  "\n\nCRC Receiver Verification\n"
                                  "Enter transmitted codeword (data + CRC bits) or 'X' to exit:- ");
 
@@ -27,7 +27,7 @@ void crc_receiver_demo(void)
 
         char generator[CHECKSUM_MAX_BITS + 1];
 
-        int generator_status = checksum_read_binary(generator, sizeof(generator),
+        int generator_status = safe_input_binary_string(generator, sizeof(generator),
                                                     "Enter generator polynomial or 'X' to exit:- ");
 
         if (generator_status == INPUT_EXIT_SIGNAL)

--- a/src/error_correction_algorithms/error_correction_algorithms.h
+++ b/src/error_correction_algorithms/error_correction_algorithms.h
@@ -41,7 +41,7 @@ void hamming_receiver_demo(void);
 
 /* Shared checksum helpers (implemented in checksum.c) */
 void checksum_print_binary(int value, int bits);
-int checksum_read_binary(char* buff, size_t size, const char* prompt);
+int safe_input_binary_string(char* buff, size_t size, const char* prompt);
 int checksum_add(int sum, int word, int k);
 int checksum_block_sum(const char* data, int len, int k);
 

--- a/src/error_correction_algorithms/hamming.c
+++ b/src/error_correction_algorithms/hamming.c
@@ -12,7 +12,7 @@ void hamming_demo(void)
     {
         char data[CHECKSUM_MAX_BITS + 1];
 
-        int data_status = checksum_read_binary(data, sizeof(data),
+        int data_status = safe_input_binary_string(data, sizeof(data),
                                                "\n\nHamming Code Demo\n"
                                                "enter binary data bits or 'X' to exit:- ");
 

--- a/src/error_correction_algorithms/hamming_receiver.c
+++ b/src/error_correction_algorithms/hamming_receiver.c
@@ -13,7 +13,7 @@ void hamming_receiver_demo(void)
         char frame[CHECKSUM_MAX_BITS + 1];
 
         int frame_status =
-            checksum_read_binary(frame, sizeof(frame),
+            safe_input_binary_string(frame, sizeof(frame),
                                  "\n\nHamming Code Receiver Demo\n"
                                  "enter received Hamming codeword or 'X' to exit:- ");
 

--- a/src/error_correction_algorithms/parity_bit.c
+++ b/src/error_correction_algorithms/parity_bit.c
@@ -101,7 +101,7 @@ void parity_bit_demo(void)
     while (1)
     {
         int data_status =
-            checksum_read_binary(data, sizeof(data), "\nEnter binary data or 'X' to exit:- ");
+            safe_input_binary_string(data, sizeof(data), "\nEnter binary data or 'X' to exit:- ");
 
         if (data_status == INPUT_EXIT_SIGNAL)
         {
@@ -162,7 +162,7 @@ void parity_bit_demo(void)
     /* RECEIVER INPUT */
     while (1)
     {
-        int recv_status = checksum_read_binary(received, sizeof(received),
+        int recv_status = safe_input_binary_string(received, sizeof(received),
                                                "\nEnter received binary string or 'X' to exit:- ");
 
         if (recv_status == INPUT_EXIT_SIGNAL)

--- a/src/error_correction_algorithms/vrc.c
+++ b/src/error_correction_algorithms/vrc.c
@@ -9,7 +9,7 @@ void vrc_demo(void)
     {
         char data[CHECKSUM_MAX_BITS + 1];
 
-        int data_status = checksum_read_binary(data, sizeof(data),
+        int data_status = safe_input_binary_string(data, sizeof(data),
                                                "\n\nVRC Demo\n"
                                                "enter binary data or 'X' to exit:- ");
 

--- a/src/error_correction_algorithms/vrc_receiver.c
+++ b/src/error_correction_algorithms/vrc_receiver.c
@@ -9,7 +9,7 @@ void vrc_receiver_demo(void)
     {
         char received_frame[CHECKSUM_MAX_BITS + 2];
 
-        int frame_status = checksum_read_binary(received_frame, sizeof(received_frame),
+        int frame_status = safe_input_binary_string(received_frame, sizeof(received_frame),
                                                 "\n\nVRC Receiver Verification\n"
                                                 "Enter received frame or 'X' to exit:- ");
 


### PR DESCRIPTION
This PR refactors the binary string input utility within the error correction module. As suggested in `checksum.md`, the function `checksum_read_binary` has been renamed to `safe_input_binary_string` to better reflect its generic purpose as a safe input helper, rather than being tied strictly to the "checksum" naming convention.

**Key Changes:**
- **Renaming:** Updated the function name from `checksum_read_binary` to `safe_input_binary_string`.
- **Consistency:** Updated the declaration in `error_correction_algorithms.h` and the definition in `checksum.c`.
- **Module-wide Sync:** Updated all call sites across the following files:
    - `checksum_receiver.c`
    - `crc.c`
    - `crc_receiver.c`
    - `hamming.c`
    - `hamming_receiver.c`
    - `parity_bit.c`
    - `vrc.c`
    - `vrc_receiver.c`
- **Zero Logic Change:** The implementation details and validation logic remain exactly as they were, ensuring no behavioral regressions.

### **Related Issue**
Fixes #237 

### **Type of Change**
- [x] Refactor (non-breaking change which improves code structure)
- [ ] New feature
- [ ] Bug fix

### **Checklist**
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] All existing unit tests pass locally with my changes.
- [x] No functional changes were introduced; only identifier renaming.

### **Screenshots/Logs**
**Build and Test Verification:**
```text
gcc ... -c src/error_correction_algorithms/checksum.c ...
gcc ... -c src/error_correction_algorithms/parity_bit.c ...
test_binaries/test_parity_bit.exe
...
All parity bit tests passed successfully!
```