### PR TITLE
Refactor safe_input_string to be a global utility function (#260)

### DIFF
--- a/src/dynamic_programming/lcs.c
+++ b/src/dynamic_programming/lcs.c
@@ -76,34 +76,7 @@ int lcs(char* X, char* Y, int m, int n)
 
     return res;
 }
-static int safe_input_string(char* buffer, const char* prompt)
-{
-    while (1)
-    {
-        printf("%s", prompt);
-        fflush(stdout);
 
-        if (scanf("%99s", buffer) != 1)
-        {
-            int c;
-            while ((c = getchar()) != '\n' && c != EOF)
-                ;
-            printf("Invalid input. Please try again.\n");
-            continue;
-        }
-
-        int c;
-        while ((c = getchar()) != '\n' && c != EOF)
-            ; // Clear the rest of the line
-
-        if (strcmp(buffer, "X") == 0)
-        {
-            return INPUT_EXIT_SIGNAL;
-        }
-
-        return 1;
-    }
-}
 
 void lcs_demo(void)
 {

--- a/src/string_algorithms/kmp.c
+++ b/src/string_algorithms/kmp.c
@@ -6,34 +6,7 @@
 #include <string.h>
 #include <time.h>
 
-static int safe_input_string(char* buffer, const char* prompt)
-{
-    while (1)
-    {
-        printf("%s", prompt);
-        fflush(stdout);
 
-        if (scanf("%99s", buffer) != 1)
-        {
-            int c;
-            while ((c = getchar()) != '\n' && c != EOF)
-                ;
-            printf("Invalid input. Please try again.\n");
-            continue;
-        }
-
-        int c;
-        while ((c = getchar()) != '\n' && c != EOF)
-            ; // Clear the rest of the line
-
-        if (strcmp(buffer, "X") == 0)
-        {
-            return INPUT_EXIT_SIGNAL;
-        }
-
-        return 1;
-    }
-}
 
 static void compute_lps_array(char* pattern, int m, int* lps)
 {

--- a/src/string_algorithms/naive_string_matching.c
+++ b/src/string_algorithms/naive_string_matching.c
@@ -5,34 +5,7 @@
 #include <string.h>
 #include <time.h>
 
-static int safe_input_string(char* buffer, const char* prompt)
-{
-    while (1)
-    {
-        printf("%s", prompt);
-        fflush(stdout);
 
-        if (scanf("%99s", buffer) != 1)
-        {
-            int c;
-            while ((c = getchar()) != '\n' && c != EOF)
-                ;
-            printf("Invalid input. Please try again.\n");
-            continue;
-        }
-
-        int c;
-        while ((c = getchar()) != '\n' && c != EOF)
-            ; // Clear the rest of the line
-
-        if (strcmp(buffer, "X") == 0)
-        {
-            return INPUT_EXIT_SIGNAL;
-        }
-
-        return 1;
-    }
-}
 
 void naive_string_matching(char* text, char* pattern)
 {

--- a/src/string_algorithms/rabin_karp.c
+++ b/src/string_algorithms/rabin_karp.c
@@ -7,34 +7,7 @@
 
 #define d 256
 
-static int safe_input_string(char* buffer, const char* prompt)
-{
-    while (1)
-    {
-        printf("%s", prompt);
-        fflush(stdout);
 
-        if (scanf("%99s", buffer) != 1)
-        {
-            int c;
-            while ((c = getchar()) != '\n' && c != EOF)
-                ;
-            printf("Invalid input. Please try again.\n");
-            continue;
-        }
-
-        int c;
-        while ((c = getchar()) != '\n' && c != EOF)
-            ; // Clear the rest of the line
-
-        if (strcmp(buffer, "X") == 0)
-        {
-            return INPUT_EXIT_SIGNAL;
-        }
-
-        return 1;
-    }
-}
 
 void rabin_karp_search(char* text, char* pattern, int q)
 {

--- a/src/utils/safe_input.h
+++ b/src/utils/safe_input.h
@@ -7,5 +7,6 @@
 int safe_input_int(int* input, const char* prompt, int min_val, int max_val);
 int validate_infix_expr(char* buff, size_t size, const char* prompt);
 int validate_postfix_expr(char* buff, size_t size, const char* prompt);
+int safe_input_string(char* buffer, const char* prompt);
 
 #endif

--- a/src/utils/safe_input_string.c
+++ b/src/utils/safe_input_string.c
@@ -1,0 +1,32 @@
+#include "safe_input.h"
+#include <stdio.h>
+#include <string.h>
+
+int safe_input_string(char* buffer, const char* prompt)
+{
+    while (1)
+    {
+        printf("%s", prompt);
+        fflush(stdout);
+
+        if (scanf("%99s", buffer) != 1)
+        {
+            int c;
+            while ((c = getchar()) != '\n' && c != EOF)
+                ;
+            printf("Invalid input. Please try again.\n");
+            continue;
+        }
+
+        int c;
+        while ((c = getchar()) != '\n' && c != EOF)
+            ; // Clear the rest of the line
+
+        if (strcmp(buffer, "X") == 0)
+        {
+            return INPUT_EXIT_SIGNAL;
+        }
+
+        return 1;
+    }
+}


### PR DESCRIPTION
Resolves #278 

## Description
Currently, the `safe_input_string` function is being unnecessarily copy-pasted and defined as a `static` helper across multiple algorithm files (e.g., `lcs.c`, `naive_string_matching.c`, `kmp.c`, and `rabin_karp.c`). 

This causes code duplication and makes it harder to maintain input validation logic consistently across the interactive suite.

## Solution
- Declared `int safe_input_string(char* buffer, const char* prompt);` in `src/utils/safe_input.h` so it is globally available.
- Implemented the definition once in `src/utils/safe_input_string.c`.
- Removed the duplicated `static` function definitions from all algorithm implementation files and ensured they include `safe_input.h`.

This will clean up the codebase and allow future algorithms to reuse the secure string input logic seamlessly.
