### PR TITLE
fix(sudoku): only count a backtrack when a placement is undone

### DIFF
--- a/src/backtracking/sudoku.c
+++ b/src/backtracking/sudoku.c
@@ -127,12 +127,12 @@ static bool solve_sudoku_util(int grid[N][N], int row, int col)
             {
                 return true;
             }
-        }
 
-        // Backtrack: assumption was wrong
-        grid[row][col] = 0;
-        backtracks++;
-        print_sudoku_board(grid, original_grid);
+            // Backtrack: this placement led to a dead end, undo it.
+            grid[row][col] = 0;
+            backtracks++;
+            print_sudoku_board(grid, original_grid);
+        }
     }
     return false;
 }


### PR DESCRIPTION
Closes #371

## Problem

The Sudoku visualizer's "Solving Statistics" reports an inflated **Backtracks** count. The undo/count block sat **outside** the `if (is_safe_sudoku(...))` branch, so `backtracks++` fired on every loop iteration — including candidates that were never placed because they failed the safety check.

This makes `backtracks` exceed `placements`, which is impossible for a real backtracking search (you can only undo a value you actually placed).

## Fix

Move the `grid[row][col] = 0; backtracks++; print_sudoku_board(...)` block **inside** the `if (is_safe_sudoku(...))` branch, so a backtrack is counted only when a real placement is undone after its recursive branch fails. Solving behaviour is unchanged — only the statistic is corrected.

## Verification

Replicated the exact `is_safe_sudoku` + `solve_sudoku_util` logic (buggy vs fixed) on the demo's 6×6 grid under `-fsanitize=address,undefined`:

```
BUGGY: solved=1 placements=4 backtracks=8   (backtracks > placements — impossible)
FIXED: solved=1 placements=4 backtracks=0   (no dead ends on this grid — correct)
```

Both versions still solve the puzzle; the fix only removes the spurious counts.
