### PR TITLE
fix(bucket-sort): widen bucket-index divisor to avoid signed overflow and OOB write

### DIFF
--- a/src/advanced_sorting_algorithms/bucket_sort.c
+++ b/src/advanced_sorting_algorithms/bucket_sort.c
@@ -47,7 +47,7 @@ void bucket_sort(int arr[], int n)
     {
         // Calculate bucket index relative to range
         long long diff = (long long)arr[i] - min_val;
-        int bucket_idx = (int)((diff * (N - 1)) / (max_val - min_val));
+        int bucket_idx = (int)((diff * (N - 1)) / ((long long)max_val - min_val));
 
         // Insert element into the bucket list using SLL utility
         int insert_status = sll_insertAtBeginning(&buckets[bucket_idx], arr[i]);

--- a/tests/test_advanced_sorting.c
+++ b/tests/test_advanced_sorting.c
@@ -1,4 +1,5 @@
 #include <assert.h>
+#include <limits.h>
 #include <stdio.h>
 
 /* Functions under test (forward-declared, same approach as the other tests).
@@ -317,6 +318,15 @@ void test_bucket_sort()
     assert(random_vals[6] == 90);
     assert(random_vals[7] == 170);
     assert(random_vals[8] == 802);
+
+    /* wide value range: max - min exceeds INT_MAX, so the bucket-index
+       divisor must be computed in a wider type to avoid signed overflow
+       and an out-of-bounds bucket index */
+    int wide[3] = {INT_MAX, 0, INT_MIN};
+    bucket_sort(wide, 3);
+    assert(wide[0] == INT_MIN);
+    assert(wide[1] == 0);
+    assert(wide[2] == INT_MAX);
 
     printf("Bucket sort tests passed\n");
 }


### PR DESCRIPTION
Closes #327

### Problem

`bucket_sort` computed the scatter-phase bucket index as:

```c
long long diff = (long long)arr[i] - min_val;
int bucket_idx = (int)((diff * (N - 1)) / (max_val - min_val));
```

`diff` is widened to `long long`, but the divisor `max_val - min_val` was left as an `int` subtraction. When the array's value range exceeds `INT_MAX` (it contains both a large negative and a large positive value), that subtraction overflows — undefined behaviour — and gives a garbage divisor, producing a `bucket_idx` outside `[0, N-1]` and an out-of-bounds write into the `calloc`'d `buckets` array (heap corruption / crash).

### Fix

Widen the divisor to `long long` as well:

```c
int bucket_idx = (int)((diff * (N - 1)) / ((long long)max_val - min_val));
```

### Test

Added a regression case to `test_bucket_sort` covering `{INT_MAX, 0, INT_MIN}` (range > INT_MAX). The existing tests only used small negatives, so this path was never exercised.

### Verification

- `make` clean under `-Werror`
- `make test` — all advanced sorting tests pass, including the new wide-range case
- `make valgrind` on `test_advanced_sorting` — 0 errors, 0 leaks
- Cross-checked the fixed function against a `qsort` reference over 500k random arrays (demo range 1..10000, small negatives, and `INT_MAX`/`INT_MIN` extremes) — all match, and `-fsanitize=address,undefined` reports no errors. Before the fix the same extreme inputs crashed with a signed-overflow + heap-buffer-overflow diagnostic.
- `clang-format` applied to the changed files.
