### PR TITLE
feat: add doubly circular linked list (dcll) implementation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,7 +106,7 @@ valgrind:
 
 TEST_BINS = test_circ_queue test_bst test_search test_hash_func \
             test_sll test_dll test_array test_stack test_tbt \
-            test_priority_queue test_scll test_simple_queue \
+            test_priority_queue test_scll test_dcll test_simple_queue \
             test_deque test_astar test_avl \
             test_greedy_bfs test_sorting_n2 test_advanced_sorting \
             test_history_logger test_shell_sort test_trie test_btree test_bplus_tree test_parity_bit \
@@ -217,6 +217,13 @@ test_scll: $(TEST_DIR)/test_scll$(EXE)
 	$(TEST_DIR)/test_scll$(EXE)
 
 $(TEST_DIR)/test_scll$(EXE): $(OBJ_DIR)/src/data_structures/scll.o $(OBJ_DIR)/src/utils/safe_input_int.o tests/test_scll.c
+	@$(call MKDIR_P,$(TEST_DIR))
+	$(CC) $(CFLAGS) $^ -o $@ $(LDFLAGS)
+
+test_dcll: $(TEST_DIR)/test_dcll$(EXE)
+	$(TEST_DIR)/test_dcll$(EXE)
+
+$(TEST_DIR)/test_dcll$(EXE): $(OBJ_DIR)/src/data_structures/dcll.o $(OBJ_DIR)/src/utils/safe_input_int.o tests/test_dcll.c
 	@$(call MKDIR_P,$(TEST_DIR))
 	$(CC) $(CFLAGS) $^ -o $@ $(LDFLAGS)
 

--- a/src/data_structures/data_structures.h
+++ b/src/data_structures/data_structures.h
@@ -160,4 +160,37 @@ bool deque_is_full(const Queue* dq);
 void display_deque(const Queue* dq);
 void deque_demo(void);
 
+
+// For Doubly cirular linked list 
+
+typedef struct dcll_Node
+{
+    int data;
+    struct dcll_Node * next;
+    struct dcll_Node * prev;
+}dcll_Node;
+
+typedef struct dcll
+{
+    dcll_Node* head;
+    dcll_Node* tail;
+    int length;
+} dcll;
+
+void dcll_init(dcll* list);
+int dcll_insertAtBeginning(dcll* list, int value);
+int dcll_insertAtEnd(dcll* list, int value);
+int dcll_insertAtPosition(dcll* list, int value, int position);
+int dcll_deleteAtBeginning(dcll* list);
+int dcll_deleteAtEnd(dcll* list);
+int dcll_deleteByValue(dcll* list, int value);
+int dcll_deleteAtPosition(dcll* list, int position);
+int dcll_search(const dcll* list, int key);
+int dcll_getLength(const dcll* list);
+void dcll_printlist(const dcll* list);
+void dcll_destroy(dcll* list);
+void dcll_Demo(void);
+
+
+
 #endif

--- a/src/data_structures/data_structures_demo.c
+++ b/src/data_structures/data_structures_demo.c
@@ -85,7 +85,8 @@ void data_structures_demo(void)
                         safe_input_int(&circular_variant_choice,
                                        "\nenter 1 for circular queue demo"
                                        "\nenter 2 for singly circular linked list demo"
-                                       "\nenter 3 for double-ended queue (deque) demo"
+                                       "\nenter 3 for doubly circular  linked list demo"
+                                       "\nenter 4 for double-ended queue (deque) demo"
                                        "\nenter choice : ",
                                        1, 3);
                     if (circular_variant_status == 0)
@@ -101,6 +102,10 @@ void data_structures_demo(void)
                         scll_Demo();
                     }
                     if (circular_variant_choice == 3)
+                    {
+                        dcll_Demo();
+                    }
+                    if (circular_variant_choice == 4)
                     {
                         deque_demo();
                     }

