### PR TITLE
feat: Implement minimal CMake support and optimize test execution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dsa
 /test_*
 output/benchmark_history.csv
 /object_files/
+/build/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,73 @@
+cmake_minimum_required(VERSION 3.10)
+project(C_DSA_interactive_suite C)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Werror")
+
+# Source directories
+set(SRC_DIRS
+    src/data_structures
+    src/expression_evaluation
+    src/sorting_algorithms_n2
+    src/advanced_sorting_algorithms
+    src/searching_algorithms
+    src/graph_traversals
+    src/hashing
+    src/utils
+    src/trees
+    src/error_correction_algorithms
+    src/job_scheduling
+    src/dynamic_programming
+    src/string_algorithms
+    src/backtracking
+    src/process_synchronization
+)
+
+# Header search paths
+foreach(DIR ${SRC_DIRS})
+    include_directories(${DIR})
+endforeach()
+
+# Collect source files
+set(SOURCES "")
+foreach(DIR ${SRC_DIRS})
+    file(GLOB DIR_SRCS "${DIR}/*.c")
+    list(APPEND SOURCES ${DIR_SRCS})
+endforeach()
+
+# Exclude src/data_structures/main.c from the library source files because it contains main()
+list(REMOVE_ITEM SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/src/data_structures/main.c")
+
+# Platform specific configurations
+if(NOT WIN32)
+    # Include TUI
+    include_directories(src/tui)
+    file(GLOB TUI_SRCS "src/tui/*.c")
+    list(APPEND SOURCES ${TUI_SRCS})
+    
+    # Find and link ncurses
+    find_package(Curses REQUIRED)
+    include_directories(${CURSES_INCLUDE_DIR})
+    set(EXTRA_LIBS ${CURSES_LIBRARIES})
+else()
+    set(EXTRA_LIBS "")
+endif()
+
+# Build library containing all common object files
+add_library(dsa_lib STATIC ${SOURCES})
+
+# Build the main executable
+add_executable(dsa src/data_structures/main.c)
+target_link_libraries(dsa dsa_lib ${EXTRA_LIBS})
+
+# Enable testing support
+enable_testing()
+
+# Build all tests
+file(GLOB TEST_FILES "tests/test_*.c")
+foreach(TEST_FILE ${TEST_FILES})
+    get_filename_component(TEST_NAME ${TEST_FILE} NAME_WE)
+    add_executable(${TEST_NAME} ${TEST_FILE})
+    target_link_libraries(${TEST_NAME} dsa_lib ${EXTRA_LIBS})
+    add_test(NAME ${TEST_NAME} COMMAND ${TEST_NAME})
+endforeach()

--- a/README.md
+++ b/README.md
@@ -63,13 +63,27 @@ sudo pacman -S ncurses
 ```
 > **Note:** The TUI is supported on Unix/Linux systems. On Windows, the project automatically falls back to the legacy CLI interface.
 
-### Build
+### Build (Makefile)
 ```bash
 make
 ```
 This generates a single executable:
 * `dsa` (Linux / macOS)
 * `dsa.exe` (Windows)
+
+### Build (CMake)
+Alternatively, you can compile the application and tests using CMake:
+```bash
+mkdir build && cd build
+cmake ..
+make
+```
+
+To execute all unit tests using CTest:
+```bash
+ctest --output-on-failure
+```
+
 
 
 ```bash

--- a/src/string_algorithms/rabin_karp.c
+++ b/src/string_algorithms/rabin_karp.c
@@ -60,6 +60,8 @@ void rabin_karp_search(char* text, char* pattern, int q)
                 t = (t + q);
         }
     }
+    (void)found;
+    (void)collisions;
 }
 
 void rabin_karp_visualization(char* text, char* pattern, int q)

--- a/src/utils/clear_screen.c
+++ b/src/utils/clear_screen.c
@@ -1,11 +1,16 @@
 #include "clear_screen.h"
+#include "cross_platform_timer.h"
 #include <stdlib.h>
 
 void clear_screen(void)
 {
+    if (!is_terminal_interactive()) {
+        return;
+    }
 #ifdef _WIN32
     system("cls");
 #else
     system("clear");
 #endif
 }
+

--- a/src/utils/config.c
+++ b/src/utils/config.c
@@ -41,6 +41,10 @@ void print_current_speed(void)
 
 void dynamic_sleep(void)
 {
+    if (!is_terminal_interactive())
+    {
+        return;
+    }
     if (current_delay_seconds > 0)
     {
         sleep_seconds(current_delay_seconds);
@@ -75,5 +79,9 @@ void settings_menu_demo(void)
 
 int is_instant(void)
 {
+    if (!is_terminal_interactive())
+    {
+        return 1;
+    }
     return (current_delay_seconds == 0) ? 1 : 0;
 }


### PR DESCRIPTION

* **Description:** 
  * Adds root-level `CMakeLists.txt` to build the main binary and register unit tests with CTest.
  * Automatically bypasses terminal clearing and animation delays in non-interactive environments, improving CTest runtime to ~2.5 seconds.
  * Updates README instructions with CMake configure, build, and test steps.
 resolves #396 