### PR TITLE
Fix exit-signal handling and exit message in bellman_ford_demo

### DIFF
--- a/src/graph_traversals/bellman_ford.c
+++ b/src/graph_traversals/bellman_ford.c
@@ -173,7 +173,7 @@ void bellman_ford_demo(void)
 
         if (dest_status == INPUT_EXIT_SIGNAL)
         {
-            printf("\nExiting Dijsktra demo\n");
+            printf("\nExiting Bellman Ford demo\n");
             free_weightedGraph(graph);
             return;
         }
@@ -182,8 +182,15 @@ void bellman_ford_demo(void)
             goto retry;
         }
 
-        wt_status = safe_input_int(&wt, "weight: ", INT_MIN, INT_MAX);
+        wt_status = safe_input_int(
+            &wt, "weight (negative weights allowed; enter '-1' to exit): ", INT_MIN, INT_MAX);
 
+        if (wt_status == INPUT_EXIT_SIGNAL)
+        {
+            printf("\nExiting Bellman Ford demo\n");
+            free_weightedGraph(graph);
+            return;
+        }
         if (wt_status == 0)
         {
             goto retry;


### PR DESCRIPTION
Closes #267

## What

Fixes two defects in the untested `void` demo `bellman_ford_demo()` (`src/graph_traversals/bellman_ford.c`):

1. **Weight input now handles `INPUT_EXIT_SIGNAL`.** Entering `-1` at the weight prompt frees the graph and exits the demo, instead of falling through and silently adding an edge. This mirrors the edge-entry loop in `dijkstra_demo()`, which already handles all three return values.
2. **Reworded the weight prompt** to make clear that negative weights are allowed but `-1` exits — Bellman-Ford supports negative edge weights, and `-1` is the reserved exit sentinel used by `safe_input_int`.
3. **Fixed the destination-input exit message**, which printed the copy-pasted and misspelled `"Exiting Dijsktra demo"` instead of referring to Bellman Ford.

## Testing

- `make` builds clean (`-Werror`)
- `make test` passes
- `make valgrind` reports 0 errors and all heap blocks freed
