### PR TITLE
Fix graph leak and bare else in dfs_demo

### DIFF
--- a/src/graph_traversals/dfs.c
+++ b/src/graph_traversals/dfs.c
@@ -81,7 +81,7 @@ void dfs_demo(void)
 
         graph_capacity = graph->V;
     }
-    else
+    else if (input_method == 1)
     {
         while (1)
         {
@@ -192,6 +192,7 @@ void dfs_demo(void)
         if (starting_node < 0 || starting_node >= graph->V)
         {
             printf("Invalid start node\n");
+            free_graph(graph);
             return;
         }
         break;


### PR DESCRIPTION
Closes #269

## What

Two robustness fixes in the untested `void` demo `dfs_demo()` (`src/graph_traversals/dfs.c`):

1. **Free the graph on the invalid-start-node path.** This branch returned without calling `free_graph(graph)`, leaking the allocated graph. `bfs_demo()` already frees in the equivalent branch — this makes `dfs_demo()` consistent.
2. **Use `else if (input_method == 1)` instead of a bare `else`.** The input method is a 1-or-2 menu; a bare `else` would let any future input option silently fall through into the manual-build branch. The explicit condition prevents that.

## Testing

- `make` builds clean (`-Werror`)
- `make test` passes
- `make valgrind` reports 0 errors and all heap blocks freed
