### PR TITLE
Test/sync producer consumer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,10 @@ TEST_BINS = test_circ_queue test_bst test_search test_hash_func \
             test_greedy_bfs test_sorting_n2 test_advanced_sorting \
             test_history_logger test_shell_sort test_trie test_btree test_bplus_tree test_parity_bit \
             test_prim test_kruskal test_floyd_warshall test_mcm \
-            test_string_algorithms test_expression_evaluation
+            test_string_algorithms test_expression_evaluation \
+            test_fcfs test_sjf test_srtf test_round_robin test_priority_scheduling test_preemptive_priority \
+            test_dijkstra test_bellman_ford test_bfs test_dfs test_topological_sort \
+            test_dining_philosophers test_petersons test_producer_consumer
 
 test: $(TEST_BINS)
 
@@ -368,6 +371,90 @@ $(TEST_DIR)/test_expression_evaluation$(EXE): \
 	$(OBJ_DIR)/src/utils/cross_platform_timer.o \
 	$(OBJ_DIR)/src/utils/config.o \
 	tests/test_expression_evaluation.c
+	@$(call MKDIR_P,$(TEST_DIR))
+	$(CC) $(CFLAGS) $^ -o $@ $(LDFLAGS)
+
+test_fcfs: $(TEST_DIR)/test_fcfs$(EXE)
+	$(TEST_DIR)/test_fcfs$(EXE)
+$(TEST_DIR)/test_fcfs$(EXE): $(filter-out $(OBJ_DIR)/src/job_scheduling/fcfs.o,$(OBJS)) tests/test_fcfs.c
+	@$(call MKDIR_P,$(TEST_DIR))
+	$(CC) $(CFLAGS) $^ -o $@ $(LDFLAGS)
+
+test_sjf: $(TEST_DIR)/test_sjf$(EXE)
+	$(TEST_DIR)/test_sjf$(EXE)
+$(TEST_DIR)/test_sjf$(EXE): $(filter-out $(OBJ_DIR)/src/job_scheduling/sjf.o,$(OBJS)) tests/test_sjf.c
+	@$(call MKDIR_P,$(TEST_DIR))
+	$(CC) $(CFLAGS) $^ -o $@ $(LDFLAGS)
+
+test_srtf: $(TEST_DIR)/test_srtf$(EXE)
+	$(TEST_DIR)/test_srtf$(EXE)
+$(TEST_DIR)/test_srtf$(EXE): $(filter-out $(OBJ_DIR)/src/job_scheduling/srtf.o,$(OBJS)) tests/test_srtf.c
+	@$(call MKDIR_P,$(TEST_DIR))
+	$(CC) $(CFLAGS) $^ -o $@ $(LDFLAGS)
+
+test_round_robin: $(TEST_DIR)/test_round_robin$(EXE)
+	$(TEST_DIR)/test_round_robin$(EXE)
+$(TEST_DIR)/test_round_robin$(EXE): $(filter-out $(OBJ_DIR)/src/job_scheduling/round_robin.o,$(OBJS)) tests/test_round_robin.c
+	@$(call MKDIR_P,$(TEST_DIR))
+	$(CC) $(CFLAGS) $^ -o $@ $(LDFLAGS)
+
+test_priority_scheduling: $(TEST_DIR)/test_priority_scheduling$(EXE)
+	$(TEST_DIR)/test_priority_scheduling$(EXE)
+$(TEST_DIR)/test_priority_scheduling$(EXE): $(filter-out $(OBJ_DIR)/src/job_scheduling/priority_scheduling.o,$(OBJS)) tests/test_priority_scheduling.c
+	@$(call MKDIR_P,$(TEST_DIR))
+	$(CC) $(CFLAGS) $^ -o $@ $(LDFLAGS)
+
+test_preemptive_priority: $(TEST_DIR)/test_preemptive_priority$(EXE)
+	$(TEST_DIR)/test_preemptive_priority$(EXE)
+$(TEST_DIR)/test_preemptive_priority$(EXE): $(filter-out $(OBJ_DIR)/src/job_scheduling/preemptive_priority.o,$(OBJS)) tests/test_preemptive_priority.c
+	@$(call MKDIR_P,$(TEST_DIR))
+	$(CC) $(CFLAGS) $^ -o $@ $(LDFLAGS)
+
+test_dijkstra: $(TEST_DIR)/test_dijkstra$(EXE)
+	$(TEST_DIR)/test_dijkstra$(EXE)
+$(TEST_DIR)/test_dijkstra$(EXE): $(filter-out $(OBJ_DIR)/src/graph_traversals/dijkstra.o,$(OBJS)) tests/test_dijkstra.c
+	@$(call MKDIR_P,$(TEST_DIR))
+	$(CC) $(CFLAGS) $^ -o $@ $(LDFLAGS)
+
+test_bellman_ford: $(TEST_DIR)/test_bellman_ford$(EXE)
+	$(TEST_DIR)/test_bellman_ford$(EXE)
+$(TEST_DIR)/test_bellman_ford$(EXE): $(filter-out $(OBJ_DIR)/src/graph_traversals/bellman_ford.o,$(OBJS)) tests/test_bellman_ford.c
+	@$(call MKDIR_P,$(TEST_DIR))
+	$(CC) $(CFLAGS) $^ -o $@ $(LDFLAGS)
+
+test_bfs: $(TEST_DIR)/test_bfs$(EXE)
+	$(TEST_DIR)/test_bfs$(EXE)
+$(TEST_DIR)/test_bfs$(EXE): $(filter-out $(OBJ_DIR)/src/graph_traversals/bfs.o,$(OBJS)) tests/test_bfs.c
+	@$(call MKDIR_P,$(TEST_DIR))
+	$(CC) $(CFLAGS) $^ -o $@ $(LDFLAGS)
+
+test_dfs: $(TEST_DIR)/test_dfs$(EXE)
+	$(TEST_DIR)/test_dfs$(EXE)
+$(TEST_DIR)/test_dfs$(EXE): $(filter-out $(OBJ_DIR)/src/graph_traversals/dfs.o,$(OBJS)) tests/test_dfs.c
+	@$(call MKDIR_P,$(TEST_DIR))
+	$(CC) $(CFLAGS) $^ -o $@ $(LDFLAGS)
+
+test_topological_sort: $(TEST_DIR)/test_topological_sort$(EXE)
+	$(TEST_DIR)/test_topological_sort$(EXE)
+$(TEST_DIR)/test_topological_sort$(EXE): $(filter-out $(OBJ_DIR)/src/graph_traversals/topological_sort.o,$(OBJS)) tests/test_topological_sort.c
+	@$(call MKDIR_P,$(TEST_DIR))
+	$(CC) $(CFLAGS) $^ -o $@ $(LDFLAGS)
+
+test_dining_philosophers: $(TEST_DIR)/test_dining_philosophers$(EXE)
+	$(TEST_DIR)/test_dining_philosophers$(EXE)
+$(TEST_DIR)/test_dining_philosophers$(EXE): $(filter-out $(OBJ_DIR)/src/process_synchronization/dining_philosophers.o,$(OBJS)) tests/test_dining_philosophers.c
+	@$(call MKDIR_P,$(TEST_DIR))
+	$(CC) $(CFLAGS) $^ -o $@ $(LDFLAGS)
+
+test_petersons: $(TEST_DIR)/test_petersons$(EXE)
+	$(TEST_DIR)/test_petersons$(EXE)
+$(TEST_DIR)/test_petersons$(EXE): $(filter-out $(OBJ_DIR)/src/process_synchronization/petersons_algorithm.o,$(OBJS)) tests/test_petersons.c
+	@$(call MKDIR_P,$(TEST_DIR))
+	$(CC) $(CFLAGS) $^ -o $@ $(LDFLAGS)
+
+test_producer_consumer: $(TEST_DIR)/test_producer_consumer$(EXE)
+	$(TEST_DIR)/test_producer_consumer$(EXE)
+$(TEST_DIR)/test_producer_consumer$(EXE): $(filter-out $(OBJ_DIR)/src/process_synchronization/producer_consumer.o,$(OBJS)) tests/test_producer_consumer.c
 	@$(call MKDIR_P,$(TEST_DIR))
 	$(CC) $(CFLAGS) $^ -o $@ $(LDFLAGS)
 

