### PR TITLE
 fixed Naming Inconsistency across all functions

### DIFF
--- a/src/data_structures/circular_queue.c
+++ b/src/data_structures/circular_queue.c
@@ -9,7 +9,7 @@
 
 // dequeue returns -1 when circular queue is empty and value when operation is succesful
 
-void circular_queue_Demo(void)
+void circular_queue_demo(void)
 {
 
     while (1)

--- a/src/data_structures/data_structures.h
+++ b/src/data_structures/data_structures.h
@@ -62,7 +62,7 @@ int sll_deleteAtBeginning(Node** head_ref);
 int sll_deleteAtEnd(Node** head_ref);
 int sll_deleteByValue(Node** head_ref, int value);
 int sll_insertAtBeginning(Node** head_ref, int value);
-void sll_Demo(void);
+void sll_demo(void);
 int sll_search(const Node* head, int key);
 int sll_reverseList(Node** head_ref);
 void delete_sll(Node* head);
@@ -119,7 +119,7 @@ int scll_search(const scll* list, int key);
 int scll_getLength(const scll* list);
 void scll_printlist(const scll* list);
 void scll_destroy(scll* list);
-void scll_Demo(void);
+void scll_demo(void);
 
 // Universal non-speacial queue structure
 typedef struct Queue
@@ -136,7 +136,7 @@ void destroy_circ_queue(Queue* queue_ptr);
 int enqueue(Queue* queue_ptr, void* value);
 void* dequeue(Queue* queue_ptr);
 void display_circ_queue(Queue* queue_ptr);
-void circular_queue_Demo(void);
+void circular_queue_demo(void);
 
 // For simple (linear) queue
 int init_simple_queue(int N, Queue* queue_ptr);
@@ -144,7 +144,7 @@ void destroy_simple_queue(Queue* queue_ptr);
 int enqueue_simple(Queue* queue_ptr, void* value);
 void* dequeue_simple(Queue* queue_ptr);
 void display_simple_queue(const Queue* queue_ptr);
-void simple_queue_Demo(void);
+void simple_queue_demo(void);
 
 // For Double-Ended Queue (Deque)
 int init_deque(int N, Queue* dq);
@@ -188,6 +188,6 @@ int dcll_search(const dcll* list, int key);
 int dcll_getLength(const dcll* list);
 void dcll_printlist(const dcll* list);
 void dcll_destroy(dcll* list);
-void dcll_Demo(void);
+void dcll_demo(void);
 
 #endif

--- a/src/data_structures/data_structures_demo.c
+++ b/src/data_structures/data_structures_demo.c
@@ -50,7 +50,7 @@ void data_structures_demo(void)
 
                     if (linear_ds_choice == 1)
                     {
-                        sll_Demo();
+                        sll_demo();
                         continue;
                     }
                     if (linear_ds_choice == 2)
@@ -70,7 +70,7 @@ void data_structures_demo(void)
                     }
                     if (linear_ds_choice == 5)
                     {
-                        simple_queue_Demo();
+                        simple_queue_demo();
                         continue;
                     }
                 }
@@ -95,15 +95,15 @@ void data_structures_demo(void)
                         break;
                     if (circular_variant_choice == 1)
                     {
-                        circular_queue_Demo();
+                        circular_queue_demo();
                     }
                     if (circular_variant_choice == 2)
                     {
-                        scll_Demo();
+                        scll_demo();
                     }
                     if (circular_variant_choice == 3)
                     {
-                        dcll_Demo();
+                        dcll_demo();
                     }
                     if (circular_variant_choice == 4)
                     {

--- a/src/data_structures/dcll.c
+++ b/src/data_structures/dcll.c
@@ -334,7 +334,7 @@ void dcll_destroy(dcll* list)
     list->length = 0;
 }
 
-void dcll_Demo(void)
+void dcll_demo(void)
 {
     dcll list;
     dcll_init(&list);

--- a/src/data_structures/scll.c
+++ b/src/data_structures/scll.c
@@ -319,7 +319,7 @@ void scll_destroy(scll* list)
     list->length = 0;
 }
 
