### PR TITLE
Refactor: Made the queue structure generic and made the project which uses old queue method use new one

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,7 +125,7 @@ $(TEST_DIR)/test_tbt$(EXE): $(OBJ_DIR)/src/utils/safe_input_int.o $(OBJ_DIR)/src
 test_circ_queue: $(TEST_DIR)/test_circ_queue$(EXE)
 	$(TEST_DIR)/test_circ_queue$(EXE)
 
-$(TEST_DIR)/test_circ_queue$(EXE): $(OBJ_DIR)/src/data_structures/circular_queue.o $(OBJ_DIR)/src/utils/safe_input_int.o tests/test_circ_queue.c
+$(TEST_DIR)/test_circ_queue$(EXE): $(OBJ_DIR)/src/data_structures/circular_queue.o $(OBJ_DIR)/src/utils/safe_input_int.o $(OBJ_DIR)/src/utils/returnMallocVal.o tests/test_circ_queue.c
 	@$(call MKDIR_P,$(TEST_DIR))
 	$(CC) $(CFLAGS) $^ -o $@
 
@@ -195,21 +195,21 @@ $(TEST_DIR)/test_scll$(EXE): $(OBJ_DIR)/src/data_structures/scll.o $(OBJ_DIR)/sr
 test_simple_queue: $(TEST_DIR)/test_simple_queue$(EXE)
 	$(TEST_DIR)/test_simple_queue$(EXE)
 
-$(TEST_DIR)/test_simple_queue$(EXE): $(OBJ_DIR)/src/data_structures/simple_queue.o $(OBJ_DIR)/src/utils/safe_input_int.o tests/test_simple_queue.c
+$(TEST_DIR)/test_simple_queue$(EXE): $(OBJ_DIR)/src/data_structures/simple_queue.o $(OBJ_DIR)/src/utils/safe_input_int.o $(OBJ_DIR)/src/utils/returnMallocVal.o tests/test_simple_queue.c
 	@$(call MKDIR_P,$(TEST_DIR))
 	$(CC) $(CFLAGS) $^ -o $@
 
 test_deque: $(TEST_DIR)/test_deque$(EXE)
 	$(TEST_DIR)/test_deque$(EXE)
 
-$(TEST_DIR)/test_deque$(EXE): $(OBJ_DIR)/src/data_structures/deque.o $(OBJ_DIR)/src/utils/safe_input_int.o tests/test_deque.c
+$(TEST_DIR)/test_deque$(EXE): $(OBJ_DIR)/src/data_structures/deque.o $(OBJ_DIR)/src/utils/safe_input_int.o $(OBJ_DIR)/src/utils/returnMallocVal.o tests/test_deque.c
 	@$(call MKDIR_P,$(TEST_DIR))
 	$(CC) $(CFLAGS) $^ -o $@
 
 test_astar: $(TEST_DIR)/test_astar$(EXE)
 	$(TEST_DIR)/test_astar$(EXE)
 
-$(TEST_DIR)/test_astar$(EXE): $(OBJ_DIR)/src/graph_traversals/astar.o $(OBJ_DIR)/src/graph_traversals/dijkstra.o $(OBJ_DIR)/src/utils/graph_io.o $(OBJ_DIR)/src/graph_traversals/bfs.o $(OBJ_DIR)/src/data_structures/circular_queue.o $(OBJ_DIR)/src/data_structures/sll.o $(OBJ_DIR)/src/utils/safe_input_int.o $(OBJ_DIR)/src/utils/history_logger.o tests/test_astar.c
+$(TEST_DIR)/test_astar$(EXE): $(OBJ_DIR)/src/graph_traversals/astar.o $(OBJ_DIR)/src/graph_traversals/dijkstra.o $(OBJ_DIR)/src/utils/graph_io.o $(OBJ_DIR)/src/graph_traversals/bfs.o $(OBJ_DIR)/src/utils/returnMallocVal.o $(OBJ_DIR)/src/data_structures/circular_queue.o $(OBJ_DIR)/src/data_structures/sll.o $(OBJ_DIR)/src/utils/safe_input_int.o $(OBJ_DIR)/src/utils/history_logger.o tests/test_astar.c
 	@$(call MKDIR_P,$(TEST_DIR))
 	$(CC) $(CFLAGS) $^ -o $@
 
@@ -237,7 +237,7 @@ $(TEST_DIR)/test_btree$(EXE): $(OBJ_DIR)/src/trees/btree.o $(OBJ_DIR)/src/utils/
 test_greedy_bfs: $(TEST_DIR)/test_greedy_bfs$(EXE)
 	$(TEST_DIR)/test_greedy_bfs$(EXE)
 
-$(TEST_DIR)/test_greedy_bfs$(EXE): $(OBJ_DIR)/src/graph_traversals/greedy_best_first_search.o $(OBJ_DIR)/src/graph_traversals/dijkstra.o $(OBJ_DIR)/src/utils/graph_io.o $(OBJ_DIR)/src/graph_traversals/bfs.o $(OBJ_DIR)/src/data_structures/circular_queue.o $(OBJ_DIR)/src/data_structures/sll.o $(OBJ_DIR)/src/utils/safe_input_int.o $(OBJ_DIR)/src/utils/history_logger.o tests/test_greedy_best_first_search.c
+$(TEST_DIR)/test_greedy_bfs$(EXE): $(OBJ_DIR)/src/graph_traversals/greedy_best_first_search.o $(OBJ_DIR)/src/graph_traversals/dijkstra.o $(OBJ_DIR)/src/utils/graph_io.o $(OBJ_DIR)/src/graph_traversals/bfs.o $(OBJ_DIR)/src/utils/returnMallocVal.o $(OBJ_DIR)/src/data_structures/circular_queue.o $(OBJ_DIR)/src/data_structures/sll.o $(OBJ_DIR)/src/utils/safe_input_int.o $(OBJ_DIR)/src/utils/history_logger.o tests/test_greedy_best_first_search.c
 	@$(call MKDIR_P,$(TEST_DIR))
 	$(CC) $(CFLAGS) $^ -o $@
 