--- a/src/graph_traversals/dijkstra.c
+++ b/src/graph_traversals/dijkstra.c
@@ -243,7 +243,7 @@ void add_edge_directed(weightedGraph* graph, int src, int dest, int wt)
     if (!graph)
         return;
 
-    if (src < 0 || src >= graph->V || dest < 0 || dest >= graph->V || wt < 0)
+    if (src < 0 || src >= graph->V || dest < 0 || dest >= graph->V)
     {
         printf("Invalid edge: %d -> %d with weight %d\n", src, dest, wt);
         return;

--- a/src/utils/mock_printf.c
+++ b/src/utils/mock_printf.c
@@ -1,19 +1,16 @@
-#ifndef TEST_UTILS_H
-#define TEST_UTILS_H
-
-#include <stdarg.h>
+#include "mock_printf.h"
 #include <stdio.h>
 
-static char g_printf_buf[65536];
-static int g_printf_len = 0;
+char g_printf_buf[65536];
+int g_printf_len = 0;
 
-static void reset_printf_buf(void)
+void reset_printf_buf(void)
 {
     g_printf_buf[0] = '\0';
     g_printf_len = 0;
 }
 
-static int mock_printf(const char* format, ...)
+int mock_printf(const char* format, ...)
 {
     va_list args;
     va_start(args, format);
@@ -21,5 +18,3 @@ static int mock_printf(const char* format, ...)
     va_end(args);
     return 0;
 }
-
-#endif // TEST_UTILS_H

--- a/src/utils/mock_printf.h
+++ b/src/utils/mock_printf.h
@@ -1,0 +1,12 @@
+#ifndef MOCK_PRINTF_H
+#define MOCK_PRINTF_H
+
+#include <stdarg.h>
+
+extern char g_printf_buf[65536];
+extern int g_printf_len;
+
+void reset_printf_buf(void);
+int mock_printf(const char* format, ...);
+
+#endif // MOCK_PRINTF_H

--- a/tests/test_bellman_ford.c
+++ b/tests/test_bellman_ford.c
@@ -6,7 +6,7 @@
 #include <string.h>
 #include "graph_traversals.h"
 
-#include "test_utils.h"
+#include "mock_printf.h"
 
 // Redirect printf to our mock
 #define printf mock_printf

--- a/tests/test_bellman_ford.c
+++ b/tests/test_bellman_ford.c
@@ -6,24 +6,7 @@
 #include <string.h>
 #include "graph_traversals.h"
 
-// Buffer to capture printf outputs from the algorithm
-static char g_printf_buf[4096];
-static int g_printf_len = 0;
-
-void reset_printf_buf()
-{
-    g_printf_buf[0] = '\0';
-    g_printf_len = 0;
-}
-
-int mock_printf(const char* format, ...)
-{
-    va_list args;
-    va_start(args, format);
-    g_printf_len += vsnprintf(g_printf_buf + g_printf_len, sizeof(g_printf_buf) - g_printf_len, format, args);
-    va_end(args);
-    return 0;
-}
+#include "test_utils.h"
 
 // Redirect printf to our mock
 #define printf mock_printf

--- a/tests/test_bfs.c
+++ b/tests/test_bfs.c
@@ -5,24 +5,7 @@
 #include <string.h>
 #include "graph_traversals.h"
 
-// Buffer to capture printf outputs from the algorithm
-static char g_printf_buf[4096];
-static int g_printf_len = 0;
-
-void reset_printf_buf()
-{
-    g_printf_buf[0] = '\0';
-    g_printf_len = 0;
-}
-
-int mock_printf(const char* format, ...)
-{
-    va_list args;
-    va_start(args, format);
-    g_printf_len += vsnprintf(g_printf_buf + g_printf_len, sizeof(g_printf_buf) - g_printf_len, format, args);
-    va_end(args);
-    return 0;
-}
+#include "test_utils.h"
 
 // Redirect printf to our mock
 #define printf mock_printf

--- a/tests/test_bfs.c
+++ b/tests/test_bfs.c
@@ -5,7 +5,7 @@
 #include <string.h>
 #include "graph_traversals.h"
 
-#include "test_utils.h"
+#include "mock_printf.h"
 
 // Redirect printf to our mock
 #define printf mock_printf

--- a/tests/test_dfs.c
+++ b/tests/test_dfs.c
@@ -5,24 +5,7 @@
 #include <string.h>
 #include "graph_traversals.h"
 
-// Buffer to capture printf outputs from the algorithm
-static char g_printf_buf[4096];
-static int g_printf_len = 0;
-
-void reset_printf_buf()
-{
-    g_printf_buf[0] = '\0';
-    g_printf_len = 0;
-}
-
-int mock_printf(const char* format, ...)
-{
-    va_list args;
-    va_start(args, format);
-    g_printf_len += vsnprintf(g_printf_buf + g_printf_len, sizeof(g_printf_buf) - g_printf_len, format, args);
-    va_end(args);
-    return 0;
-}
+#include "test_utils.h"
 
 // Redirect printf to our mock
 #define printf mock_printf

--- a/tests/test_dfs.c
+++ b/tests/test_dfs.c
@@ -5,7 +5,7 @@
 #include <string.h>
 #include "graph_traversals.h"
 
-#include "test_utils.h"
+#include "mock_printf.h"
 
 // Redirect printf to our mock
 #define printf mock_printf

--- a/tests/test_dijkstra.c
+++ b/tests/test_dijkstra.c
@@ -6,7 +6,7 @@
 #include <string.h>
 #include "graph_traversals.h"
 
-#include "test_utils.h"
+#include "mock_printf.h"
 
 // Redirect printf to our mock
 #define printf mock_printf

--- a/tests/test_dijkstra.c
+++ b/tests/test_dijkstra.c
@@ -6,24 +6,7 @@
 #include <string.h>
 #include "graph_traversals.h"
 
-// Buffer to capture printf outputs from the algorithm
-static char g_printf_buf[4096];
-static int g_printf_len = 0;
-
-void reset_printf_buf()
-{
-    g_printf_buf[0] = '\0';
-    g_printf_len = 0;
-}
-
-int mock_printf(const char* format, ...)
-{
-    va_list args;
-    va_start(args, format);
-    g_printf_len += vsnprintf(g_printf_buf + g_printf_len, sizeof(g_printf_buf) - g_printf_len, format, args);
-    va_end(args);
-    return 0;
-}
+#include "test_utils.h"
 
 // Redirect printf to our mock
 #define printf mock_printf

--- a/tests/test_producer_consumer.c
+++ b/tests/test_producer_consumer.c
@@ -14,6 +14,8 @@
 #define sleep_seconds(x) (void)0
 #define getchar() '\n'
 
+#include "test_utils.h"
+
 // Mocking safe_input_int to feed inputs to the interactive loop
 static int g_inputs[100];
 static int g_inputs_count = 0;
@@ -41,25 +43,6 @@ int mock_safe_input_int(int* var, const char* prompt, int low, int high)
     }
     *var = -1;
     return -111; // INPUT_EXIT_SIGNAL
