### PR TITLE
fix: Wrap safe_input_int in validation loop for N-Queens

### DIFF
--- a/src/backtracking/n_queens.c
+++ b/src/backtracking/n_queens.c
@@ -81,27 +81,35 @@ static bool solve_n_queens_util(int N, char board[MAX_N][MAX_N], int col)
 
 void n_queens_demo(void)
 {
-    int N;
-    int status = safe_input_int(&N, "\nEnter the board size N (between 4 and 8): ", 4, MAX_N);
-    if (status == INPUT_EXIT_SIGNAL)
+    while (1)
     {
-        return;
-    }
+        int N;
+        int status = safe_input_int(&N, "\nEnter the board size N (between 4 and 8), or -1 to exit: ", 4, MAX_N);
+        if (status == INPUT_EXIT_SIGNAL)
+        {
+            printf("\nExiting N-Queens Solver...\n");
+            return;
+        }
+        if (status == 0)
+        {
+            continue;
+        }
 
-    char board[MAX_N][MAX_N];
-    for (int i = 0; i < MAX_N; i++)
-        for (int j = 0; j < MAX_N; j++)
-            board[i][j] = '.';
+        char board[MAX_N][MAX_N];
+        for (int i = 0; i < MAX_N; i++)
+            for (int j = 0; j < MAX_N; j++)
+                board[i][j] = '.';
 
-    printf("\nStarting N-Queens Solver...\n");
-    sleep_seconds(1);
+        printf("\nStarting N-Queens Solver...\n");
+        sleep_seconds(1);
 
-    if (solve_n_queens_util(N, board, 0) == false)
-    {
-        printf("\nSolution does not exist for N=%d\n", N);
-    }
-    else
-    {
-        printf("\nSolution found successfully!\n");
+        if (solve_n_queens_util(N, board, 0) == false)
+        {
+            printf("\nSolution does not exist for N=%d\n", N);
+        }
+        else
+        {
+            printf("\nSolution found successfully!\n");
+        }
     }
 }


### PR DESCRIPTION

### Description
This PR fixes a bug in the N-Queens implementation where invalid user input (such as entering `2` when the range is 4 to 8) bypassed the validation constraint and allowed the algorithm to execute with an uninitialized variable.

**The Bug:**
`safe_input_int` returns `0` upon failure. The original implementation did not check for this failure status and didn't loop to ask the user to retry, resulting in the algorithm attempting to run immediately with a broken board size.

**The Fix:**
Wrapped the `safe_input_int` call inside a `while(1)` loop, ensuring it forces the user to try again upon a `0` failure code, only breaking when `1` (success) or returning on `INPUT_EXIT_SIGNAL` is achieved.

**Testing:**
- Verified that inputting `2` now correctly traps the user in a retry loop until they enter a valid number.

Closes #294 

