### PR TITLE
feat: Add animated 6x6 Sudoku Solver using Backtracking

### DIFF
--- a/src/backtracking/sudoku.c
+++ b/src/backtracking/sudoku.c
@@ -1,7 +1,176 @@
 #include "backtracking.h"
+#include "cross_platform.h"
+#include "safe_input.h"
+#include <stdbool.h>
 #include <stdio.h>
+#include <stdlib.h>
+
+#define N 6
+
+// A 6x6 Sudoku puzzle with some missing numbers to demonstrate backtracking.
+// It is small enough to run quickly even with the 1-second animation delay.
+static int initial_grid[N][N] = {
+    {1, 5, 3, 4, 6, 0},
+    {4, 6, 2, 0, 1, 3},
+    {2, 4, 5, 6, 3, 1},
+    {0, 1, 6, 2, 4, 5},
+    {5, 3, 4, 1, 2, 6},
+    {6, 0, 1, 3, 5, 4}
+};
+
+static void print_sudoku_board(int grid[N][N])
+{
+#ifdef _WIN32
+    system("cls");
+#else
+    system("clear");
+#endif
+    printf("\n--- Sudoku Solver Visualization (6x6) ---\n\n");
+    for (int row = 0; row < N; row++)
+    {
+        if (row % 2 == 0 && row != 0)
+        {
+            printf("-----------------\n");
+        }
+        for (int col = 0; col < N; col++)
+        {
+            if (col % 3 == 0 && col != 0)
+            {
+                printf(" | ");
+            }
+            if (grid[row][col] == 0)
+            {
+                printf(". ");
+            }
+            else
+            {
+                printf("%d ", grid[row][col]);
+            }
+        }
+        printf("\n");
+    }
+    printf("\n");
+    sleep_seconds(1);
+}
+
+static bool is_safe_sudoku(int grid[N][N], int row, int col, int num)
+{
+    // Check if we find the same num in the similar row
+    for (int x = 0; x < N; x++)
+    {
+        if (grid[row][x] == num)
+        {
+            return false;
+        }
+    }
+
+    // Check if we find the same num in the similar column
+    for (int x = 0; x < N; x++)
+    {
+        if (grid[x][col] == num)
+        {
+            return false;
+        }
+    }
+
+    // Check if we find the same num in the 2x3 matrix (blocks for 6x6 Sudoku)
+    int startRow = row - (row % 2);
+    int startCol = col - (col % 3);
+
+    for (int i = 0; i < 2; i++)
+    {
+        for (int j = 0; j < 3; j++)
+        {
+            if (grid[i + startRow][j + startCol] == num)
+            {
+                return false;
+            }
+        }
+    }
+
+    return true;
+}
+
+static bool solve_sudoku_util(int grid[N][N], int row, int col)
+{
+    // If we have reached the Nth row, the board is completely filled
+    if (row == N)
+    {
+        return true;
+    }
+
+    // If column reaches N, move to the next row and reset column to 0
+    if (col == N)
+    {
+        return solve_sudoku_util(grid, row + 1, 0);
+    }
+
+    // If the current position already contains a value > 0, move to next column
+    if (grid[row][col] > 0)
+    {
+        return solve_sudoku_util(grid, row, col + 1);
+    }
+
+    for (int num = 1; num <= N; num++)
+    {
+        // Check if it is safe to place the num (1-6) in the given row,col
+        if (is_safe_sudoku(grid, row, col, num))
+        {
+            grid[row][col] = num;
+            print_sudoku_board(grid);
+
+            // Checking for next possibility with next column
+            if (solve_sudoku_util(grid, row, col + 1))
+            {
+                return true;
+            }
+        }
+
+        // Backtrack: assumption was wrong
+        grid[row][col] = 0; 
+        print_sudoku_board(grid);
+    }
+    return false;
+}
 
 void sudoku_demo(void)
 {
-    printf("\nSudoku solver demo is coming soon!\n");
+    while (1)
+    {
+        int choice;
+        // safe_input_int prevents crashes from ANY invalid value (letters, symbols, out of range)
+        int status = safe_input_int(&choice, "\nEnter 1 to solve the predefined 6x6 Sudoku puzzle, or -1 to exit: ", 1, 1);
+        
+        if (status == INPUT_EXIT_SIGNAL)
+        {
+            printf("\nExiting Sudoku Solver...\n");
+            return;
+        }
+        if (status == 0)
+        {
+            continue; // Force retry on failure
+        }
+
+        int grid[N][N];
+        for (int i = 0; i < N; i++)
+        {
+            for (int j = 0; j < N; j++)
+            {
+                grid[i][j] = initial_grid[i][j];
+            }
+        }
+
+        printf("\nStarting Sudoku Solver...\n");
+        sleep_seconds(1);
+        print_sudoku_board(grid);
+
+        if (solve_sudoku_util(grid, 0, 0))
+        {
+            printf("\nSudoku solved successfully!\n");
+        }
+        else
+        {
+            printf("\nNo solution exists for this Sudoku.\n");
+        }
+    }
 }


### PR DESCRIPTION
Resolves #290 
### Description
This PR introduces the **Sudoku Solver** algorithm to the Backtracking module. 

To provide a highly satisfying and fast-paced visualization, a **6x6 grid** was chosen over the traditional 9x9 grid. A 6x6 grid has a drastically smaller search space, allowing the algorithm to animate "deep backtracking" optimally without taking an unreasonable amount of time to finish.

**Key Changes:**
- Implemented `is_safe_sudoku` to correctly validate numbers against rows, columns, and $2 \times 3$ subgrids.
- Implemented `solve_sudoku_util` to recursively explore paths and backtrack upon hitting dead ends.
- Added a `print_sudoku_board` visualizer utilizing `sleep_seconds(1)` and console clearing for frame-by-frame animation.
- Wrapped the `sudoku_demo` in an infinite `while (1)` loop.
- Bound input handling with `safe_input_int`, safely handling out-of-bounds or non-numeric inputs by returning a failure code (`0`) that is caught with `continue`.

**Testing:**
- Verified compilation with `mingw32-make` (no warnings).
- Verified the algorithm correctly solves the predefined 6x6 puzzle.
- Verified the loop correctly prompts to solve again or exit on `-1`.
- Verified typing letters or invalid choices successfully loops the prompt without crashing.
