### PR TITLE
feat: Implement Animated Knight's Tour Backtracking Algorithm

### DIFF
--- a/src/backtracking/knights_tour.c
+++ b/src/backtracking/knights_tour.c
@@ -1,7 +1,230 @@
+#define _DEFAULT_SOURCE
 #include "backtracking.h"
+#include "safe_input.h"
 #include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+
+#ifdef _WIN32
+#include <windows.h>
+#define sleep_ms(ms) Sleep(ms)
+#define clear_screen() system("cls")
+#else
+#include <unistd.h>
+#define sleep_ms(ms) usleep((ms) * 1000)
+#define clear_screen() printf("\033[H\033[J")
+#endif
+
+// ANSI styles
+#define ANSI_COLOR_RESET   "\033[0m"
+
+static int delay_time = 150; // default delay in ms
+
+static const int x_move[8] = {2, 1, -1, -2, -2, -1, 1, 2};
+static const int y_move[8] = {1, 2, 2, 1, -1, -2, -2, -1};
+
+typedef struct {
+    int index;
+    int degree;
+} MoveCandidate;
+
+// Compare degrees for Warnsdorff sorting (ascending order)
+static int compare_candidates(const void* a, const void* b)
+{
+    return ((MoveCandidate*)a)->degree - ((MoveCandidate*)b)->degree;
+}
+
+static void print_board(int N, int board[8][8], int knight_x, int knight_y)
+{
+    clear_screen();
+    printf("\n=== KNIGHT'S TOUR BACKTRACKING VISUALIZER ===\n\n");
+    for (int i = 0; i < N; i++)
+    {
+        for (int j = 0; j < N; j++)
+        {
+            // Checkerboard backgrounds (alternating dark and medium gray blocks)
+            const char* bg = ((i + j) % 2 == 0) ? "\033[48;5;236m" : "\033[48;5;240m";
+
+            if (i == knight_x && j == knight_y)
+            {
+                // Print Knight ♞ in bold yellow
+                printf("%s\033[38;5;226;1m ♞ " ANSI_COLOR_RESET, bg);
+            }
+            else if (board[i][j] != -1)
+            {
+                // Print step count in cyan
+                printf("%s\033[38;5;51m %02d" ANSI_COLOR_RESET, bg, board[i][j]);
+            }
+            else
+            {
+                // Print empty checkered space
+                printf("%s   " ANSI_COLOR_RESET, bg);
+            }
+        }
+        printf("\n");
+    }
+    printf("\nLegend: ♞ Knight | Numbers show sequence of moves\n");
+    printf("Delay: %dms\n", delay_time);
+    fflush(stdout);
+    sleep_ms(delay_time);
+}
+
+// Standard Backtracking solver (no heuristic) - Good for small boards
+static int solve_standard(int x, int y, int move_count, int board[8][8], int N)
+{
+    if (move_count == N * N)
+    {
+        print_board(N, board, x, y);
+        return 1;
+    }
+
+    for (int i = 0; i < 8; i++)
+    {
+        int next_x = x + x_move[i];
+        int next_y = y + y_move[i];
+
+        if (next_x >= 0 && next_x < N && next_y >= 0 && next_y < N && board[next_x][next_y] == -1)
+        {
+            board[next_x][next_y] = move_count;
+            print_board(N, board, next_x, next_y);
+
+            if (solve_standard(next_x, next_y, move_count + 1, board, N))
+                return 1;
+
+            // Backtrack
+            board[next_x][next_y] = -1;
+            print_board(N, board, x, y);
+        }
+    }
+    return 0;
+}
+
+// Helper for Warnsdorff: Get number of onward unvisited moves from cell
+static int get_degree(int x, int y, int board[8][8], int N)
+{
+    int count = 0;
+    for (int i = 0; i < 8; i++)
+    {
+        int nx = x + x_move[i];
+        int ny = y + y_move[i];
+        if (nx >= 0 && nx < N && ny >= 0 && ny < N && board[nx][ny] == -1)
+            count++;
+    }
+    return count;
+}
+
+// Warnsdorff Heuristic guided Backtracking solver - Fast for 8x8 boards
+static int solve_warnsdorff(int x, int y, int move_count, int board[8][8], int N)
+{
+    if (move_count == N * N)
+    {
+        print_board(N, board, x, y);
+        return 1;
+    }
+
+    MoveCandidate candidates[8];
+    int cand_count = 0;
+
+    for (int i = 0; i < 8; i++)
+    {
+        int next_x = x + x_move[i];
+        int next_y = y + y_move[i];
+        if (next_x >= 0 && next_x < N && next_y >= 0 && next_y < N && board[next_x][next_y] == -1)
+        {
+            candidates[cand_count].index = i;
+            candidates[cand_count].degree = get_degree(next_x, next_y, board, N);
+            cand_count++;
+        }
+    }
+
+    // Sort moves in ascending order of degree (minimum degree tried first)
+    qsort(candidates, cand_count, sizeof(MoveCandidate), compare_candidates);
+
+    for (int i = 0; i < cand_count; i++)
+    {
+        int move_idx = candidates[i].index;
+        int next_x = x + x_move[move_idx];
+        int next_y = y + y_move[move_idx];
+
+        board[next_x][next_y] = move_count;
+        print_board(N, board, next_x, next_y);
+
+        if (solve_warnsdorff(next_x, next_y, move_count + 1, board, N))
+            return 1;
+
+        // Backtrack
+        board[next_x][next_y] = -1;
+        print_board(N, board, x, y);
+    }
+    return 0;
+}
 
 void knights_tour_demo(void)
 {
-    printf("\nKnight's Tour demo is coming soon!\n");
+    // Set console output to UTF-8 on Windows for Emojis
+#ifdef _WIN32
+    UINT old_cp = GetConsoleOutputCP();
+    SetConsoleOutputCP(CP_UTF8);
+#endif
+
+    int board[8][8];
+
+    while (1)
+    {
+        int N;
+        int status = safe_input_int(&N,
+                                    "\nEnter the board size N (between 4 and 8), or -1 to exit: ",
+                                    4, 8);
+
+        if (status == INPUT_EXIT_SIGNAL)
+        {
+#ifdef _WIN32
+            SetConsoleOutputCP(old_cp); // restore code page
+#endif
+            printf("\nReturning to Backtracking menu...\n");
+            return;
+        }
+
+        if (status == 0)
+            continue;
+
+        // Initialize board
+        for (int i = 0; i < N; i++)
+        {
+            for (int j = 0; j < N; j++)
+            {
+                board[i][j] = -1;
+            }
+        }
+
+        // Start from cell (0, 0)
+        board[0][0] = 0;
+
+        print_board(N, board, 0, 0);
+
+        clock_t start_t = clock();
+        int solved = 0;
+        // Use standard backtracking for smaller boards to show backtracking/failures,
+        // and Warnsdorff heuristic for larger boards (N >= 6) to solve instantly.
+        if (N <= 5)
+        {
+            solved = solve_standard(0, 0, 1, board, N);
+        }
+        else
+        {
+            solved = solve_warnsdorff(0, 0, 1, board, N);
+        }
+        clock_t end_t = clock();
+        double total_t = (double)(end_t - start_t) / CLOCKS_PER_SEC;
+
+        if (solved)
+        {
+            printf("\n SUCCESS: The knight completed the tour successfully!\n");
+        }
+        else
+        {
+            printf("\n❌ FAILURE: No tour exists for the knight from the starting position.\n");
+        }
+        printf("Time taken: %f seconds\n", total_t);
+    }
 }


