### PR TITLE
feat: Add structural baseline for Knight's Tour Backtracking Algorithm

### DIFF
--- a/src/backtracking/backtracking.h
+++ b/src/backtracking/backtracking.h
@@ -7,5 +7,6 @@ void n_queens_demo(void);
 void sudoku_demo(void);
 void rat_in_maze_demo(void);
 void graph_coloring_demo(void);
+void knights_tour_demo(void);
 
 #endif // BACKTRACKING_H

--- a/src/backtracking/backtracking_demo.c
+++ b/src/backtracking/backtracking_demo.c
@@ -13,8 +13,9 @@ void backtracking_demo(void)
                                    "\nenter 2 for Sudoku solver"
                                    "\nenter 3 for Rat in a Maze"
                                    "\nenter 4 for Graph Coloring"
+                                   "\nenter 5 for Knight's Tour"
                                    "\nenter choice : ",
-                                   1, 4);
+                                   1, 5);
 
         if (bt_status == INPUT_EXIT_SIGNAL)
         {
@@ -38,6 +39,9 @@ void backtracking_demo(void)
                 break;
             case 4:
                 graph_coloring_demo();
+                break;
+            case 5:
+                knights_tour_demo();
                 break;
         }
     }

--- a/src/backtracking/knights_tour.c
+++ b/src/backtracking/knights_tour.c
@@ -1,0 +1,7 @@
+#include "backtracking.h"
+#include <stdio.h>
+
+void knights_tour_demo(void)
+{
+    printf("\nKnight's Tour demo is coming soon!\n");
+}


### PR DESCRIPTION
Resolves #290

# PR Description

## Summary
This PR implements a structural baseline for the **Knight's Tour** algorithm inside the backtracking module. It adds the skeleton/boilerplate structure and wires the entry points, aligning with the pattern used for other backtracking algorithms in PR #291.

## Changes Made
- **Header Files**:
  - Declared `void knights_tour_demo(void);` in [backtracking.h](file:///e:/C-DSA-interactive-suite/src/backtracking/backtracking.h).
- **Interactive Menu**:
  - Modified [backtracking_demo.c](file:///e:/C-DSA-interactive-suite/src/backtracking/backtracking_demo.c) to add choice `5` for "Knight's Tour" and increased the range in `safe_input_int` from `1, 4` to `1, 5`.
  - Added `case 5` in the switch block to route to `knights_tour_demo()`.
- **Baseline Source**:
  - Created [knights_tour.c](file:///e:/C-DSA-interactive-suite/src/backtracking/knights_tour.c) implementing `knights_tour_demo()` with a "coming soon" placeholder message.

## Verification
- Verified that compiling the code with `mingw32-make` runs without errors.
- Ran the executable `./dsa.exe` and verified:
  - Option `13` (Backtracking) -> Option `5` (Knight's Tour) correctly prints `Knight's Tour demo is coming soon!`.