### PR TITLE
fix(graph): Replace unsafe sprintf with snprintf in astar.c

### DIFF
--- a/src/graph_traversals/astar.c
+++ b/src/graph_traversals/astar.c
@@ -391,7 +391,7 @@ void astar_demo(void)
                 int h_val;
                 int h_status;
                 char prompt[50];
-                sprintf(prompt, "h(%d): ", i);
+                snprintf(prompt, sizeof(prompt), "h(%d): ", i);
             retry_h:
                 h_status = safe_input_int(&h_val, prompt, 0, INT_MAX);
                 if (h_status == INPUT_EXIT_SIGNAL)


### PR DESCRIPTION
### Description
This PR addresses the unsafe `sprintf` usage in `src/graph_traversals/astar.c` at line 394. 

Replacing this with a bounded `snprintf` call:
- Guarantees memory safety by ensuring the destination buffer `prompt` does not overflow.
- Clears compiler deprecation warnings and prevents build failures in strict compiler configurations.

resolves #417 