### PR TITLE
feat: add cross-platform clear_screen utility

### DIFF
--- a/src/utils/clear_screen.c
+++ b/src/utils/clear_screen.c
@@ -1,0 +1,11 @@
+#include "clear_screen.h"
+#include <stdlib.h>
+
+void clear_screen(void)
+{
+#ifdef _WIN32
+    system("cls");
+#else
+    system("clear");
+#endif
+}

--- a/src/utils/clear_screen.h
+++ b/src/utils/clear_screen.h
@@ -1,0 +1,11 @@
+#ifndef CLEAR_SCREEN_H
+#define CLEAR_SCREEN_H
+
+/**
+ * Clears the terminal screen in a cross-platform manner.
+ * On Windows, it executes system("cls").
+ * On non-Windows platforms, it executes system("clear").
+ */
+void clear_screen(void);
+
+#endif // CLEAR_SCREEN_H


### PR DESCRIPTION
## Overview
This PR introduces a cross-platform screen clearing utility (`clear_screen`) in `src/utils`. 

## Rationale
Currently, multiple visualizer modules (such as those in `src/backtracking`) define local macros or inline preprocessor directives to execute `system("cls")` on Windows and `system("clear")` on other platforms. Centralizing this logic into a utility reduces redundancy and simplifies screen-clearing calls.

As requested, this PR only introduces the utility module interface and implementation. Refactoring the backtracking visualizers to use this function will be handled in a follow-up PR.

## Changes
- Created `src/utils/clear_screen.h`: Declares the `clear_screen(void)` function.
- Created `src/utils/clear_screen.c`: Implements the function using cross-platform preprocessor directives (`_WIN32`).

## Verification
- Verified successful compilation and linking of the new utility objects into the main build:
  ```powershell
  mingw32-make clean; mingw32-make

closes #314 