### PR TITLE
fix: resolve severe ncurses memory leak by replacing initscr with refresh

### DIFF
--- a/src/tui/tui.c
+++ b/src/tui/tui.c
@@ -364,13 +364,11 @@ static void run_demo(demo_fn fn, const char* name, State* s)
         ;
 
     /* reclaim terminal */
-    // setlocale(LC_ALL, "");
-    initscr();
+    refresh();
     noecho();
     cbreak();
     keypad(stdscr, TRUE);
     curs_set(0);
-    init_colors();
 
     /* update state */
     strncpy(s->last_ran, name, sizeof(s->last_ran) - 1);


### PR DESCRIPTION
## Description
This PR resolves a critical memory leak and undefined behavior issue within the `ncurses` TUI wrapper. 
Fixes #334 
Previously, `src/tui/tui.c` incorrectly invoked `initscr()` to resume the TUI after suspending it via `endwin()`. Repeatedly calling `initscr()` without terminating the program causes `ncurses` to blindly allocate overlapping memory buffers, resulting in severe memory leaks each time a demo is closed and control returns to the main menu. 

This PR fixes the issue by replacing the redundant initialization calls with `refresh()`, which is the standard, documented way to safely resume an existing `ncurses` session after `endwin()`.

## Changes Made
* **`src/tui/tui.c`**: 
  * Removed `initscr()` and `init_colors()` from the post-demo terminal reclamation block in `run_demo()`.
  * Added `refresh()` to properly restore the suspended `ncurses` context.

## Testing Performed
* Verified that the application compiles without warnings.
* Manually ran algorithm demos (e.g., Rat in a Maze) and ensured that the TUI cleanly resumes without visual corruption or crashes.
