### PR TITLE
Check trie_create_node() result in trie_insert to avoid NULL deref

### DIFF
--- a/src/trees/trie.c
+++ b/src/trees/trie.c
@@ -24,7 +24,11 @@ void trie_insert(TrieNode* root, const char* word)
         if (idx < 0 || idx >= TRIE_ALPHA_SIZE)
             return;
         if (curr->children[idx] == NULL)
+        {
             curr->children[idx] = trie_create_node();
+            if (curr->children[idx] == NULL)
+                return;
+        }
         curr = curr->children[idx];
     }
     curr->is_end = 1;


### PR DESCRIPTION
Closes #342

## Bug

`trie_insert` dereferenced a NULL pointer (crash) when a child node allocation failed.

## Root cause

`trie_create_node()` returns `NULL` on malloc failure (`trie.c:7-13`), but `trie_insert` assigned that result straight into `curr` without checking it:

```c
if (curr->children[idx] == NULL)
    curr->children[idx] = trie_create_node();   // may be NULL
curr = curr->children[idx];                      // curr can become NULL
...
curr->is_end = 1;                                // NULL write -> crash
```

On allocation failure `curr` became `NULL`, and the next loop iteration (`curr->children[idx]`) or the final `curr->is_end = 1;` wrote through NULL.

## Fix

Check `trie_create_node()`'s return and bail out gracefully &mdash; `trie_insert` is already `void` and early-returns on invalid input, so this matches its existing style and the project's direction of checking malloc everywhere:

```c
if (curr->children[idx] == NULL)
{
    curr->children[idx] = trie_create_node();
    if (curr->children[idx] == NULL)
        return;
}
curr = curr->children[idx];
```

## Verification

`trie.c` compiles clean under `-Wall -Wextra -Werror -std=c11`; clang-format clean. The original crash was reproduced under a malloc-failure harness (SEGV writing to 0x0 in `trie_insert`); with this guard the function returns cleanly instead of dereferencing NULL. Normal insert/search behaviour is unchanged.
