### PR TITLE
docs: add Docker and build system architecture overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,44 @@ Removes executables and generated object files.
 
 ---
 
+## Architectural Breakdown: Docker & The Build System
+
+### Why Docker?
+
+Docker acts as a cross-platform wrapper around the build system. Contributors on Windows, macOS, and Linux can use the same isolated Ubuntu environment without manually configuring compiler toolchains, build dependencies, or platform-specific settings.
+
+### Container Build Chain
+
+The current build flow is:
+
+```text
+Docker Container
+      ↓
+   Makefile
+      ↓
+GCC Compilation
+      ↓
+dsa Executable
+```
+
+The Docker image installs the required build tools and executes the project's Makefile, ensuring consistent builds across different operating systems.
+
+### Relationship Between Docker, Makefile, and CMake
+
+Each component serves a different purpose:
+
+- Docker provides a reproducible Linux build environment.
+- The Makefile defines the primary build workflow used by the project today.
+- CMakeLists.txt provides an alternative build system that can generate platform-specific build files while supporting testing and future expansion.
+
+These tools are complementary rather than competing solutions.
+
+### Future-Proofing With CMake
+
+The project currently uses a Makefile as its primary build system while also providing CMake support. As the project grows and introduces additional dependencies, CMake can simplify dependency management, testing integration, and cross-platform development while continuing to work inside the Docker environment.
+
+---
+
 ## Continuous Integration
 
 [![CI](https://github.com/darshan2456/C_DSA_interactive_suite/actions/workflows/ci.yml/badge.svg)](https://github.com/darshan2456/C_DSA_interactive_suite/actions/workflows/ci.yml)


### PR DESCRIPTION
## Summary

Added a new README section explaining the project's build architecture and toolchain.

### Changes
- Added "Architectural Breakdown: Docker & The Build System"
- Explained Docker's role as a cross-platform build wrapper
- Documented the current container build chain:
  Docker → Makefile → GCC → dsa executable
- Added guidance on how existing CMake support can be leveraged as the project grows

### Why
This helps new contributors understand how Docker, Makefile, and CMake fit together without needing prior knowledge of the project's build system.

### Fixes: #399 