### PR TITLE
refactor: Support fractional delay in sleep_seconds

### DIFF
--- a/src/utils/cross_platform.c
+++ b/src/utils/cross_platform.c
@@ -6,11 +6,11 @@
 #include <unistd.h>
 #endif
 
-void sleep_seconds(unsigned int seconds)
+void sleep_seconds(float seconds)
 {
 #ifdef _WIN32
     Sleep(seconds * 1000);
 #else
-    sleep(seconds);
+    usleep(seconds * 1000000);
 #endif
 }

--- a/src/utils/cross_platform.c
+++ b/src/utils/cross_platform.c
@@ -3,6 +3,7 @@
 #ifdef _WIN32
 #include <windows.h>
 #else
+#define _DEFAULT_SOURCE
 #include <unistd.h>
 #endif
 

--- a/src/utils/cross_platform.h
+++ b/src/utils/cross_platform.h
@@ -1,6 +1,6 @@
 #ifndef CROSS_PLATFORM_H
 #define CROSS_PLATFORM_H
 
-void sleep_seconds(unsigned int seconds);
+void sleep_seconds(float seconds);
 
 #endif


### PR DESCRIPTION
## Description

Updated `sleep_seconds()` to support fractional delays for smoother algorithm visualizations.

### Changes Made
- Changed `sleep_seconds()` parameter type from `unsigned int` to `float`
- Replaced `sleep()` with `usleep()` on UNIX systems for microsecond precision
- Retained Windows compatibility using `Sleep()`

### Example
Now supports:

```c
sleep_seconds(0.5);
```

### Fixes: #309 