### PR TITLE
Add time delay to parantheses_checker.c demo (closes #307)

### DIFF
--- a/src/expression_evaluation/parantheses_checker.c
+++ b/src/expression_evaluation/parantheses_checker.c
@@ -1,3 +1,4 @@
+#include "cross_platform.h"
 #include "safe_input.h"
 #include "stack.h"
 #include <stdio.h>
@@ -98,6 +99,7 @@ int check_parantheses(char* s)
         }
         printf("-----------------------------------\n");
         i++;
+        sleep_seconds(1);
     }
     int result = isEmpty(parantheses);
     if (!result)


### PR DESCRIPTION
Closes #307
**Summary**
Adds a time delay to _parantheses_checker.c's_ demo function, bringing it in line with the existing behavior in _infix_to_postfix.c_ and _postfix_evaluation.c._

**Changes**

Added #include "_cross_platform.h_" to _parantheses_checker.c_
Added _sleep_seconds(1_) after each step in the _check_parantheses_ loop

**Before**
All steps (Step, Char, Action, Stack) were printed instantly with no delay, making it hard to follow the stack operations in real time.

**After**
Each step now pauses for 1 second before moving to the next, matching the step-by-step demo style of the infix-to-postfix and postfix evaluation demos.

**Testing**
Built and ran the project locally with mingw32-make and mingw32-make run. Tested the parantheses checker demo with inputs like ([{}]) and confirmed each step now pauses for 1 second, consistent with the other demos.