### PR TITLE
test(scheduling): Add unit tests for First-Come First-Served (FCFS)

### DIFF
--- a/src/job_scheduling/job_scheduling.h
+++ b/src/job_scheduling/job_scheduling.h
@@ -37,6 +37,13 @@ void priority_scheduling_demo(void);
 void preemptive_priority_demo(void);
 void round_robin_demo(void);
 
+#ifdef TEST_MOCK_SCHEDULING
+#define js_read_processes mock_js_read_processes
+#define js_print_result mock_js_print_result
+#define js_print_gantt mock_js_print_gantt
+#define add_to_history mock_add_to_history
+#endif
+
 // Prompts for the process count and then each process's arrival and burst time
 // (and priority when need_priority is non-zero), filling procs and *n. Returns
 // 1 once a valid set has been read, or 0 if the user asked to exit (-1).

--- a/tests/test_fcfs.c
+++ b/tests/test_fcfs.c
@@ -1,0 +1,118 @@
+#define TEST_MOCK_SCHEDULING
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "../src/job_scheduling/job_scheduling.h"
+
+// Globals to feed input and collect output
+static Process g_input_procs[10];
+static int g_input_count = 0;
+static Process g_output_procs[10];
+static int g_output_count = 0;
+
+// Mock implementations of the interactive/UI functions
+int mock_js_read_processes(Process* procs, int* n, int need_priority)
+{
+    (void)need_priority;
+    for (int i = 0; i < g_input_count; i++)
+    {
+        procs[i] = g_input_procs[i];
+        procs[i].remaining = procs[i].burst;
+    }
+    *n = g_input_count;
+    return 1;
+}
+
+void mock_js_print_result(const Process* procs, int n)
+{
+    g_output_count = n;
+    for (int i = 0; i < n; i++)
+    {
+        g_output_procs[i] = procs[i];
+    }
+}
+
+void mock_js_print_gantt(const GanttSegment* segments, int count)
+{
+    (void)segments;
+    (void)count;
+}
+
+// Stub for add_to_history to avoid linking dependency
+void mock_add_to_history(const char* algorithm, int size, double execution_time)
+{
+    (void)algorithm;
+    (void)size;
+    (void)execution_time;
+}
+
+// Include the source file directly so the compiler compiles fcfs_demo
+// as part of this translation unit, bypassing duplicate symbol linking.
+#include "../src/job_scheduling/fcfs.c"
+
+void test_fcfs_basic()
+{
+    // Initialize input processes
+    g_input_count = 3;
+    
+    // Process 1: id=1, arrival=0, burst=5
+    g_input_procs[0].id = 1;
+    g_input_procs[0].arrival = 0;
+    g_input_procs[0].burst = 5;
+    g_input_procs[0].priority = 0;
+    
+    // Process 2: id=2, arrival=2, burst=3
+    g_input_procs[1].id = 2;
+    g_input_procs[1].arrival = 2;
+    g_input_procs[1].burst = 3;
+    g_input_procs[1].priority = 0;
+    
+    // Process 3: id=3, arrival=4, burst=1
+    g_input_procs[2].id = 3;
+    g_input_procs[2].arrival = 4;
+    g_input_procs[2].burst = 1;
+    g_input_procs[2].priority = 0;
+
+    // Run the scheduler demo (which will execute the mocked functions)
+    fcfs_demo();
+
+    // Assert results
+    assert(g_output_count == 3);
+    
+    // FCFS execution order should be P1, P2, P3
+    // P1: starts at 0, finishes at 5. Wait = 0, Turnaround = 5
+    // P2: starts at 5, finishes at 8. Wait = 3, Turnaround = 6
+    // P3: starts at 8, finishes at 9. Wait = 4, Turnaround = 5
+
+    // Find and verify each process's computed values
+    for (int i = 0; i < g_output_count; i++)
+    {
+        if (g_output_procs[i].id == 1)
+        {
+            assert(g_output_procs[i].completion == 5);
+            assert(g_output_procs[i].turnaround == 5);
+            assert(g_output_procs[i].waiting == 0);
+        }
+        else if (g_output_procs[i].id == 2)
+        {
+            assert(g_output_procs[i].completion == 8);
+            assert(g_output_procs[i].turnaround == 6);
+            assert(g_output_procs[i].waiting == 3);
+        }
+        else if (g_output_procs[i].id == 3)
+        {
+            assert(g_output_procs[i].completion == 9);
+            assert(g_output_procs[i].turnaround == 5);
+            assert(g_output_procs[i].waiting == 4);
+        }
+    }
+    printf("FCFS basic test passed\n");
+}
+
+int main()
+{
+    test_fcfs_basic();
+    printf("All FCFS tests passed\n");
+    return 0;
+}


### PR DESCRIPTION
### Description
This PR introduces unit test coverage for the First-Come First-Served (FCFS) CPU scheduling algorithm under `src/job_scheduling/fcfs.c`.

To test the scheduler without altering the existing CLI-demo APIs, this PR also updates `job_scheduling.h` with preprocessor macro redirections to support testing mock configurations of input/output and history logging utilities.

resolves #418