--- a/src/data_structures/circular_queue.c
+++ b/src/data_structures/circular_queue.c
@@ -78,25 +78,34 @@ void circular_queue_Demo(void)
                     continue;
                 }
 
-                if (enqueue(&rollnos, enqueue_val) == -1)
+                int* value = malloc(sizeof(int));
+                if (value == NULL)
                 {
-                    printf("\nQueue is full (circular overflow)\n");
+                    printf("malloc failed\n");
+                    continue;
                 }
-
+                *value = enqueue_val;
+                if(enqueue(&rollnos, value) == -1)
+                {
+                    free(value);
+                    printf("Queue is full (Circular Overflow)\n");
+                }
+                
                 display_circ_queue(&rollnos);
             }
 
             else if (circ_queue_choice == 2)
             {
-                int removed = dequeue(&rollnos);
+                void* removed = dequeue(&rollnos);
 
-                if (removed == -1)
+                if (removed == NULL)
                 {
                     printf("\nQueue is empty\n");
                 }
                 else
                 {
-                    printf("\nDequeued element: %d\n", removed);
+                    printf("\nDequeued element: %d\n", *(int*)removed);
+                    free(removed);
                 }
 
                 display_circ_queue(&rollnos);
@@ -109,7 +118,7 @@ int init_circ_queue(int N, Queue* queue_ptr)
 {
     if (N < 1)
         return 0;
-    queue_ptr->arr = malloc(sizeof(int) * N);
+    queue_ptr->arr = malloc(sizeof(void*) * N);
     if (queue_ptr->arr == NULL)
         return 0;
     queue_ptr->N = N;
@@ -120,8 +129,17 @@ int init_circ_queue(int N, Queue* queue_ptr)
 
 void destroy_circ_queue(Queue* queue_ptr)
 {
-    if (queue_ptr->arr == NULL)
+    if (queue_ptr == NULL || queue_ptr->arr == NULL)
         return;
+    
+    int i = queue_ptr->front;
+
+    while (i != queue_ptr->rear)
+    {
+        free(queue_ptr->arr[i]);
+        i = (i + 1) % queue_ptr->N;
+    }
+
     free(queue_ptr->arr);
     queue_ptr->arr = NULL;
     queue_ptr->front = 0;
@@ -129,19 +147,21 @@ void destroy_circ_queue(Queue* queue_ptr)
     queue_ptr->N = 0;
 }
 
-int enqueue(Queue* queue_ptr, int value)
-{ // one slot is kept empty to differentiate between full and empty queue
-    if (((queue_ptr->rear) + 1) % (queue_ptr->N) == queue_ptr->front)
+int enqueue(Queue* queue_ptr, void* value)
+{ 
+    // one slot is kept empty to differentiate between full and empty queue
+    if ((queue_ptr == NULL)|| (queue_ptr->arr == NULL) || (((queue_ptr->rear) + 1) % (queue_ptr->N) == queue_ptr->front))
         return -1;
+    
     queue_ptr->arr[queue_ptr->rear] = value;
     queue_ptr->rear = ((queue_ptr->rear) + 1) % (queue_ptr->N);
     return 1;
 }
 
-int dequeue(Queue* queue_ptr)
+void* dequeue(Queue* queue_ptr)
 {
-    if (queue_ptr->rear == queue_ptr->front)
-        return -1;
+    if (queue_ptr == NULL || queue_ptr->arr == NULL || queue_ptr->rear == queue_ptr->front)
+        return NULL;
     int front_value = queue_ptr->front;
     queue_ptr->front = ((queue_ptr->front) + 1) % (queue_ptr->N);
     return queue_ptr->arr[front_value];
@@ -149,10 +169,13 @@ int dequeue(Queue* queue_ptr)
 
 void display_circ_queue(Queue* queue_ptr)
 {
+    if(queue_ptr == NULL)
+        return;
+
     int i = queue_ptr->front;
     while (i != queue_ptr->rear)
     {
-        printf("%d<->", queue_ptr->arr[i]);
+        printf("%d<->", *(int*)queue_ptr->arr[i]);
         i = (i + 1) % queue_ptr->N;
     }
 }

--- a/src/data_structures/data_structures.h
+++ b/src/data_structures/data_structures.h
@@ -127,32 +127,32 @@ typedef struct Queue
     int rear;
     int front;
     int N;
-    int* arr;
+    void** arr;
 } Queue;
 
 // For circular queue
 int init_circ_queue(int N, Queue* queue_ptr);
 void destroy_circ_queue(Queue* queue_ptr);
-int enqueue(Queue* queue_ptr, int value);
-int dequeue(Queue* queue_ptr);
+int enqueue(Queue* queue_ptr, void* value);
+void* dequeue(Queue* queue_ptr);
 void display_circ_queue(Queue* queue_ptr);
 void circular_queue_Demo(void);
 
 // For simple (linear) queue
 int init_simple_queue(int N, Queue* queue_ptr);
 void destroy_simple_queue(Queue* queue_ptr);
-int enqueue_simple(Queue* queue_ptr, int value);
-int dequeue_simple(Queue* queue_ptr);
+int enqueue_simple(Queue* queue_ptr, void* value);
+void* dequeue_simple(Queue* queue_ptr);
 void display_simple_queue(const Queue* queue_ptr);
 void simple_queue_Demo(void);
 
 // For Double-Ended Queue (Deque)
 int init_deque(int N, Queue* dq);
 void destroy_deque(Queue* dq);
-int deque_insert_front(Queue* dq, int value);
-int deque_insert_rear(Queue* dq, int value);
-int deque_delete_front(Queue* dq, int* val);
-int deque_delete_rear(Queue* dq, int* val);
+int deque_insert_front(Queue* dq, void* value);
+int deque_insert_rear(Queue* dq, void* value);
+void* deque_delete_front(Queue* dq);
+void* deque_delete_rear(Queue* dq);
 int deque_get_front(const Queue* dq);
 int deque_get_rear(const Queue* dq);
 bool deque_is_empty(const Queue* dq);

--- a/src/data_structures/deque.c
+++ b/src/data_structures/deque.c
@@ -7,7 +7,7 @@ int init_deque(int N, Queue* dq)
 {
     if (N < 1)
         return 0;
-    dq->arr = malloc(sizeof(int) * N);
+    dq->arr = malloc(sizeof(void*) * N);
     if (dq->arr == NULL)
         return 0;
     dq->N = N;
@@ -18,8 +18,24 @@ int init_deque(int N, Queue* dq)
 
 void destroy_deque(Queue* dq)
 {
-    if (dq->arr == NULL)
+    if (dq == NULL || dq->arr == NULL)
         return;
+
+    if (!deque_is_empty(dq))
+    {
+        int i = dq->front;
+
+        while (1)
+        {
+            free(dq->arr[i]);
+
+            if (i == dq->rear)
+                break;
+
+            i = (i + 1) % dq->N;
+        }
+    }
+
     free(dq->arr);
     dq->arr = NULL;
     dq->front = -1;
@@ -29,17 +45,19 @@ void destroy_deque(Queue* dq)
 
 bool deque_is_empty(const Queue* dq)
 {
-    return (dq->front == -1);
+    return (dq == NULL || dq->front == -1);
 }
 
 bool deque_is_full(const Queue* dq)
 {
+    if(dq == NULL)
+        return false;
     return ((dq->front == 0 && dq->rear == dq->N - 1) || (dq->front == dq->rear + 1));
 }
 
-int deque_insert_front(Queue* dq, int value)
+int deque_insert_front(Queue* dq, void* value)
 {
-    if (deque_is_full(dq))
+    if (dq == NULL || dq->arr == NULL || deque_is_full(dq))
         return -1;
 
     if (dq->front == -1) // empty
@@ -60,9 +78,9 @@ int deque_insert_front(Queue* dq, int value)
     return 1;
 }
 
-int deque_insert_rear(Queue* dq, int value)
+int deque_insert_rear(Queue* dq, void* value)
 {
-    if (deque_is_full(dq))
+    if (dq == NULL || dq->arr == NULL || deque_is_full(dq))
         return -1;
 
     if (dq->front == -1) // empty
@@ -83,12 +101,12 @@ int deque_insert_rear(Queue* dq, int value)
     return 1;
 }
 
-int deque_delete_front(Queue* dq, int* val)
+void* deque_delete_front(Queue* dq)
 {
-    if (deque_is_empty(dq))
-        return -1;
+    if (dq == NULL || dq->arr == NULL || deque_is_empty(dq))
+        return NULL;
 
-    *val = dq->arr[dq->front];
+    void* removed = dq->arr[dq->front];
 
     if (dq->front == dq->rear) // only one element
     {
@@ -104,15 +122,15 @@ int deque_delete_front(Queue* dq, int* val)
         dq->front = dq->front + 1;
     }
 
-    return 1;
+    return removed;
 }
 
-int deque_delete_rear(Queue* dq, int* val)
+void* deque_delete_rear(Queue* dq)
 {
-    if (deque_is_empty(dq))
-        return -1;
+    if (dq == NULL || dq->arr == NULL || deque_is_empty(dq))
+        return NULL;
 
-    *val = dq->arr[dq->rear];
+    void* removed = dq->arr[dq->rear];
 
     if (dq->front == dq->rear) // only one element
     {
@@ -128,26 +146,26 @@ int deque_delete_rear(Queue* dq, int* val)
         dq->rear = dq->rear - 1;
     }
 
-    return 1;
+    return removed;
 }
 
 int deque_get_front(const Queue* dq)
 {
-    if (deque_is_empty(dq))
+    if (dq == NULL || dq->arr == NULL || deque_is_empty(dq))
         return -1;
-    return dq->arr[dq->front];
+    return *(int*)dq->arr[dq->front];
 }
 
 int deque_get_rear(const Queue* dq)
 {
-    if (deque_is_empty(dq))
+    if (dq == NULL || dq->arr == NULL || deque_is_empty(dq))
         return -1;
-    return dq->arr[dq->rear];
+    return *(int*)dq->arr[dq->rear];
 }
 
 void display_deque(const Queue* dq)
 {
-    if (deque_is_empty(dq))
+    if (dq == NULL || dq->arr == NULL || deque_is_empty(dq))
     {
         printf("\nDeque is empty\n");
         return;
@@ -156,7 +174,7 @@ void display_deque(const Queue* dq)
     int i = dq->front;
     while (1)
     {
-        printf("%d", dq->arr[i]);
+        printf("%d", *(int*)dq->arr[i]);
         if (i == dq->rear)
             break;
         printf("<->");
@@ -169,7 +187,7 @@ void deque_demo(void)
 {
     while (1)
     {
-        Queue dq;
+        Queue dq = {0};
         int capacity;
         int status = safe_input_int(&capacity,
                                     "\n\nenter capacity number (N) of deque (between 1 and 100), "
@@ -228,9 +246,18 @@ void deque_demo(void)
                 }
                 if (val_status == 0)
                     continue;
-
-                if (deque_insert_front(&dq, val) == -1)
+                
+                int* ptr = malloc(sizeof(int));
+                if(ptr == NULL)
                 {
+                    printf("Malloc failed\n");
+                    continue;
+                }
+                *ptr = val;
+
+                if (deque_insert_front(&dq, ptr) == -1)
+                {
+                    free(ptr);
                     printf("\nDeque is full (overflow)\n");
                 }
                 display_deque(&dq);
@@ -248,38 +275,47 @@ void deque_demo(void)
                 }
                 if (val_status == 0)
                     continue;
-
-                if (deque_insert_rear(&dq, val) == -1)
+                
+                int* ptr = malloc(sizeof(int));
+                if(ptr == NULL)
                 {
+                    printf("Malloc failed\n");
+                    continue;
+                }
+                *ptr = val;
+
+                if (deque_insert_rear(&dq, ptr) == -1)
+                {
+                    free(ptr);
                     printf("\nDeque is full (overflow)\n");
                 }
                 display_deque(&dq);
             }
             else if (choice == 3)
             {
-                int removed_val;
-                int status_code = deque_delete_front(&dq, &removed_val);
-                if (status_code == -1)
+                void* removed_val = deque_delete_front(&dq);
+                if (removed_val == NULL)
                 {
                     printf("\nDeque is empty (underflow)\n");
                 }
                 else
                 {
-                    printf("\nDeleted element from front: %d\n", removed_val);
+                    printf("\nDeleted element from front: %d\n", *(int*)removed_val);
+                    free(removed_val);
                 }
                 display_deque(&dq);
             }
             else if (choice == 4)
             {
-                int removed_val;
-                int status_code = deque_delete_rear(&dq, &removed_val);
-                if (status_code == -1)
+                void* removed_val = deque_delete_rear(&dq);
+                if (removed_val == NULL)
                 {
                     printf("\nDeque is empty (underflow)\n");
                 }
                 else
                 {
-                    printf("\nDeleted element from rear: %d\n", removed_val);
+                    printf("\nDeleted element from rear: %d\n", *(int*)removed_val);
+                    free(removed_val);
                 }
                 display_deque(&dq);
             }

--- a/src/data_structures/simple_queue.c
+++ b/src/data_structures/simple_queue.c
@@ -144,9 +144,12 @@ void destroy_simple_queue(Queue* queue_ptr)
     if (queue_ptr->arr == NULL)
         return;
 
-    for (int i = queue_ptr->front; i <= queue_ptr->rear; i++)
+    if (queue_ptr->front != -1)
     {
-        free(queue_ptr->arr[i]);
+        for (int i = queue_ptr->front; i <= queue_ptr->rear; i++)
+        {
+            free(queue_ptr->arr[i]);
+        }
     }
     
     free(queue_ptr->arr);
@@ -157,8 +160,9 @@ void destroy_simple_queue(Queue* queue_ptr)
 }
 
 int enqueue_simple(Queue* queue_ptr, void* value)
-{ // rear never moves backward, so a slot freed by dequeue at the front is not reclaimed
-    if (queue_ptr == NULL || queue_ptr->arr == NULL ||queue_ptr->rear == queue_ptr->N - 1)
+{ 
+    // rear never moves backward, so a slot freed by dequeue at the front is not reclaimed
+    if (queue_ptr == NULL || queue_ptr->arr == NULL || queue_ptr->rear == queue_ptr->N - 1)
         return -1;
     if (queue_ptr->front == -1)
         queue_ptr->front = 0;
@@ -172,7 +176,15 @@ void* dequeue_simple(Queue* queue_ptr)
     if (queue_ptr == NULL || queue_ptr->arr == NULL || queue_ptr->front == -1 || queue_ptr->front > queue_ptr->rear)
         return NULL;
     void* front_value = queue_ptr->arr[queue_ptr->front];
-    queue_ptr->front++;
+    if (queue_ptr->front == queue_ptr->rear)
+    {
+        queue_ptr->front = -1;
+        queue_ptr->rear = -1;
+    }
+    else
+    {
+        queue_ptr->front++;
+    }
     return front_value;
 }
 

--- a/src/data_structures/simple_queue.c
+++ b/src/data_structures/simple_queue.c
@@ -20,7 +20,7 @@ void simple_queue_Demo(void)
 
     while (1)
     {
-        Queue q;
+        Queue q = {0};
         int queue_capacity_value;
         int queue_capacity_status =
             safe_input_int(&queue_capacity_value,
@@ -87,9 +87,18 @@ void simple_queue_Demo(void)
                 { // invalid input, (chars or number+chars) loopback to start
                     continue;
                 }
-
-                if (enqueue_simple(&q, enqueue_val) == -1)
+                
+                int* ptr = malloc(sizeof(int));
+                if(ptr == NULL)
                 {
+                    printf("Malloc failed\n");
+                    continue;
+                }
+                *ptr = enqueue_val;
+
+                if (enqueue_simple(&q, ptr) == -1)
+                {
+                    free(ptr);
                     printf("\nQueue is full (linear overflow - freed front slots cannot be "
                            "reused)\n");
                 }
@@ -99,15 +108,16 @@ void simple_queue_Demo(void)
 
             else if (simple_queue_choice == 2)
             {
-                int removed = dequeue_simple(&q);
+                void* removed = dequeue_simple(&q);
 
-                if (removed == -1)
+                if (removed == NULL)
                 {
                     printf("\nQueue is empty\n");
                 }
                 else
                 {
-                    printf("\nDequeued element: %d\n", removed);
+                    printf("\nDequeued element: %d\n", *(int*)removed);
+                    free(removed);
                 }
 
                 display_simple_queue(&q);
@@ -120,7 +130,7 @@ int init_simple_queue(int N, Queue* queue_ptr)
 {
     if (N < 1)
         return 0;
-    queue_ptr->arr = malloc(sizeof(int) * N);
+    queue_ptr->arr = malloc(sizeof(void*) * N);
     if (queue_ptr->arr == NULL)
         return 0;
     queue_ptr->N = N;
@@ -133,6 +143,12 @@ void destroy_simple_queue(Queue* queue_ptr)
 {
     if (queue_ptr->arr == NULL)
         return;
+
+    for (int i = queue_ptr->front; i <= queue_ptr->rear; i++)
+    {
+        free(queue_ptr->arr[i]);
+    }
+    
     free(queue_ptr->arr);
     queue_ptr->arr = NULL;
     queue_ptr->front = -1;
@@ -140,9 +156,9 @@ void destroy_simple_queue(Queue* queue_ptr)
     queue_ptr->N = 0;
 }
 
-int enqueue_simple(Queue* queue_ptr, int value)
+int enqueue_simple(Queue* queue_ptr, void* value)
 { // rear never moves backward, so a slot freed by dequeue at the front is not reclaimed
-    if (queue_ptr->rear == queue_ptr->N - 1)
+    if (queue_ptr == NULL || queue_ptr->arr == NULL ||queue_ptr->rear == queue_ptr->N - 1)
         return -1;
     if (queue_ptr->front == -1)
         queue_ptr->front = 0;
@@ -151,18 +167,18 @@ int enqueue_simple(Queue* queue_ptr, int value)
     return 1;
 }
 
-int dequeue_simple(Queue* queue_ptr)
+void* dequeue_simple(Queue* queue_ptr)
 {
-    if (queue_ptr->front == -1 || queue_ptr->front > queue_ptr->rear)
-        return -1;
-    int front_value = queue_ptr->arr[queue_ptr->front];
+    if (queue_ptr == NULL || queue_ptr->arr == NULL || queue_ptr->front == -1 || queue_ptr->front > queue_ptr->rear)
+        return NULL;
+    void* front_value = queue_ptr->arr[queue_ptr->front];
     queue_ptr->front++;
     return front_value;
 }
 
 void display_simple_queue(const Queue* queue_ptr)
 {
-    if (queue_ptr->front == -1 || queue_ptr->front > queue_ptr->rear)
+    if (queue_ptr == NULL || queue_ptr->arr == NULL || queue_ptr->front == -1 || queue_ptr->front > queue_ptr->rear)
     {
         printf("\nQueue (front -> rear): [empty]\n");
         return;
@@ -170,7 +186,7 @@ void display_simple_queue(const Queue* queue_ptr)
     printf("\nQueue (front -> rear): ");
     for (int i = queue_ptr->front; i <= queue_ptr->rear; i++)
     {
-        printf("%d -> ", queue_ptr->arr[i]);
+        printf("%d -> ", *(int*)queue_ptr->arr[i]);
     }
     printf("END\n");
 }

--- a/src/graph_traversals/bfs.c
+++ b/src/graph_traversals/bfs.c
@@ -2,6 +2,7 @@
 #include "graph_io.h"
 #include "graph_traversals.h"
 #include "history_logger.h"
+#include "returnMallocVal.h"
 #include "safe_input.h"
 #include <stdio.h>
 #include <stdlib.h>
@@ -39,13 +40,17 @@ void bfs(Graph* graph, int start)
     start_t = clock();
 
     visited[start] = 1;
-    enqueue(&nodes, start);
+    enqueue(&nodes, returnMallocInt(start));
 
     while (1)
     {
-        int curr = dequeue(&nodes);
-        if (curr == -1)
+        int* curr_ptr = dequeue(&nodes);
+
+        if (curr_ptr == NULL)
             break;
+
+        int curr = *curr_ptr;
+        free(curr_ptr);
 
         printf("%d->", curr);
 
@@ -54,11 +59,13 @@ void bfs(Graph* graph, int start)
         while (temp)
         {
             int v = temp->data;
+
             if (!visited[v])
             {
                 visited[v] = 1;
-                enqueue(&nodes, v);
+                enqueue(&nodes, returnMallocInt(v));
             }
+
             temp = temp->next;
         }
     }
@@ -68,7 +75,9 @@ void bfs(Graph* graph, int start)
 
     printf("end\n");
     printf("\ntotal CPU time taken for BFS traversal:- %f seconds\n", total_t);
+
     add_to_history("BFS", size, total_t);
+
     destroy_circ_queue(&nodes);
 }
 
@@ -354,6 +363,7 @@ void topological_sort_kahn(Graph* graph)
     for (int u = 0; u < size; u++)
     {
         Node* temp = graph->array[u];
+
         while (temp)
         {
             in_degree[temp->data]++;
@@ -373,7 +383,7 @@ void topological_sort_kahn(Graph* graph)
     for (int i = 0; i < size; i++)
     {
         if (in_degree[i] == 0)
-            enqueue(&q, i);
+            enqueue(&q, returnMallocInt(i));
     }
 
     /* Step 3: Process the queue (Kahn's BFS) */
@@ -383,20 +393,28 @@ void topological_sort_kahn(Graph* graph)
 
     while (1)
     {
-        int u = dequeue(&q);
-        if (u == -1)
+        int* u_ptr = dequeue(&q);
+
+        if (u_ptr == NULL)
             break;
+
+        int u = *u_ptr;
+        free(u_ptr);
 
         printf("%d ", u);
         processed++;
 
         Node* temp = graph->array[u];
+
         while (temp)
         {
             int v = temp->data;
+
             in_degree[v]--;
+
             if (in_degree[v] == 0)
-                enqueue(&q, v);
+                enqueue(&q, returnMallocInt(v));
+
             temp = temp->next;
         }
     }
@@ -406,7 +424,8 @@ void topological_sort_kahn(Graph* graph)
     /* Step 4: Cycle detection */
     if (processed != size)
     {
-        printf("Cycle detected! Only %d of %d vertices were processed.\n", processed, size);
+        printf("Cycle detected! Only %d of %d vertices were processed.\n",
+               processed, size);
         printf("The graph is NOT a DAG -- topological sort is not possible.\n");
     }
     else

--- a/src/utils/returnMallocVal.c
+++ b/src/utils/returnMallocVal.c
@@ -1,0 +1,14 @@
+#include "returnMallocVal.h"
+#include <stdlib.h>
+#include<stdio.h>
+
+void* returnMallocInt(int val)
+{
+    int* intVal = malloc(sizeof(int));
+    if(intVal == NULL)
+        return NULL;
+    
+    *intVal = val;
+
+    return intVal;
+}

--- a/src/utils/returnMallocVal.h
+++ b/src/utils/returnMallocVal.h
@@ -1,0 +1,6 @@
+#ifndef RETURN_MALLOC_VAL_H
+#define RETURN_MALLOC_VAL_H
+
+void* returnMallocInt(int val);
+
+#endif

--- a/tests/test_circ_queue.c
+++ b/tests/test_circ_queue.c
@@ -1,6 +1,8 @@
 #include "data_structures.h"
 #include <assert.h>
 #include <stdio.h>
+#include <stdlib.h>
+#include "returnMallocVal.h"
 
 void test_init()
 {
@@ -9,6 +11,7 @@ void test_init()
     assert(q.N == 5);
     assert(q.front == 0);
     assert(q.rear == 0);
+
     destroy_circ_queue(&q);
 
     printf("Circular queue init test passed\n");
@@ -19,11 +22,20 @@ void test_basic_enqueue_dequeue()
     Queue q;
     init_circ_queue(5, &q);
 
-    assert(enqueue(&q, 30) == 1);
-    assert(enqueue(&q, 20) == 1);
+    assert(enqueue(&q, returnMallocInt(30)) == 1);
+    assert(enqueue(&q, returnMallocInt(20)) == 1);
 
-    assert(dequeue(&q) == 30);
-    assert(dequeue(&q) == 20);
+    int* val;
+
+    val = dequeue(&q);
+    assert(val != NULL);
+    assert(*val == 30);
+    free(val);
+
+    val = dequeue(&q);
+    assert(val != NULL);
+    assert(*val == 20);
+    free(val);
 
     destroy_circ_queue(&q);
 
@@ -35,7 +47,7 @@ void test_underflow()
     Queue q;
     init_circ_queue(5, &q);
 
-    assert(dequeue(&q) == -1);
+    assert(dequeue(&q) == NULL);
 
     destroy_circ_queue(&q);
 
@@ -47,11 +59,15 @@ void test_overflow()
     Queue q;
     init_circ_queue(4, &q);
 
-    assert(enqueue(&q, 1) == 1);
-    assert(enqueue(&q, 2) == 1);
-    assert(enqueue(&q, 3) == 1);
+    assert(enqueue(&q, returnMallocInt(1)) == 1);
+    assert(enqueue(&q, returnMallocInt(2)) == 1);
+    assert(enqueue(&q, returnMallocInt(3)) == 1);
 
-    assert(enqueue(&q, 4) == -1);
+    int* ptr = returnMallocInt(4);
+    assert(ptr != NULL);
+
+    assert(enqueue(&q, ptr) == -1);
+    free(ptr);
 
     destroy_circ_queue(&q);
 
@@ -63,19 +79,39 @@ void test_wraparound()
     Queue q;
     init_circ_queue(4, &q);
 
-    enqueue(&q, 1);
-    enqueue(&q, 2);
-    enqueue(&q, 3);
+    enqueue(&q, returnMallocInt(1));
+    enqueue(&q, returnMallocInt(2));
+    enqueue(&q, returnMallocInt(3));
 
-    assert(dequeue(&q) == 1);
-    assert(dequeue(&q) == 2);
+    int* val;
 
-    assert(enqueue(&q, 4) == 1);
-    assert(enqueue(&q, 5) == 1);
+    val = dequeue(&q);
+    assert(val != NULL);
+    assert(*val == 1);
+    free(val);
 
-    assert(dequeue(&q) == 3);
-    assert(dequeue(&q) == 4);
-    assert(dequeue(&q) == 5);
+    val = dequeue(&q);
+    assert(val != NULL);
+    assert(*val == 2);
+    free(val);
+
+    assert(enqueue(&q, returnMallocInt(4)) == 1);
+    assert(enqueue(&q, returnMallocInt(5)) == 1);
+
+    val = dequeue(&q);
+    assert(val != NULL);
+    assert(*val == 3);
+    free(val);
+
+    val = dequeue(&q);
+    assert(val != NULL);
+    assert(*val == 4);
+    free(val);
+
+    val = dequeue(&q);
+    assert(val != NULL);
+    assert(*val == 5);
+    free(val);
 
     destroy_circ_queue(&q);
 

--- a/tests/test_deque.c
+++ b/tests/test_deque.c
@@ -1,6 +1,8 @@
 #include "data_structures.h"
 #include <assert.h>
 #include <stdio.h>
+#include <stdlib.h>
+#include "returnMallocVal.h"
 
 void test_deque_init()
 {
@@ -11,6 +13,7 @@ void test_deque_init()
     assert(dq.rear == -1);
     assert(deque_is_empty(&dq) == true);
     assert(deque_is_full(&dq) == false);
+
     destroy_deque(&dq);
 
     printf("Deque init test passed\n");
@@ -21,22 +24,32 @@ void test_deque_basic_ops()
     Queue dq;
     init_deque(5, &dq);
 
-    assert(deque_insert_rear(&dq, 10) == 1);
-    assert(deque_insert_rear(&dq, 20) == 1);
-    assert(deque_insert_front(&dq, 5) == 1);
+    assert(deque_insert_rear(&dq, returnMallocInt(10)) == 1);
+    assert(deque_insert_rear(&dq, returnMallocInt(20)) == 1);
+    assert(deque_insert_front(&dq, returnMallocInt(5)) == 1);
 
     assert(deque_get_front(&dq) == 5);
     assert(deque_get_rear(&dq) == 20);
 
-    int val;
-    assert(deque_delete_front(&dq, &val) == 1);
-    assert(val == 5);
-    assert(deque_delete_rear(&dq, &val) == 1);
-    assert(val == 20);
-    assert(deque_delete_front(&dq, &val) == 1);
-    assert(val == 10);
+    int* val;
+
+    val = deque_delete_front(&dq);
+    assert(val != NULL);
+    assert(*val == 5);
+    free(val);
+
+    val = deque_delete_rear(&dq);
+    assert(val != NULL);
+    assert(*val == 20);
+    free(val);
+
+    val = deque_delete_front(&dq);
+    assert(val != NULL);
+    assert(*val == 10);
+    free(val);
 
     assert(deque_is_empty(&dq) == true);
+
     destroy_deque(&dq);
 
     printf("Deque basic ops test passed\n");
@@ -47,13 +60,13 @@ void test_deque_underflow()
     Queue dq;
     init_deque(5, &dq);
 
-    int val;
-    assert(deque_delete_front(&dq, &val) == -1);
-    assert(deque_delete_rear(&dq, &val) == -1);
+    assert(deque_delete_front(&dq) == NULL);
+    assert(deque_delete_rear(&dq) == NULL);
     assert(deque_get_front(&dq) == -1);
     assert(deque_get_rear(&dq) == -1);
 
     destroy_deque(&dq);
+
     printf("Deque underflow test passed\n");
 }
 
@@ -62,15 +75,23 @@ void test_deque_overflow()
     Queue dq;
     init_deque(3, &dq);
 
-    assert(deque_insert_rear(&dq, 1) == 1);
-    assert(deque_insert_front(&dq, 2) == 1);
-    assert(deque_insert_rear(&dq, 3) == 1);
+    assert(deque_insert_rear(&dq, returnMallocInt(1)) == 1);
+    assert(deque_insert_front(&dq, returnMallocInt(2)) == 1);
+    assert(deque_insert_rear(&dq, returnMallocInt(3)) == 1);
     assert(deque_is_full(&dq) == true);
 
-    assert(deque_insert_front(&dq, 4) == -1);
-    assert(deque_insert_rear(&dq, 5) == -1);
+    int* ptr1 = returnMallocInt(4);
+    assert(ptr1 != NULL);
+    assert(deque_insert_front(&dq, ptr1) == -1);
+    free(ptr1);
+
+    int* ptr2 = returnMallocInt(5);
+    assert(ptr2 != NULL);
+    assert(deque_insert_rear(&dq, ptr2) == -1);
+    free(ptr2);
 
     destroy_deque(&dq);
+
     printf("Deque overflow test passed\n");
 }
 
@@ -79,31 +100,43 @@ void test_deque_wraparound()
     Queue dq;
     init_deque(3, &dq);
 
-    int val;
-    // Front: -1, Rear: -1
-    assert(deque_insert_rear(&dq, 1) == 1);     // F: 0, R: 0 [1]
-    assert(deque_insert_rear(&dq, 2) == 1);     // F: 0, R: 1 [1, 2]
-    assert(deque_delete_front(&dq, &val) == 1); // F: 1, R: 1 [2]
-    assert(val == 1);
+    int* val;
 
-    assert(deque_insert_front(&dq, 3) == 1); // F: 0, R: 1 [3, 2]
-    assert(deque_insert_front(&dq, 4) == 1); // F: 2, R: 1 [3, 2] (under the hood F wraps to N-1
-                                             // which is 2) [4 at idx 2, 3 at idx 0, 2 at idx 1]
+    // Front: -1, Rear: -1
+    assert(deque_insert_rear(&dq, returnMallocInt(1)) == 1); // F: 0, R: 0 [1]
+    assert(deque_insert_rear(&dq, returnMallocInt(2)) == 1); // F: 0, R: 1 [1, 2]
+
+    val = deque_delete_front(&dq); // F: 1, R: 1 [2]
+    assert(val != NULL);
+    assert(*val == 1);
+    free(val);
+
+    assert(deque_insert_front(&dq, returnMallocInt(3)) == 1); // F: 0, R: 1 [3, 2]
+    assert(deque_insert_front(&dq, returnMallocInt(4)) == 1); // F: 2, R: 1 [4, 3, 2]
     assert(deque_is_full(&dq) == true);
 
     assert(deque_get_front(&dq) == 4);
     assert(deque_get_rear(&dq) == 2);
 
-    assert(deque_delete_rear(&dq, &val) == 1); // F: 2, R: 0
-    assert(val == 2);
-    assert(deque_delete_front(&dq, &val) == 1); // F: 0, R: 0
-    assert(val == 4);
-    assert(deque_delete_front(&dq, &val) == 1); // F: -1, R: -1
-    assert(val == 3);
+    val = deque_delete_rear(&dq); // F: 2, R: 0
+    assert(val != NULL);
+    assert(*val == 2);
+    free(val);
+
+    val = deque_delete_front(&dq); // F: 0, R: 0
+    assert(val != NULL);
+    assert(*val == 4);
+    free(val);
+
+    val = deque_delete_front(&dq); // F: -1, R: -1
+    assert(val != NULL);
+    assert(*val == 3);
+    free(val);
 
     assert(deque_is_empty(&dq) == true);
 
     destroy_deque(&dq);
+
     printf("Deque wraparound test passed\n");
 }
 
@@ -116,5 +149,6 @@ int main()
     test_deque_wraparound();
 
     printf("All Deque tests passed\n");
+
     return 0;
 }

--- a/tests/test_simple_queue.c
+++ b/tests/test_simple_queue.c
@@ -1,6 +1,8 @@
 #include "data_structures.h"
 #include <assert.h>
 #include <stdio.h>
+#include <stdlib.h>
+#include "returnMallocVal.h"
 
 void test_init()
 {
@@ -9,6 +11,7 @@ void test_init()
     assert(q.N == 5);
     assert(q.front == -1);
     assert(q.rear == -1);
+
     destroy_simple_queue(&q);
 
     printf("Simple queue init test passed\n");
@@ -19,12 +22,20 @@ void test_basic_enqueue_dequeue()
     Queue q;
     init_simple_queue(5, &q);
 
-    assert(enqueue_simple(&q, 30) == 1);
-    assert(enqueue_simple(&q, 20) == 1);
+    assert(enqueue_simple(&q, returnMallocInt(30)) == 1);
+    assert(enqueue_simple(&q, returnMallocInt(20)) == 1);
 
-    // FIFO: first in, first out
-    assert(dequeue_simple(&q) == 30);
-    assert(dequeue_simple(&q) == 20);
+    int* val;
+
+    val = dequeue_simple(&q);
+    assert(val != NULL);
+    assert(*val == 30);
+    free(val);
+
+    val = dequeue_simple(&q);
+    assert(val != NULL);
+    assert(*val == 20);
+    free(val);
 
     destroy_simple_queue(&q);
 
@@ -36,7 +47,7 @@ void test_underflow()
     Queue q;
     init_simple_queue(5, &q);
 
-    assert(dequeue_simple(&q) == -1);
+    assert(dequeue_simple(&q) == NULL);
 
     destroy_simple_queue(&q);
 
@@ -48,12 +59,15 @@ void test_overflow()
     Queue q;
     init_simple_queue(3, &q);
 
-    assert(enqueue_simple(&q, 1) == 1);
-    assert(enqueue_simple(&q, 2) == 1);
-    assert(enqueue_simple(&q, 3) == 1);
+    assert(enqueue_simple(&q, returnMallocInt(1)) == 1);
+    assert(enqueue_simple(&q, returnMallocInt(2)) == 1);
+    assert(enqueue_simple(&q, returnMallocInt(3)) == 1);
 
-    // capacity reached: rear is at the last slot
-    assert(enqueue_simple(&q, 4) == -1);
+    int* ptr = returnMallocInt(4);
+    assert(ptr != NULL);
+
+    assert(enqueue_simple(&q, ptr) == -1);
+    free(ptr);
 
     destroy_simple_queue(&q);
 
@@ -62,26 +76,37 @@ void test_overflow()
 
 void test_false_overflow()
 {
-    // The defining limitation of a linear queue: once rear reaches the last slot the queue
-    // is full even after the front has been dequeued. The freed slots are NOT reusable
-    // (unlike a circular queue, which wraps around). This test pins that behaviour.
     Queue q;
     init_simple_queue(3, &q);
 
-    enqueue_simple(&q, 1);
-    enqueue_simple(&q, 2);
-    enqueue_simple(&q, 3); // rear == N-1, queue full
+    enqueue_simple(&q, returnMallocInt(1));
+    enqueue_simple(&q, returnMallocInt(2));
+    enqueue_simple(&q, returnMallocInt(3));
 
-    assert(dequeue_simple(&q) == 1);
-    assert(dequeue_simple(&q) == 2); // two front slots are now free
+    int* val;
 
-    // Only one element (3) remains in a capacity-3 queue, yet enqueue still fails:
-    // rear cannot move past N-1 and the freed front slots cannot be reclaimed.
-    assert(enqueue_simple(&q, 4) == -1);
+    val = dequeue_simple(&q);
+    assert(val != NULL);
+    assert(*val == 1);
+    free(val);
 
-    // The remaining element is still retrievable in order, then the queue is empty.
-    assert(dequeue_simple(&q) == 3);
-    assert(dequeue_simple(&q) == -1);
+    val = dequeue_simple(&q);
+    assert(val != NULL);
+    assert(*val == 2);
+    free(val);
+
+    int* ptr = returnMallocInt(4);
+    assert(ptr != NULL);
+
+    assert(enqueue_simple(&q, ptr) == -1);
+    free(ptr);
+
+    val = dequeue_simple(&q);
+    assert(val != NULL);
+    assert(*val == 3);
+    free(val);
+
+    assert(dequeue_simple(&q) == NULL);
 
     destroy_simple_queue(&q);
 
@@ -94,10 +119,15 @@ void test_fifo_order()
     init_simple_queue(4, &q);
 
     for (int i = 1; i <= 4; i++)
-        assert(enqueue_simple(&q, i * 10) == 1);
+        assert(enqueue_simple(&q, returnMallocInt(i * 10)) == 1);
 
     for (int i = 1; i <= 4; i++)
-        assert(dequeue_simple(&q) == i * 10);
+    {
+        int* val = dequeue_simple(&q);
+        assert(val != NULL);
+        assert(*val == i * 10);
+        free(val);
+    }
 
     destroy_simple_queue(&q);
 


### PR DESCRIPTION
Closes #214 

The queue structure has been made generic so any type of structure can be stored in it.

One special case is with int values as normally we would just type number but as the queue is generic and uses void pointers , we need to use malloc and allocate space for that integer value and free it later. 

For other structures while initializing them they are malloced and have specialized destroy functions so there is no issue like integer values with that.