### PR TITLE
feat: add clear_screen and 2s delay in parentheses checker and fix dfs capacity warning

### DIFF
--- a/src/expression_evaluation/parantheses_checker.c
+++ b/src/expression_evaluation/parantheses_checker.c
@@ -1,6 +1,7 @@
 #include "cross_platform_timer.h"
 #include "safe_input.h"
 #include "stack.h"
+#include "clear_screen.h"
 #include <stdio.h>
 #include <string.h>
 
@@ -11,6 +12,7 @@ int check_parantheses(char* s)
     stack* parantheses = createStack();
     while (s[i] != '\0')
     {
+        clear_screen();
         printf("\nStep    : %d\n", step++);
         printf("Char    : %c\n", s[i]);
         if (s[i] == '(' || s[i] == '[' || s[i] == '{')
@@ -99,7 +101,7 @@ int check_parantheses(char* s)
         }
         printf("-----------------------------------\n");
         i++;
-        sleep_seconds(1);
+        sleep_seconds(2);
     }
     int result = isEmpty(parantheses);
     if (!result)

--- a/src/graph_traversals/dfs.c
+++ b/src/graph_traversals/dfs.c
@@ -11,7 +11,7 @@ void dfs(Graph* graph, int start);
 void dfs_demo(void)
 {
     int edges;
-    int graph_capacity;
+    int graph_capacity = 0;
     int starting_node;
     int input_method;
     Graph* graph = NULL;


### PR DESCRIPTION




This PR adds screen-clearing behavior and adjusts the delay in `parantheses_checker.c` to mirror the user experience of `infix_to_postfix.c`.
resolves #347
### Changes:
1. **Parentheses Checker Update:**
   - Included `clear_screen.h` in `src/expression_evaluation/parantheses_checker.c`.
   - Added `clear_screen()` at the beginning of each iteration in `check_parantheses` to clear previous steps from the view.
   - Extended the interval delay between steps from `1` second to `2` seconds.
2. **Build Warning Fix:**
   - Initialized `graph_capacity = 0;` in `src/graph_traversals/dfs.c` to resolve an uninitialized variable warning under compiler flags `-Werror` and `-Wsometimes-uninitialized`.