--- a/src/data_structures/dcll.c
+++ b/src/data_structures/dcll.c
@@ -1,0 +1,668 @@
+#include "data_structures.h"
+#include "safe_input.h"
+#include <stdio.h>
+#include <stdlib.h>
+
+// Doubly circular linked list. See data_structures.h for the head/tail/length invariant.
+//
+// A note on traversal: because the list is circular there is no NULL terminator to stop on.
+// Every traversal here therefore walks at most `length` nodes, using the idiom
+//     cur = head; do { ...; cur = cur->next; } while (cur != head);
+// which visits each node exactly once and is guaranteed to terminate (it stops the moment it
+// arrives back at head). This is what prevents the infinite loops a circular list invites.
+//
+// Unlike scll, each node also carries a prev pointer so deletions at the end are O(1) —
+// no predecessor walk is needed.
+
+// Allocates a node holding `value`. Returns NULL on malloc failure. The caller is responsible
+// for linking it into the ring (next and prev are left as NULL on purpose).
+
+static dcll_Node* dcll_create_node(int value)
+{
+    dcll_Node* node = malloc(sizeof(dcll_Node));
+    if (node == NULL)
+    {
+        return NULL;
+    }
+    node->data = value;
+    node->next = NULL;
+    node->prev = NULL;
+    return node;
+}
+
+void dcll_init(dcll* list)
+{
+    list->head = NULL;
+    list->tail = NULL;
+    list->length = 0;
+}
+
+int dcll_insertAtBeginning(dcll* list, int value)
+{
+    dcll_Node* node = dcll_create_node(value);
+    if (node == NULL)
+    {
+        return -1;
+    }
+
+    if (list->head == NULL)
+    {
+        // First node: it must point to itself so that tail->next == head and head->prev == tail.
+        node->next = node;
+        node->prev = node;
+        list->head = node;
+        list->tail = node;
+    }
+    else
+    {
+        // New node becomes the head; tail keeps closing the ring onto the new head.
+        node->next = list->head;
+        node->prev = list->tail;
+        list->head->prev = node;
+        list->tail->next = node;
+        list->head = node;
+    }
+
+    list->length++;
+    return 1;
+}
+
+int dcll_insertAtEnd(dcll* list, int value)
+{
+    dcll_Node* node = dcll_create_node(value);
+    if (node == NULL)
+    {
+        return -1;
+    }
+
+    if (list->head == NULL)
+    {
+        // First node: point to itself in both directions.
+        node->next = node;
+        node->prev = node;
+        list->head = node;
+        list->tail = node;
+    }
+    else
+    {
+        // Link after the current tail and close the ring back onto head. O(1) thanks to tail.
+        node->next = list->head;
+        node->prev = list->tail;
+        list->tail->next = node;
+        list->head->prev = node;
+        list->tail = node;
+    }
+
+    list->length++;
+    return 1;
+}
+
+int dcll_insertAtPosition(dcll* list, int value, int position)
+{
+    // Valid insert positions are 0..length (length == append at the end).
+    if (position < 0 || position > list->length)
+    {
+        return -2;
+    }
+
+    if (position == 0)
+    {
+        return dcll_insertAtBeginning(list, value);
+    }
+    if (position == list->length)
+    {
+        return dcll_insertAtEnd(list, value);
+    }
+
+    // Interior insert: walk to the node just before the target position.
+    dcll_Node* node = dcll_create_node(value);
+    if (node == NULL)
+    {
+        return -1;
+    }
+
+    dcll_Node* prev = list->head;
+    for (int i = 0; i < position - 1; i++)
+    {
+        prev = prev->next;
+    }
+
+    node->next = prev->next;
+    node->prev = prev;
+    prev->next->prev = node;
+    prev->next = node;
+    // head and tail are untouched here (position is strictly interior), invariant preserved.
+
+    list->length++;
+    return 1;
+}
+
+int dcll_deleteAtBeginning(dcll* list)
+{
+    if (list->head == NULL)
+    {
+        return -1;
+    }
+
+    dcll_Node* old_head = list->head;
+
+    if (list->head == list->tail)
+    {
+        // Single node deletes down to the empty list.
+        free(old_head);
+        list->head = NULL;
+        list->tail = NULL;
+    }
+    else
+    {
+        list->head = old_head->next;
+        list->head->prev = list->tail; // new head's prev closes onto tail
+        list->tail->next = list->head; // tail closes ring onto new head
+        free(old_head);
+    }
+
+    list->length--;
+    return 1;
+}
+
+int dcll_deleteAtEnd(dcll* list)
+{
+    if (list->head == NULL)
+    {
+        return -1;
+    }
+
+    dcll_Node* old_tail = list->tail;
+
+    if (list->head == list->tail)
+    {
+        // Single node deletes down to the empty list.
+        free(old_tail);
+        list->head = NULL;
+        list->tail = NULL;
+    }
+    else
+    {
+        // O(1) because prev pointer gives us the predecessor directly.
+        list->tail = old_tail->prev;
+        list->tail->next = list->head; // re-close the ring forward
+        list->head->prev = list->tail; // re-close the ring backward
+        free(old_tail);
+    }
+
+    list->length--;
+    return 1;
+}
+
+int dcll_deleteByValue(dcll* list, int value)
+{
+    if (list->head == NULL)
+    {
+        return -2;
+    }
+
+    // Deleting the head value is delegated so the head/tail bookkeeping stays in one place.
+    if (list->head->data == value)
+    {
+        return dcll_deleteAtBeginning(list);
+    }
+
+    // Search for the node holding `value`, bounded by one full lap.
+    dcll_Node* cur = list->head->next;
+    while (cur != list->head)
+    {
+        if (cur->data == value)
+        {
+            cur->prev->next = cur->next;
+            cur->next->prev = cur->prev;
+            if (cur == list->tail)
+            {
+                list->tail = cur->prev; // removed the tail: prev becomes the new tail
+            }
+            free(cur);
+            list->length--;
+            return 1;
+        }
+        cur = cur->next;
+    }
+
+    return -1; // value not present
+}
+
+int dcll_deleteAtPosition(dcll* list, int position)
+{
+    if (list->head == NULL)
+    {
+        return -1;
+    }
+    // Valid delete positions are 0..length-1.
+    if (position < 0 || position >= list->length)
+    {
+        return -2;
+    }
+
+    if (position == 0)
+    {
+        return dcll_deleteAtBeginning(list);
+    }
+
+    if (position == list->length - 1)
+    {
+        return dcll_deleteAtEnd(list);
+    }
+
+    // Walk to the target node.
+    dcll_Node* target = list->head;
+    for (int i = 0; i < position; i++)
+    {
+        target = target->next;
+    }
+
+    target->prev->next = target->next;
+    target->next->prev = target->prev;
+    free(target);
+
+    list->length--;
+    return 1;
+}
+
+int dcll_search(const dcll* list, int key)
+{
+    if (list->head == NULL)
+    {
+        return -1;
+    }
+
+    int index = 0;
+    const dcll_Node* cur = list->head;
+    do
+    {
+        if (cur->data == key)
+        {
+            return index;
+        }
+        cur = cur->next;
+        index++;
+    } while (cur != list->head);
+
+    return -1;
+}
+
+int dcll_getLength(const dcll* list)
+{
+    return list->length;
+}
+
+void dcll_printlist(const dcll* list)
+{
+    printf("HEAD->");
+    if (list->head == NULL)
+    {
+        printf("(empty)");
+        return;
+    }
+
+    const dcll_Node* cur = list->head;
+    do
+    {
+        printf("%d->", cur->data);
+        cur = cur->next;
+    } while (cur != list->head);
+
+    printf("(back to HEAD)");
+}
+
+void dcll_destroy(dcll* list)
+{
+    if (list->head == NULL)
+    {
+        return;
+    }
+
+    // Break the ring first so the walk has a NULL terminator and we never revisit a freed node.
+    list->tail->next = NULL;
+    dcll_Node* cur = list->head;
+    while (cur != NULL)
+    {
+        dcll_Node* upcoming = cur->next;
+        free(cur);
+        cur = upcoming;
+    }
+
+    list->head = NULL;
+    list->tail = NULL;
+    list->length = 0;
+}
+
+void dcll_Demo(void)
+{
+    dcll list;
+    dcll_init(&list);
+
+    int dcll_element_count;
+    int dcll_length_status;
+
+start_dcll:
+    dcll_length_status = safe_input_int(
+        &dcll_element_count,
+        "enter how many elements you want to insert, (between 1 and 100), enter '-1' to exit :- ",
+        1, 100);
+
+    if (dcll_length_status == INPUT_EXIT_SIGNAL)
+    {
+        printf("\nExiting dcll demo\n");
+        dcll_destroy(&list);
+        return;
+    }
+
+    if (dcll_length_status == 0)
+    {
+        goto start_dcll;
+    }
+
+    while (dcll_element_count > 0)
+    {
+        int dcll_position_choice;
+        int dcll_position_status;
+
+    dcll_position_selection:
+        dcll_position_status = safe_input_int(&dcll_position_choice,
+                                              "\nenter '0' for inserting at beginning"
+                                              "\nenter '1' for inserting at end"
+                                              "\nenter '2' for inserting at specific position"
+                                              "\nenter '-1' to exit :- ",
+                                              0, 2);
+
+        if (dcll_position_status == INPUT_EXIT_SIGNAL)
+        {
+            printf("\nExiting dcll demo\n");
+            dcll_destroy(&list);
+            return;
+        }
+
+        if (dcll_position_status == 0)
+        {
+            goto dcll_position_selection;
+        }
+
+        if (dcll_position_choice == 1)
+        {
+            int dcll_end_status;
+            int dcll_end_value;
+        dcll_enter_end_value:
+            dcll_end_status = safe_input_int(&dcll_end_value,
+                                             "enter the no. you want to insert at end, (between 1 "
+                                             "and 100), enter '-1' to exit :- ",
+                                             1, 100);
+
+            if (dcll_end_status == INPUT_EXIT_SIGNAL)
+            {
+                printf("\nExiting dcll demo\n");
+                dcll_destroy(&list);
+                return;
+            }
+
+            if (dcll_end_status == 0)
+            {
+                goto dcll_enter_end_value;
+            }
+
+            int status = dcll_insertAtEnd(&list, dcll_end_value);
+            if (status == -1)
+            {
+                printf("\nmalloc allocation failure. try again\n");
+                goto dcll_enter_end_value;
+            }
+            printf("\n");
+            dcll_printlist(&list);
+        }
+        else if (dcll_position_choice == 0)
+        {
+            int dcll_start_status;
+            int dcll_start_value;
+
+        dcll_enter_start_value:
+            dcll_start_status = safe_input_int(&dcll_start_value,
+                                               "enter the no. you want to insert at beginning, "
+                                               "(between 1 and 100), enter '-1' to exit :- ",
+                                               1, 100);
+
+            if (dcll_start_status == INPUT_EXIT_SIGNAL)
+            {
+                printf("\nExiting dcll demo\n");
+                dcll_destroy(&list);
+                return;
+            }
+
+            if (dcll_start_status == 0)
+            {
+                goto dcll_enter_start_value;
+            }
+            int status = dcll_insertAtBeginning(&list, dcll_start_value);
+            if (status == -1)
+            {
+                printf("\nmalloc allocation failure. try again\n");
+                goto dcll_enter_start_value;
+            }
+            printf("\n");
+            dcll_printlist(&list);
+        }
+        else if (dcll_position_choice == 2)
+        {
+            int dcll_pos_status;
+            int dcll_pos_value;
+            int dcll_pos_index;
+            char dcll_pos_prompt[128];
+
+        dcll_enter_pos_value:
+            dcll_pos_status = safe_input_int(&dcll_pos_value,
+                                             "enter the no. you want to insert, (between 1 "
+                                             "and 100), enter '-1' to exit :- ",
+                                             1, 100);
+
+            if (dcll_pos_status == INPUT_EXIT_SIGNAL)
+            {
+                printf("\nExiting dcll demo\n");
+                dcll_destroy(&list);
+                return;
+            }
+
+            if (dcll_pos_status == 0)
+            {
+                goto dcll_enter_pos_value;
+            }
+
+        dcll_enter_pos_index:
+            snprintf(dcll_pos_prompt, sizeof(dcll_pos_prompt),
+                     "enter the position (0 to %d), enter '-1' to exit :- ", dcll_getLength(&list));
+            dcll_pos_status =
+                safe_input_int(&dcll_pos_index, dcll_pos_prompt, 0, dcll_getLength(&list));
+
+            if (dcll_pos_status == INPUT_EXIT_SIGNAL)
+            {
+                printf("\nExiting dcll demo\n");
+                dcll_destroy(&list);
+                return;
+            }
+
+            if (dcll_pos_status == 0)
+            {
+                goto dcll_enter_pos_index;
+            }
+
+            int status = dcll_insertAtPosition(&list, dcll_pos_value, dcll_pos_index);
+            if (status == -1)
+            {
+                printf("\nmalloc allocation failure. try again\n");
+                goto dcll_enter_pos_value;
+            }
+            else if (status == -2)
+            {
+                printf("\ninvalid position. try again\n");
+                goto dcll_enter_pos_index;
+            }
+            printf("\n");
+            dcll_printlist(&list);
+        }
+
+        dcll_element_count--;
+    }
+
+    // searching elements in dcll
+    while (1)
+    {
+        int dcll_search_status;
+        int dcll_search_value;
+        dcll_search_status = safe_input_int(
+            &dcll_search_value,
+            "\nenter the element to be searched, (between 1 and 100), enter '-1' to exit :- ", 1,
+            100);
+        if (dcll_search_status == INPUT_EXIT_SIGNAL)
+        {
+            break;
+        }
+        if (dcll_search_status == 0)
+        {
+            continue;
+        }
+
+        int index = dcll_search(&list, dcll_search_value);
+        printf("\nelement found at index :- %d", index);
+    }
+
+    // deleting elements in dcll
+    while (1)
+    {
+        int dcll_delete_choice;
+        int dcll_delete_status;
+
+    dcll_delete_selection:
+        dcll_delete_status = safe_input_int(&dcll_delete_choice,
+                                            "\nenter '0' to delete at beginning"
+                                            "\nenter '1' to delete at end"
+                                            "\nenter '2' to delete by value"
+                                            "\nenter '3' to delete at position"
+                                            "\nenter '-1' to exit :- ",
+                                            0, 3);
+
+        if (dcll_delete_status == INPUT_EXIT_SIGNAL)
+        {
+            printf("\nExiting dcll demo\n");
+            dcll_destroy(&list);
+            return;
+        }
+        if (dcll_delete_status == 0)
+        {
+            goto dcll_delete_selection;
+        }
+
+        if (dcll_delete_choice == 0)
+        {
+            int status = dcll_deleteAtBeginning(&list);
+            if (status == -1)
+            {
+                printf("\nList is empty\n");
+            }
+            else
+            {
+                printf("\ndcll after deletion - ");
+                dcll_printlist(&list);
+            }
+        }
+        else if (dcll_delete_choice == 1)
+        {
+            int status = dcll_deleteAtEnd(&list);
+            if (status == -1)
+            {
+                printf("\nList is empty\n");
+            }
+            else
+            {
+                printf("\ndcll after deletion - ");
+                dcll_printlist(&list);
+            }
+        }
+        else if (dcll_delete_choice == 2)
+        {
+            int dcll_delete_value;
+            dcll_delete_status = safe_input_int(
+                &dcll_delete_value,
+                "\nenter the element to be deleted, (between 1 and 100), enter '-1' to exit :- ", 1,
+                100);
+
+            if (dcll_delete_status == INPUT_EXIT_SIGNAL)
+            {
+                printf("\nExiting dcll demo\n");
+                dcll_destroy(&list);
+                return;
+            }
+            if (dcll_delete_status == 0)
+            {
+                continue;
+            }
+
+            int status = dcll_deleteByValue(&list, dcll_delete_value);
+            if (status == -2)
+            {
+                printf("\nList is empty\n");
+            }
+            else if (status == -1)
+            {
+                printf("\nvalue not found\n");
+            }
+            else
+            {
+                printf("\ndcll after deletion - ");
+                dcll_printlist(&list);
+            }
+        }
+        else if (dcll_delete_choice == 3)
+        {
+            int dcll_pos_delete_status;
+            int dcll_pos_delete_index;
+            char dcll_pos_delete_prompt[128];
+
+            if (dcll_getLength(&list) == 0)
+            {
+                printf("\nList is empty\n");
+                continue;
+            }
+
+        dcll_delete_pos_input:
+            snprintf(dcll_pos_delete_prompt, sizeof(dcll_pos_delete_prompt),
+                     "enter the position to delete (0 to %d), enter '-1' to exit :- ",
+                     dcll_getLength(&list) - 1);
+            dcll_pos_delete_status = safe_input_int(&dcll_pos_delete_index, dcll_pos_delete_prompt,
+                                                    0, dcll_getLength(&list) - 1);
+
+            if (dcll_pos_delete_status == INPUT_EXIT_SIGNAL)
+            {
+                printf("\nExiting dcll demo\n");
+                dcll_destroy(&list);
+                return;
+            }
+
+            if (dcll_pos_delete_status == 0)
+            {
+                goto dcll_delete_pos_input;
+            }
+
+            int status = dcll_deleteAtPosition(&list, dcll_pos_delete_index);
+            if (status == -1)
+            {
+                printf("\nList is empty\n");
+            }
+            else if (status == -2)
+            {
+                printf("\nInvalid position\n");
+            }
+            else
+            {
+                printf("\ndcll after deletion - ");
+                dcll_printlist(&list);
+            }
+        }
+    }
+
+    dcll_destroy(&list);
+}

