### PR TITLE
fix: show feedback when deleting from empty singly linked list

### DIFF
--- a/src/data_structures/sll.c
+++ b/src/data_structures/sll.c
@@ -264,9 +264,17 @@ start_sll:
                 continue;
             }
 
-            sll_deleteByValue(&head, sll_delete_value);
-            printf("\nsll after deletion - ");
-            sll_printlist(head);
+            int status=sll_deleteByValue(&head, sll_delete_value);
+            if(status==-2){
+                printf("\nList is empty.Nothing to delete.");
+            }
+            else if(status==-1){
+                printf("\nelement not found");
+            }
+            else{
+                printf("\nsll after deletion - ");
+                sll_printlist(head);
+            }
         }
         else if (sll_delete_choice == 1)
         {


### PR DESCRIPTION
Summary:
Show explicit feedback when deleting from an empty singly linked list.

Changes:
- Handle empty list case in delete-by-value flow
- Show "List is empty. Nothing to delete."
- Show "Element not found." when value does not exist

Testing:
- Inserted values
- Deleted all elements
- Attempted deletion again
- Verified correct feedback

Fixes #351 