-}
-
-// Buffer to capture printf outputs from the algorithm
-static char g_printf_buf[65536];
-static int g_printf_len = 0;
-
-void reset_printf_buf()
-{
-    g_printf_buf[0] = '\0';
-    g_printf_len = 0;
-}
-
-int mock_printf(const char* format, ...)
-{
-    va_list args;
-    va_start(args, format);
-    g_printf_len += vsnprintf(g_printf_buf + g_printf_len, sizeof(g_printf_buf) - g_printf_len, format, args);
-    va_end(args);
-    return 0;
 }
 
 // Redirect functions using preprocessor macros

--- a/tests/test_producer_consumer.c
+++ b/tests/test_producer_consumer.c
@@ -12,7 +12,7 @@
 #define is_instant() 1
 #define clear_screen() (void)0
 #define sleep_seconds(x) (void)0
-#define getchar() '\n'
+#define getchar() ((void)'\n')
 
 #include "test_utils.h"
 

--- a/tests/test_producer_consumer.c
+++ b/tests/test_producer_consumer.c
@@ -14,7 +14,7 @@
 #define sleep_seconds(x) (void)0
 #define getchar() ((void)'\n')
 
-#include "test_utils.h"
+#include "mock_printf.h"
 
 // Mocking safe_input_int to feed inputs to the interactive loop
 static int g_inputs[100];

