### PR TITLE
Guard tui_run() behind _WIN32 conditional in main.c

### DIFF
--- a/src/data_structures/main.c
+++ b/src/data_structures/main.c
@@ -12,7 +12,9 @@
 #include "sorting_algorithms_n2.h"
 #include "string_algorithms.h"
 #include "trees.h"
+#ifndef _WIN32
 #include "tui.h"
+#endif
 #include <stdio.h>
 
 
@@ -90,6 +92,7 @@ void run_legacy_menu(){
         }
 }
 
+#ifndef _WIN32
 void tui_menu(){
     while(1){
     int choice;
@@ -125,11 +128,12 @@ void tui_menu(){
               }
     }
 }
+#endif
 
 int main()
 {
 
-    #ifdef __WIN32
+    #ifdef _WIN32
     run_legacy_menu();
     #else
     tui_menu();


### PR DESCRIPTION
Closes #338

## What

Makes `tui_run()` completely invisible to the compiler on Windows, so the project builds there even though `src/tui` is not part of the Windows build.

## Why

On Windows the Makefile's `OS == Windows_NT` branch does **not** add `src/tui` to `SRC_DIRS`, nor `-Isrc/tui` to `CFLAGS`, nor `-lncurses`. So on Windows:

- `#include "tui.h"` can't be resolved (the header's directory isn't on the include path), and
- `tui_run()` has no definition (`tui.c` is never compiled), so any reference to it is an unresolved symbol.

`main.c` referenced all of this unconditionally (it included `tui.h` and `tui_menu()` called `tui_run()`), which broke the Windows build.

## Change

Mirroring the same `Windows_NT` gating already used in the Makefile, everything tui-related in `main.c` is wrapped in a preprocessor conditional:

- `#include "tui.h"` &rarr; guarded with `#ifndef _WIN32`
- the whole `tui_menu()` function &rarr; guarded with `#ifndef _WIN32`
- the `main()` dispatch already had a guard, but used `#ifdef __WIN32` (double underscore &mdash; not a predefined macro); fixed to the portable `#ifdef _WIN32`

On Windows the compiler now only ever sees `run_legacy_menu()` &mdash; zero tui include, zero `tui_menu`, zero `tui_run` reference. Linux/macOS behaviour is unchanged.

## Verification

Compiling `main.c` with the exact Windows Makefile config (`-D_WIN32`, no `-Isrc/tui`) produces a clean object file with **no** `tui_run`/`tui_menu` symbols. Compiling with the Linux config (with `-Isrc/tui`) still references `tui_run` as expected, confirming Linux behaviour is untouched.
