### PR TITLE
feat(docker): let users choose the base image (ubuntu or debian)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,10 +10,20 @@
 #     docker build --target dev -t dsa:dev .
 #     docker run -it dsa:dev
 #
+# Choice of base image. Ubuntu and Debian share the same apt package
+# names, so either works unchanged. Default is ubuntu:24.04; pass a
+# lighter Debian base with --build-arg:
+#
+#     docker build --build-arg BASE_IMAGE=debian:stable-slim \
+#                  --target runtime -t dsa:slim .
+#
 # Note: dsa is an interactive ncurses menu, so it needs `docker run -it`.
 
+# Base image for both stages. Override with `--build-arg BASE_IMAGE=...`.
+ARG BASE_IMAGE=ubuntu:24.04
+
 # ---------- Stage 1: dev — full toolchain, debug-ready (heavyweight) ----------
-FROM ubuntu:24.04 AS dev
+FROM ${BASE_IMAGE} AS dev
 
 # Prevent interactive timezone/keyboard prompts from freezing the build
 ENV DEBIAN_FRONTEND=noninteractive
@@ -39,7 +49,7 @@ RUN make clean && make
 CMD ["./dsa"]
 
 # ---------- Stage 2: runtime — binary + ncurses runtime only (slim) ----------
-FROM ubuntu:24.04 AS runtime
+FROM ${BASE_IMAGE} AS runtime
 
 ENV DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
Closes #409

## Problem

The multi-stage Dockerfile from #403 hardcodes `ubuntu:24.04` for both the `dev` and `runtime` stages. Users who prefer a lighter **Debian** base have no way to switch without editing the Dockerfile by hand.

## Fix

Parameterize the base image with a single build **ARG**:

- `ARG BASE_IMAGE=ubuntu:24.04` is declared before the stages; both `FROM` lines now read `FROM ${BASE_IMAGE} AS ...`.
- Default stays `ubuntu:24.04`, so existing builds are **unchanged**.
- Build on Debian with `--build-arg BASE_IMAGE=debian:stable-slim`.

Ubuntu and Debian share the same apt package names (`build-essential`, `libncurses-dev`, `libncurses6`, ...), so the same Dockerfile builds on either with no further edits. The header comment documents the Debian invocation.

## Verification

Built locally (Docker Engine 29.1.3) on both bases, both targets:

```
docker build --target runtime .                                        # ubuntu  -> 119 MB
docker build --target dev     .                                        # ubuntu  -> 840 MB
docker build --build-arg BASE_IMAGE=debian:stable-slim --target runtime .   # debian -> 119 MB
docker build --build-arg BASE_IMAGE=debian:stable-slim --target dev     .   # debian -> 849 MB
```

The Debian slim binary resolves its ncurses runtime and launches the menu:

```
$ docker run --rm --entrypoint ldd dsa:debian-slim /app/dsa | grep -E 'ncurses|tinfo'
	libncurses.so.6 => /lib/x86_64-linux-gnu/libncurses.so.6
	libtinfo.so.6 => /lib/x86_64-linux-gnu/libtinfo.so.6
```

Note: the runtime image lands at ~119 MB on either base, since the bulk is `libncurses6` + its runtime deps rather than the base layer. The change delivers the **choice** of base image (and a lighter Debian build/dev base) rather than a smaller runtime.