--- a/tests/test_topological_sort.c
+++ b/tests/test_topological_sort.c
@@ -5,24 +5,7 @@
 #include <string.h>
 #include "graph_traversals.h"
 
-// Buffer to capture printf outputs from the algorithm
-static char g_printf_buf[4096];
-static int g_printf_len = 0;
-
-void reset_printf_buf()
-{
-    g_printf_buf[0] = '\0';
-    g_printf_len = 0;
-}
-
-int mock_printf(const char* format, ...)
-{
-    va_list args;
-    va_start(args, format);
-    g_printf_len += vsnprintf(g_printf_buf + g_printf_len, sizeof(g_printf_buf) - g_printf_len, format, args);
-    va_end(args);
-    return 0;
-}
+#include "test_utils.h"
 
 // Redirect printf to our mock
 #define printf mock_printf

--- a/tests/test_topological_sort.c
+++ b/tests/test_topological_sort.c
@@ -5,7 +5,7 @@
 #include <string.h>
 #include "graph_traversals.h"
 
-#include "test_utils.h"
+#include "mock_printf.h"
 
 // Redirect printf to our mock
 #define printf mock_printf

--- a/tests/test_utils.h
+++ b/tests/test_utils.h
@@ -1,0 +1,25 @@
+#ifndef TEST_UTILS_H
+#define TEST_UTILS_H
+
+#include <stdarg.h>
+#include <stdio.h>
+
+static char g_printf_buf[65536];
+static int g_printf_len = 0;
+
+static void reset_printf_buf(void)
+{
+    g_printf_buf[0] = '\0';
+    g_printf_len = 0;
+}
+
+static int mock_printf(const char* format, ...)
+{
+    va_list args;
+    va_start(args, format);
+    g_printf_len += vsnprintf(g_printf_buf + g_printf_len, sizeof(g_printf_buf) - g_printf_len, format, args);
+    va_end(args);
+    return 0;
+}
+
+#endif // TEST_UTILS_H


### PR DESCRIPTION


Here is a summary of the finalized changes:
1. **Shared utility in `src/utils`**: `mock_printf` is now defined in [src/utils/mock_printf.h](file:///Users/akshatshukla/Downloads/Work/open/C_DSA_interactive_suite.git/src/utils/mock_printf.h) and [src/utils/mock_printf.c](file:///Users/akshatshukla/Downloads/Work/open/C_DSA_interactive_suite.git/src/utils/mock_printf.c).
2. **Reused across all tests**: All graph and synchronization tests now include `"mock_printf.h"` instead of having duplicate inline print mocking code.
3. **Producer-Consumer warning fixed**: The `getchar()` mock was casted to `void` to suppress the compilation warning/error.
4. **Bellman-Ford test resolved**: Negative edge weights are now permitted by `add_edge_directed` in `src/graph_traversals/dijkstra.c`, allowing the Bellman-Ford shortest paths and negative cycles to build and verify correctly.
5. **Makefile updated**: All 14 scheduling, graph, and process synchronization tests are registered in the root `Makefile` using `filter-out` to resolve duplicate linker symbols correctly.

