### PR TITLE
feat(docker): multi-stage build with slim runtime and dev targets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,24 @@
-# 1. Use the official lightweight Ubuntu image
-FROM ubuntu:latest
+# syntax=docker/dockerfile:1
+#
+# Multi-stage build. Two named targets give you a choice of image:
+#
+#   Slim, run-only image (default):
+#     docker build --target runtime -t dsa:slim .
+#     docker run -it dsa:slim
+#
+#   Full development image (compiler + valgrind + gdb inside):
+#     docker build --target dev -t dsa:dev .
+#     docker run -it dsa:dev
+#
+# Note: dsa is an interactive ncurses menu, so it needs `docker run -it`.
 
-# 2. Prevent interactive timezone/keyboard prompts from freezing the build
+# ---------- Stage 1: dev — full toolchain, debug-ready (heavyweight) ----------
+FROM ubuntu:24.04 AS dev
+
+# Prevent interactive timezone/keyboard prompts from freezing the build
 ENV DEBIAN_FRONTEND=noninteractive
 
-# 3. Install the C compiler suite, Make, and Valgrind
+# Full build + debug toolchain: compiler, make, valgrind, gdb, ncurses headers
 RUN apt-get update && apt-get install -y \
     build-essential \
     gcc \
@@ -14,14 +28,30 @@ RUN apt-get update && apt-get install -y \
     libncurses-dev \
     && rm -rf /var/lib/apt/lists/*
 
-# 4. Set the working directory inside the isolated container
 WORKDIR /app
 
-# 5. Copy your entire repository source code into the container
+# Copy the whole repo so you can also rebuild/debug from inside this image
 COPY . .
 
-# 6. Compile the project fresh inside the Linux container
+# Compile fresh inside the container
 RUN make clean && make
 
-# 7. Execute the compiled binary
+CMD ["./dsa"]
+
+# ---------- Stage 2: runtime — binary + ncurses runtime only (slim) ----------
+FROM ubuntu:24.04 AS runtime
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Only the ncurses RUNTIME library the binary links against (-lncurses).
+# No compiler, no headers, no valgrind/gdb, no source.
+RUN apt-get update && apt-get install -y \
+    libncurses6 \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Pull only the compiled binary out of the dev stage
+COPY --from=dev /app/dsa .
+
 CMD ["./dsa"]


### PR DESCRIPTION
Closes #401

### What

Refactors the `Dockerfile` (from #389) into a **multi-stage build** with two named targets, so users can choose which image to build:

- **`dev`** — full toolchain (`build-essential`, `gcc`, `make`, `valgrind`, `gdb`, `libncurses-dev`) + source. Build, debug, or run Valgrind inside the container. This stage also compiles the binary that the runtime stage ships, so there is no duplicated build config.
- **`runtime`** — slim image: installs only `libncurses6` (the suite links with `-lncurses`, so no headers/compiler) and copies just the compiled `dsa` binary out of the `dev` stage.

Also pins the base `ubuntu:latest` → `ubuntu:24.04` for reproducible builds.

### Usage

```
# slim, run-only image
docker build --target runtime -t dsa:slim .
docker run -it dsa:slim

# full toolchain image for development / debugging
docker build --target dev -t dsa:dev .
docker run -it dsa:dev
```

### Why `libncurses6` (not `-dev`) in the runtime stage

The TUI links with `-lncurses` (`Makefile`), whose runtime SONAME is `libncurses.so.6`, provided by the `libncurses6` package (which pulls `libtinfo6` automatically). The `-dev` package only adds headers needed at compile time, which the runtime image doesn't do — so it's intentionally left out of the slim stage.

### Verification (built & run locally with Docker 29.1.3)

Both targets build cleanly, and the slim image runs the suite:

| Image | Size |
| --- | --- |
| `dsa:original` (current single-stage) | **892 MB** |
| `dsa:slim` (this PR, `runtime` target) | **119 MB** |
| `dsa:dev` (this PR, `dev` target) | 840 MB |

The slim image is **~87% smaller** than the current single-stage image.

Lib resolution inside the slim image (no compiler/headers present):

```
$ docker run --rm dsa:slim ldd /app/dsa
    libncurses.so.6 => /lib/x86_64-linux-gnu/libncurses.so.6
    libtinfo.so.6   => /lib/x86_64-linux-gnu/libtinfo.so.6
```

`docker run -it dsa:slim` launches the interactive welcome menu, confirming the slim image has the ncurses runtime it needs.

### Out of scope

README documentation of the build architecture / `docker run -it` is tracked separately under #399.
