### PR TITLE
fix: Add missing modules and resolve unreachable Deque selection in legacy menu

### DIFF
--- a/src/data_structures/data_structures_demo.c
+++ b/src/data_structures/data_structures_demo.c
@@ -88,7 +88,7 @@ void data_structures_demo(void)
                                        "\nenter 3 for doubly circular  linked list demo"
                                        "\nenter 4 for double-ended queue (deque) demo"
                                        "\nenter choice : ",
-                                       1, 3);
+                                       1, 4);
                     if (circular_variant_status == 0)
                         continue;
                     if (circular_variant_status == INPUT_EXIT_SIGNAL)

--- a/src/data_structures/main.c
+++ b/src/data_structures/main.c
@@ -42,8 +42,11 @@ void run_legacy_menu(){
                 "click 8 for trees demo\n"
                 "click 9 for error correction algorithms demo\n"
                 "click 10 for job scheduling (FCFS / SJF / priority / round robin) demo\n"
+                "click 11 for backtracking algorithms demo\n"
+                "click 12 for dynamic programming algorithms demo\n"
+                "click 13 for string algorithms demo\n"
                 "enter choice : ",
-                1, 10 // limits
+                1, 13 // limits
             );
     
             if (status == -111)
@@ -87,6 +90,15 @@ void run_legacy_menu(){
                     break;
                 case 10:
                     job_scheduling_demo();
+                    break;
+                case 11:
+                    backtracking_demo();
+                    break;
+                case 12:
+                    dynamic_programming_demo();
+                    break;
+                case 13:
+                    string_algorithms_demo();
                     break;
             }
         }


### PR DESCRIPTION
### PR Description
This Pull Request resolves bugs and omissions in the legacy console menu system by integrating three missing modules and fixing an invalid choice range constraint in the circular data structures sub-menu.

#### Key Changes

1. **Integrated Missing Top-Level Modules** ([main.c](file:///e:/C-DSA-interactive-suite/src/data_structures/main.c))
   * Added options **11** (Backtracking), **12** (Dynamic Programming), and **13** (String Algorithms) to the prompt.
   * Expanded input boundaries from `1-10` to `1-13` in `safe_input_int`.
   * Added corresponding switch-case routing mapping to `backtracking_demo()`, `dynamic_programming_demo()`, and `string_algorithms_demo()`.

2. **Fixed Unreachable Deque Selection** ([data_structures_demo.c](file:///e:/C-DSA-interactive-suite/src/data_structures/data_structures_demo.c))
   * Updated the circular variant list menu selection boundaries from `1, 3` to `1, 4` in `safe_input_int`.
   * This allows option **4** (Double-ended Queue / Deque) to pass validation and run successfully.

---

### Verification
* Ran `mingw32-make clean` followed by `mingw32-make` to ensure the project compiles successfully.
* Verified that both modified source files compile without errors or warnings.

closes #350 