### PR TITLE
fix(hashing): prevent negative hash index for large table sizes (OOB access)

### DIFF
--- a/src/hashing/linear_probing.c
+++ b/src/hashing/linear_probing.c
@@ -17,7 +17,17 @@ static int next_prime(int n)
             return i;
         }
     }
-    return -1;
+    // No prime greater than n fits in the table (n is near its upper bound).
+    // Fall back to the largest prime <= n so the multiplier stays a positive
+    // prime and hash_function never yields a negative (out-of-bounds) index.
+    for (int i = (n < size ? n : size - 1); i >= 2; i--)
+    {
+        if (PRIMES[i])
+        {
+            return i;
+        }
+    }
+    return 1;
 }
 
 int hash_function(int value, int length_of_array)


### PR DESCRIPTION
Closes #370

## Problem

`hash_function()` (shared by all four hashing demos) could return a negative value that was then used directly as an array index, causing an out-of-bounds access.

`next_prime(n)` returns the first prime index `> n` in the `PRIMES[]` sieve, or `-1` when none exists. `PRIMES[]` covers indices `0..999` and its largest prime is `997`, so for `length_of_array` of `997`–`1000` (all selectable via `safe_input_int(..., 1, 1000)`) it returned `-1`. `hash_function` then computed `((value + 1) * -1) % length`, e.g. `-2` for value `1`, length `1000` — indexing `arr[-2]`.

## Fix

When no prime greater than `n` exists in the table, `next_prime` now falls back to the largest prime `<= n`. The multiplier is therefore always a positive prime, so `hash_function` always returns an index in `[0, length)`. The fix is local to `next_prime()`, so it covers linear probing, quadratic probing, double hashing, and separate chaining at once.

## Verification

- Exhaustively checked all `length` in `1..1000` x `value` in `1..1000` under `-fsanitize=address,undefined`: zero negative/out-of-bounds indices (previously lengths 997–1000 produced `-2`).
- Lengths 997–1000 now map to `next_prime = 997`, producing in-range indices.
- The change is confined to `next_prime()`; full build + test suite run in CI.
