### PR TITLE
Fix wrong/misspelled exit messages in binary_search_demo and dijkstra_demo

### DIFF
--- a/src/graph_traversals/dijkstra.c
+++ b/src/graph_traversals/dijkstra.c
@@ -418,7 +418,7 @@ void dijkstra_demo(void)
 
             if (dest_status == INPUT_EXIT_SIGNAL)
             {
-                printf("\nExiting Dijsktra demo\n");
+                printf("\nExiting Dijkstra demo\n");
                 free_weightedGraph(graph);
                 return;
             }
@@ -431,7 +431,7 @@ void dijkstra_demo(void)
 
             if (wt_status == INPUT_EXIT_SIGNAL)
             {
-                printf("\nExiting Dijsktra demo\n");
+                printf("\nExiting Dijkstra demo\n");
                 free_weightedGraph(graph);
                 return;
             }

--- a/src/searching_algorithms/binary_search.c
+++ b/src/searching_algorithms/binary_search.c
@@ -46,7 +46,7 @@ void binary_search_demo(void)
 
             if (element_status == INPUT_EXIT_SIGNAL)
             {
-                printf("\nExiting linear search demo....\n");
+                printf("\nExiting binary search demo....\n");
                 return;
             }
 


### PR DESCRIPTION
Closes #271

## What

Fixes copy-paste typos in user-facing exit messages inside untested `void` demo functions:

- `binary_search_demo()` printed `"Exiting linear search demo...."` (copied from the linear search demo) → now `"Exiting binary search demo...."`.
- `dijkstra_demo()` printed `"Exiting Dijsktra demo"` in two places ("Dijkstra" misspelled) → now `"Exiting Dijkstra demo"`.

All are reachable by entering `-1` at the respective prompts. No logic changes.

## Testing

- `make` builds clean (`-Werror`)
- `make test` passes
- `make valgrind` reports 0 errors and all heap blocks freed
