### PR TITLE
refactor(backtracking): use centralized clear_screen utility

### DIFF
--- a/src/backtracking/graph_coloring.c
+++ b/src/backtracking/graph_coloring.c
@@ -6,13 +6,9 @@
 #include <time.h>
 #include <string.h>
 
+#include "clear_screen.h"
 #ifdef _WIN32
     #include <windows.h>
-    #define clear_screen() system("cls")
-#else
-    #define _DEFAULT_SOURCE
-    #include <unistd.h>
-    #define clear_screen() printf("\033[H\033[J")
 #endif
 
 #define MAX_V 10
@@ -287,7 +283,6 @@ void graph_coloring_demo(void)
 {
     // Set console output to UTF-8 on Windows for Unicode support (●)
 #ifdef _WIN32
-    #include <windows.h>
     UINT old_cp = GetConsoleOutputCP();
     SetConsoleOutputCP(CP_UTF8);
 #endif

--- a/src/backtracking/knights_tour.c
+++ b/src/backtracking/knights_tour.c
@@ -6,12 +6,9 @@
 #include <time.h>
 #include "cross_platform.h"
 
+#include "clear_screen.h"
 #ifdef _WIN32
 #include <windows.h>
-#define clear_screen() system("cls")
-#else
-#include <unistd.h>
-#define clear_screen() printf("\033[H\033[J")
 #endif
 
 // ANSI styles

--- a/src/backtracking/n_queens.c
+++ b/src/backtracking/n_queens.c
@@ -6,15 +6,13 @@
 
 #include "cross_platform.h"
 
+#include "clear_screen.h"
+
 #define MAX_N 8
 
 static void print_board(int N, char board[MAX_N][MAX_N])
 {
-#ifdef _WIN32
-    system("cls");
-#else
-    system("clear");
-#endif
+    clear_screen();
     printf("\n--- N-Queens Visualization ---\n\n");
     for (int i = 0; i < N; i++)
     {

--- a/src/backtracking/rat_in_maze.c
+++ b/src/backtracking/rat_in_maze.c
@@ -5,6 +5,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+#include "clear_screen.h"
+
 #define N 6
 
 // 1 represents an open path, 0 represents a wall
@@ -13,11 +15,7 @@ static int initial_maze[N][N] = {{1, 1, 1, 1, 0, 1}, {1, 0, 0, 1, 0, 1}, {1, 1, 
 
 static void print_maze_state(int maze[N][N], int solution[N][N])
 {
-#ifdef _WIN32
-    system("cls");
-#else
-    system("clear");
-#endif
+    clear_screen();
     printf("\n--- Rat in a Maze Visualization (6x6) ---\n\n");
     for (int i = 0; i < N; i++)
     {

--- a/src/backtracking/sudoku.c
+++ b/src/backtracking/sudoku.c
@@ -5,6 +5,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+#include "clear_screen.h"
+
 #define N 6
 
 // A 6x6 Sudoku puzzle with some missing numbers to demonstrate backtracking.
@@ -14,11 +16,7 @@ static int initial_grid[N][N] = {{1, 5, 3, 4, 6, 0}, {4, 6, 2, 0, 1, 3}, {2, 4, 
 
 static void print_sudoku_board(int grid[N][N])
 {
-#ifdef _WIN32
-    system("cls");
-#else
-    system("clear");
-#endif
+    clear_screen();
     printf("\n--- Sudoku Solver Visualization (6x6) ---\n\n");
     for (int row = 0; row < N; row++)
     {


### PR DESCRIPTION
## Overview
Closes #320 .

This PR refactors all backtracking visualizer files to use the centralized `clear_screen()` utility from `src/utils/clear_screen.h`, eliminating redundant, platform-specific screen-clearing preprocessor macros and system-call wrappers.

## Changes
- Removed duplicate local `#define clear_screen()` macro definitions from `graph_coloring.c` and `knights_tour.c`.
- Replaced duplicate inline `#ifdef _WIN32 system("cls"); #else ...` blocks with direct calls to `clear_screen()` in `n_queens.c`, `rat_in_maze.c`, and `sudoku.c`.
- Included `"clear_screen.h"` in all affected visualizer files.
- Restored standard `<windows.h>` includes to the top of `graph_coloring.c` and `knights_tour.c` to prevent nested inclusion compile errors under Windows.

## Verification
- Verified successful clean build:
  ```powershell
  mingw32-make clean; mingw32-make