-void scll_Demo(void)
+void scll_demo(void)
 {
     scll list;
     scll_init(&list);

--- a/src/data_structures/simple_queue.c
+++ b/src/data_structures/simple_queue.c
@@ -15,7 +15,7 @@
 // is never reused. This "false overflow" is exactly the limitation the circular queue avoids
 // by wrapping front/rear modulo N; the two implementations sit side-by-side for comparison.
 
-void simple_queue_Demo(void)
+void simple_queue_demo(void)
 {
 
     while (1)

--- a/src/data_structures/sll.c
+++ b/src/data_structures/sll.c
@@ -7,7 +7,7 @@
 // printlist, search
 // deleteByValue and reverseList
 
-void sll_Demo(void)
+void sll_demo(void)
 {
     Node* head = NULL;
     int sll_element_count;

--- a/src/expression_evaluation/expression.h
+++ b/src/expression_evaluation/expression.h
@@ -2,8 +2,8 @@
 #define EXPRESSION_H
 #include "stack.h"
 
-void infix_to_postfix_Demo(void);
-void postfix_evaluation_Demo(void);
+void infix_to_postfix_demo(void);
+void postfix_evaluation_demo(void);
 void expression_evaluation_demo(void);
 void parantheses_checker_demo(void);
 void infix_to_prefix_demo(void);

--- a/src/expression_evaluation/expression_evaluation_demo.c
+++ b/src/expression_evaluation/expression_evaluation_demo.c
@@ -27,12 +27,12 @@ void expression_evaluation_demo(void)
 
         if (expr_eval_choice == 1)
         {
-            infix_to_postfix_Demo();
+            infix_to_postfix_demo();
             continue;
         }
         else if (expr_eval_choice == 2)
         {
-            postfix_evaluation_Demo();
+            postfix_evaluation_demo();
             continue;
         }
         else if (expr_eval_choice == 3)

--- a/src/expression_evaluation/infix_to_postfix.c
+++ b/src/expression_evaluation/infix_to_postfix.c
@@ -28,7 +28,7 @@ int isOperator(char ch)
     return 0;
 }
 
-void infix_to_postfix_Demo(void)
+void infix_to_postfix_demo(void)
 {
     char infix_expr[50];
     char postfix_expr[50];

--- a/src/expression_evaluation/postfix_evaluation.c
+++ b/src/expression_evaluation/postfix_evaluation.c
@@ -11,7 +11,7 @@
 // main while loop, it indicates malformed postfix expression and program exits with error code '-1'
 // and on succesful evaluation returns '0' maximum expression length is 50 characters
 
-void postfix_evaluation_Demo(void)
+void postfix_evaluation_demo(void)
 {
     char postfix_expr[50];
     while (1)

--- a/src/trees/bst.c
+++ b/src/trees/bst.c
@@ -199,7 +199,7 @@ bstNode* bst_delete(bstNode* root, int value)
     return root;
 }
 
-void binary_search_tree_Demo(void)
+void binary_search_tree_demo(void)
 {
 
     while (1)

--- a/src/trees/trees.h
+++ b/src/trees/trees.h
@@ -29,7 +29,7 @@ typedef struct bstNode
     struct bstNode* left;
     struct bstNode* right;
 } bstNode;
-void binary_search_tree_Demo(void);
+void binary_search_tree_demo(void);
 int bst_insert(bstNode** head_ref, int value);
 void bst_inorder(const bstNode* head);
 void bst_preorder(const bstNode* head);

--- a/src/trees/trees_demo.c
+++ b/src/trees/trees_demo.c
@@ -30,7 +30,7 @@ void trees_demo(void)
         switch (tree_choice)
         {
             case 1:
-                binary_search_tree_Demo();
+                binary_search_tree_demo();
                 break;
 
             case 2:

--- a/src/tui/tui.c
+++ b/src/tui/tui.c
@@ -1,4 +1,3 @@
-
 // #include <math.h>
 #include <ncurses.h>
 // #include <stdlib.h>
@@ -59,15 +58,15 @@ static Entry ENTRIES[] = {
 
     {"data_structures", NULL, 1, 1, 0},
     {"Linear Data Structures", NULL, 1, 0, 0},
-    {"Singly Linked List", sll_Demo, 0, 0, 1},
+    {"Singly Linked List", sll_demo, 0, 0, 1},
     {"Doubly Linked List", dll_demo, 0, 0, 1},
     {"Array", array_demo, 0, 0, 1},
     {"Priority Queue", priority_queue_demo, 0, 0, 1},
-    {"Linear Queue", simple_queue_Demo, 0, 0, 1},
+    {"Linear Queue", simple_queue_demo, 0, 0, 1},
     {"Circular Data Structures", NULL, 1, 0, 0},
-    {"Circular Queue", circular_queue_Demo, 0, 0, 1},
-    {"Singly Circular Linked List", scll_Demo, 0, 0, 1},
-    {"Doubly Circular Linked List", dcll_Demo, 0, 0, 1},
+    {"Circular Queue", circular_queue_demo, 0, 0, 1},
+    {"Singly Circular Linked List", scll_demo, 0, 0, 1},
+    {"Doubly Circular Linked List", dcll_demo, 0, 0, 1},
     {"Double-ended Queue", deque_demo, 0, 0, 1},
 
     {"Backtracking", NULL, 1, 1, 0},
@@ -84,7 +83,7 @@ static Entry ENTRIES[] = {
     {"matrix Chain", mcm_demo, 0, 0, 1},
 
     {"trees", NULL, 1, 1, 0},
-    {"Binary Search Tree", binary_search_tree_Demo, 0, 0, 1},
+    {"Binary Search Tree", binary_search_tree_demo, 0, 0, 1},
     {"AVL Tree", avl_demo, 0, 0, 1},
     {"Threaded Binary Tree", TBT_demo, 0, 0, 1},
     {"Trie", trie_demo, 0, 0, 1},
@@ -131,8 +130,8 @@ static Entry ENTRIES[] = {
     {"Quadratic Probing", quadratic_probing_demo, 0, 0, 1},
 
     {"expression_evaluation", NULL, 1, 1, 0},
-    {"Infix to Postfix", infix_to_postfix_Demo, 0, 0, 1},
-    {"Postfix Evaluation", postfix_evaluation_Demo, 0, 0, 1},
+    {"Infix to Postfix", infix_to_postfix_demo, 0, 0, 1},
+    {"Postfix Evaluation", postfix_evaluation_demo, 0, 0, 1},
     {"Parentheses Checker", parantheses_checker_demo, 0, 0, 1},
     {"Infix to Prefix", infix_to_prefix_demo, 0, 0, 1},
 


### PR DESCRIPTION
The majority of the project follows snake_case with a lowercase _demo suffix. few symbols break this.
Fix: Rename sll_Demo to sll_demo and scll_Demo to scll_demo everywhere they appear.

all changes done:
Header Files (Declarations)

data_structures.h
Updated declarations: sll_demo, scll_demo, circular_queue_demo, simple_queue_demo, dcll_demo.

trees.h
Updated declaration: binary_search_tree_demo.

expression.h
Updated declarations: infix_to_postfix_demo, postfix_evaluation_demo.
Implementation Files (Definitions)

sll.c
Renamed sll_Demo definition to sll_demo.

scll.c
Renamed scll_Demo definition to scll_demo.

circular_queue.c
Renamed circular_queue_Demo definition to circular_queue_demo.

simple_queue.c
Renamed simple_queue_Demo definition to simple_queue_demo.

dcll.c
Renamed dcll_Demo definition to dcll_demo.

bst.c
Renamed binary_search_tree_Demo definition to binary_search_tree_demo.

infix_to_postfix.c
Renamed infix_to_postfix_Demo definition to infix_to_postfix_demo.

postfix_evaluation.c
Renamed postfix_evaluation_Demo definition to postfix_evaluation_demo.
Demo Call Files (Usage)

data_structures_demo.c
Renamed calls to sll_demo, simple_queue_demo, circular_queue_demo, scll_demo, and dcll_demo.

trees_demo.c
Renamed call to binary_search_tree_demo.

expression_evaluation_demo.c
Renamed calls to infix_to_postfix_demo and postfix_evaluation_demo.
TUI Registry

tui.c
Updated references in the main ENTRIES menu registry table to point to the new lowercase function names.