### PR DESCRIPTION
resolves #290 

# PR Description

## Summary
This PR fully implements the **Knight's Tour** backtracking solver and interactive visualizer. It features a dynamically sized board input, visualizes the steps taken using checkered cell backgrounds and a chess knight icon (`♞`), measures the solver execution time, and supports both standard backtracking and Warnsdorff's heuristic for fast solutions on larger boards.

## Changes Made
- **Interactive Knight's Tour Visualizer**:
  - Implemented a dynamic board size prompt asking for $N$ between 4 and 8, or `-1` to exit.
  - Implemented alternating light/dark checkered backgrounds using ANSI color escapes.
  - Displays the step number sequence in cyan, and the current knight position using the Unicode `♞` piece in bold yellow.
  - Displays the total solver execution time using `clock()` upon tour completion/failure.
  - Directly loops back to the board size prompt upon completion without intermediate keypress blocks.
- **Backtracking Solvers**:
  - **Standard Backtracking**: Runs on smaller chessboards ($N \le 5$) to show backtrack steps and dead-ends in real-time.
  - **Warnsdorff's Heuristic**: Runs on larger chessboards ($N \ge 6$) to prioritize moves with the minimum onward degree, solving even an $8 \times 8$ board instantly.
- **Portability & Build System**:
  - Defined `#define _DEFAULT_SOURCE` at the top of [knights_tour.c](file:///e:/C-DSA-interactive-suite/src/backtracking/knights_tour.c) to expose the POSIX `usleep` function, resolving strict C11 compiler flags (`-Werror`) under Linux/macOS.

## Verification
- Verified compilation using `mingw32-make` under MinGW/GCC without errors.
- Verified manual execution path on `./dsa.exe` under option `13` (Backtracking) -> `5` (Knight's Tour).