### PR TITLE
Fix Prim MST dropping a vertex reached only by an INT_MAX-weight edge

### DIFF
--- a/src/graph_traversals/prim.c
+++ b/src/graph_traversals/prim.c
@@ -293,7 +293,7 @@ void prim_demo(void)
             }
 
         retry_w:
-            status = safe_input_int(&w, "  Weight: ", 0, INT_MAX);
+            status = safe_input_int(&w, "  Weight: ", 0, INT_MAX - 1);
             if (status == INPUT_EXIT_SIGNAL)
             {
                 printf("\nExiting Prim's demo.....\n");


### PR DESCRIPTION
Closes #341

## Bug

In Prim's MST, a vertex reachable **only** via an edge of weight exactly `INT_MAX` (`2147483647`) was never added to the MST, so Prim wrongly reported a disconnected "minimum spanning forest" for a connected graph.

## Root cause

`key[]` is initialized to `INT_MAX` as the "infinity / not yet reached" sentinel (`prim.c:39`), and relaxation uses a strict `weight < key[v]` (`prim.c:106`). But the weight prompt allowed a real weight of exactly `INT_MAX` (`prim.c:296`). When the only edge to a vertex had weight `INT_MAX`, the test became `INT_MAX < INT_MAX` &mdash; false &mdash; so the vertex never entered the priority queue or the MST. A valid weight was indistinguishable from the infinity sentinel.

## Fix

Bound the weight input to `INT_MAX - 1` so no valid edge weight can ever collide with the `INT_MAX` infinity sentinel. Prim stores the raw edge weight in `key[]` (never a path sum), so `INT_MAX - 1 < INT_MAX` always relaxes correctly and there is no overflow concern. This mirrors how the sibling MST algorithm Kruskal already keeps weights below the sentinel.

One-line change in `src/graph_traversals/prim.c`.

## Verification

`prim.c` compiles clean under `-Wall -Wextra -Werror -std=c11`; clang-format clean. With the bound in place, the largest enterable weight (`INT_MAX - 1`) relaxes against the `INT_MAX` sentinel correctly, so a vertex attached only by a max-weight edge is now included in the MST.