--- a/src/tui/tui.c
+++ b/src/tui/tui.c
@@ -53,7 +53,8 @@ static Entry ENTRIES[] = {
     {"Linear Queue", simple_queue_Demo, 0, 0, 1},
     {"Circular Data Structures", NULL, 1, 0, 0},
     {"Circular Queue", circular_queue_Demo, 0, 0, 1},
-    {"Singly Circular Queue", scll_Demo, 0, 0, 1},
+    {"Singly Circular Linked List", scll_Demo, 0, 0, 1},
+    {"Doubly Circular Linked List", dcll_Demo, 0, 0, 1},
     {"Double-ended Queue", deque_demo, 0, 0, 1},
 
     

--- a/tests/test_dcll.c
+++ b/tests/test_dcll.c
@@ -1,0 +1,341 @@
+#include "data_structures.h"
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+// Independently counts the ring by walking at most one full lap. Returns the node count and,
+// via *invariant_ok, whether tail->next == head and head->prev == tail currently holds.
+// Walking is bounded: it stops when it returns to head, or after length+1 hops as a safety cap
+// so a broken ring can never loop forever inside the tests themselves.
+static int ring_count(const dcll* list, int* invariant_ok)
+{
+    if (list->head == NULL)
+    {
+        *invariant_ok = (list->tail == NULL);
+        return 0;
+    }
+
+    // Both forward and backward ring invariants must hold.
+    *invariant_ok = (list->tail->next == list->head) &&
+                    (list->head->prev == list->tail);
+
+    int count = 0;
+    const dcll_Node* cur = list->head;
+    do
+    {
+        count++;
+        cur = cur->next;
+    } while (cur != list->head && count <= list->length + 1);
+
+    return count;
+}
+
+// Asserts the structural invariant after a mutation: tail->next == head, head->prev == tail,
+// and the cached length matches an independent walk of the ring.
+static void assert_invariant(const dcll* list)
+{
+    int invariant_ok = 0;
+    int counted = ring_count(list, &invariant_ok);
+    assert(invariant_ok);
+    assert(counted == list->length);
+}
+
+// Copies the list into arr by walking exactly `length` nodes forward. Returns items copied.
+static int list_to_array(const dcll* list, int arr[], int max)
+{
+    int i = 0;
+    if (list->head == NULL)
+    {
+        return 0;
+    }
+    const dcll_Node* cur = list->head;
+    while (i < list->length && i < max)
+    {
+        arr[i++] = cur->data;
+        cur = cur->next;
+    }
+    return i;
+}
+
+// Copies the list into arr by walking backward from tail. Returns items copied.
+// Used to verify prev pointers are correctly maintained.
+static int list_to_array_reverse(const dcll* list, int arr[], int max)
+{
+    int i = 0;
+    if (list->tail == NULL)
+    {
+        return 0;
+    }
+    const dcll_Node* cur = list->tail;
+    while (i < list->length && i < max)
+    {
+        arr[i++] = cur->data;
+        cur = cur->prev;
+    }
+    return i;
+}
+
+void test_insert_begin_end()
+{
+    dcll list;
+    dcll_init(&list);
+
+    assert(dcll_insertAtEnd(&list, 10) == 1);
+    // Single node points to itself in both directions and is both head and tail.
+    assert(list.head == list.tail);
+    assert(list.head->next == list.head);
+    assert(list.head->prev == list.head);
+    assert_invariant(&list);
+
+    assert(dcll_insertAtEnd(&list, 20) == 1);
+    assert(dcll_insertAtBeginning(&list, 5) == 1);
+    assert_invariant(&list);
+
+    int out[3];
+    int n = list_to_array(&list, out, 3);
+    assert(n == 3);
+    assert(out[0] == 5 && out[1] == 10 && out[2] == 20);
+    assert(list.head->data == 5);
+    assert(list.tail->data == 20);
+
+    // Verify prev pointers by walking backward.
+    int rev[3];
+    int m = list_to_array_reverse(&list, rev, 3);
+    assert(m == 3);
+    assert(rev[0] == 20 && rev[1] == 10 && rev[2] == 5);
+
+    dcll_destroy(&list);
+    printf("dcll insert begin/end tests passed\n");
+}
+
+void test_insert_at_position()
+{
+    dcll list;
+    dcll_init(&list);
+
+    // Insert into empty list at position 0.
+    assert(dcll_insertAtPosition(&list, 10, 0) == 1);
+    // Append at the end (position == length).
+    assert(dcll_insertAtPosition(&list, 30, 1) == 1);
+    // Interior insert.
+    assert(dcll_insertAtPosition(&list, 20, 1) == 1);
+    assert_invariant(&list);
+
+    int out[3];
+    int n = list_to_array(&list, out, 3);
+    assert(n == 3);
+    assert(out[0] == 10 && out[1] == 20 && out[2] == 30);
+    assert(list.tail->data == 30);
+
+    // Invalid positions.
+    assert(dcll_insertAtPosition(&list, 99, 10) == -2);
+    assert(dcll_insertAtPosition(&list, 99, -1) == -2);
+    assert_invariant(&list);
+
+    dcll_destroy(&list);
+    printf("dcll insert at position tests passed\n");
+}
+
+void test_delete_begin_end()
+{
+    dcll list;
+    dcll_init(&list);
+    for (int v = 1; v <= 3; v++)
+    {
+        assert(dcll_insertAtEnd(&list, v) == 1);
+    }
+
+    assert(dcll_deleteAtBeginning(&list) == 1);
+    assert(list.head->data == 2);
+    assert_invariant(&list);
+
+    assert(dcll_deleteAtEnd(&list) == 1);
+    assert(list.tail->data == 2);
+    assert(list.head == list.tail); // back down to a single node
+    assert_invariant(&list);
+
+    assert(dcll_deleteAtBeginning(&list) == 1);
+    assert(list.head == NULL && list.tail == NULL && list.length == 0);
+
+    dcll_destroy(&list);
+    printf("dcll delete begin/end tests passed\n");
+}
+
+void test_delete_by_value()
+{
+    dcll list;
+    dcll_init(&list);
+    for (int v = 1; v <= 4; v++)
+    {
+        assert(dcll_insertAtEnd(&list, v) == 1);
+    }
+
+    // Delete an interior value.
+    assert(dcll_deleteByValue(&list, 2) == 1);
+    assert_invariant(&list);
+
+    // Delete the tail value: tail must be updated.
+    assert(dcll_deleteByValue(&list, 4) == 1);
+    assert(list.tail->data == 3);
+    assert_invariant(&list);
+
+    // Delete the head value.
+    assert(dcll_deleteByValue(&list, 1) == 1);
+    assert(list.head->data == 3);
+    assert_invariant(&list);
+
+    // Value not present.
+    assert(dcll_deleteByValue(&list, 99) == -1);
+
+    int out[2];
+    int n = list_to_array(&list, out, 2);
+    assert(n == 1 && out[0] == 3);
+
+    dcll_destroy(&list);
+    printf("dcll delete by value tests passed\n");
+}
+
+void test_delete_at_position()
+{
+    dcll list;
+    dcll_init(&list);
+    for (int v = 1; v <= 4; v++)
+    {
+        assert(dcll_insertAtEnd(&list, v) == 1);
+    }
+
+    // Delete head via position 0.
+    assert(dcll_deleteAtPosition(&list, 0) == 1);
+    // Delete the new last node (position length-1) -> tail update.
+    assert(dcll_deleteAtPosition(&list, list.length - 1) == 1);
+    assert(list.tail->data == 3);
+    assert_invariant(&list);
+
+    int out[2];
+    int n = list_to_array(&list, out, 2);
+    assert(n == 2 && out[0] == 2 && out[1] == 3);
+
+    // Invalid positions.
+    assert(dcll_deleteAtPosition(&list, 10) == -2);
+    assert(dcll_deleteAtPosition(&list, -1) == -2);
+
+    dcll_destroy(&list);
+    printf("dcll delete at position tests passed\n");
+}
+
+void test_search_and_length()
+{
+    dcll list;
+    dcll_init(&list);
+    assert(dcll_getLength(&list) == 0);
+
+    int values[] = {5, 10, 15};
+    for (int i = 0; i < 3; i++)
+    {
+        assert(dcll_insertAtEnd(&list, values[i]) == 1);
+    }
+    assert(dcll_getLength(&list) == 3);
+
+    assert(dcll_search(&list, 5) == 0);
+    assert(dcll_search(&list, 15) == 2);
+    assert(dcll_search(&list, 100) == -1);
+
+    dcll_destroy(&list);
+    printf("dcll search and length tests passed\n");
+}
+
+void test_edge_cases()
+{
+    dcll list;
+    dcll_init(&list);
+
+    // Operations on an empty list return the documented error codes.
+    assert(dcll_deleteAtBeginning(&list) == -1);
+    assert(dcll_deleteAtEnd(&list) == -1);
+    assert(dcll_deleteByValue(&list, 10) == -2);
+    assert(dcll_deleteAtPosition(&list, 0) == -1); // empty list -> -1 (not an invalid-position -2)
+    assert(dcll_search(&list, 10) == -1);
+    assert(dcll_getLength(&list) == 0);
+
+    // Single-node list: node points to itself in both directions, head == tail.
+    assert(dcll_insertAtBeginning(&list, 42) == 1);
+    assert(list.head == list.tail);
+    assert(list.head->next == list.head);
+    assert(list.head->prev == list.head);
+    assert(dcll_search(&list, 42) == 0);
+    assert_invariant(&list);
+
+    // Delete down to empty, then reuse the same list object.
+    assert(dcll_deleteAtEnd(&list) == 1);
+    assert(list.head == NULL && list.length == 0);
+    assert(dcll_insertAtEnd(&list, 7) == 1);
+    assert(list.head->data == 7);
+    assert_invariant(&list);
+
+    dcll_destroy(&list);
+    printf("dcll edge case tests passed\n");
+}
+
+void test_prev_pointers()
+{
+    dcll list;
+    dcll_init(&list);
+
+    // Specifically test that prev pointers are correct after various operations.
+    for (int v = 1; v <= 5; v++)
+    {
+        assert(dcll_insertAtEnd(&list, v) == 1);
+    }
+
+    // Walk backward and verify order is reversed.
+    int rev[5];
+    int n = list_to_array_reverse(&list, rev, 5);
+    assert(n == 5);
+    assert(rev[0] == 5 && rev[1] == 4 && rev[2] == 3 && rev[3] == 2 && rev[4] == 1);
+    assert_invariant(&list);
+
+    // Delete middle node and re-verify backward walk.
+    assert(dcll_deleteByValue(&list, 3) == 1);
+    int rev2[4];
+    int m = list_to_array_reverse(&list, rev2, 4);
+    assert(m == 4);
+    assert(rev2[0] == 5 && rev2[1] == 4 && rev2[2] == 2 && rev2[3] == 1);
+    assert_invariant(&list);
+
+    dcll_destroy(&list);
+    printf("dcll prev pointer tests passed\n");
+}
+
+void test_destroy_is_idempotent()
+{
+    dcll list;
+    dcll_init(&list);
+    for (int v = 1; v <= 3; v++)
+    {
+        assert(dcll_insertAtEnd(&list, v) == 1);
+    }
+
+    dcll_destroy(&list);
+    assert(list.head == NULL && list.tail == NULL && list.length == 0);
+    // Destroying an already-empty list is a safe no-op.
+    dcll_destroy(&list);
+    assert(list.head == NULL);
+
+    printf("dcll destroy tests passed\n");
+}
+
+int main()
+{
+    test_insert_begin_end();
+    test_insert_at_position();
+    test_delete_begin_end();
+    test_delete_by_value();
+    test_delete_at_position();
+    test_search_and_length();
+    test_edge_cases();
+    test_prev_pointers();
+    test_destroy_is_idempotent();
+
+    printf("All DCLL tests passed\n");
+    return 0;
+}


### PR DESCRIPTION
closes #332 
i implemented  the  complete doubly circular linked list (dcll) data structure,
following the same patterns and style as the existing scll implementation.

## Changes
- `src/data_structures/dcll.c` — full dcll implementation
- `src/data_structures/data_structures.h` — fixed dcll struct (head/tail corrected to dcll_Node*) and added new function signatures
- `tests/test_dcll.c` — comprehensive test suite matching scll test style
- `src/tui/tui.c` — added dcll_Demo entry to the navigator menu
- `Makefile` — added test_dcll build and run rule

already tested  and build was clean