### PR TITLE
test(graph): Refactor mock printf to utility and update Makefile 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -375,67 +375,67 @@ $(TEST_DIR)/test_expression_evaluation$(EXE): \
 
 test_fcfs: $(TEST_DIR)/test_fcfs$(EXE)
 	$(TEST_DIR)/test_fcfs$(EXE)
-$(TEST_DIR)/test_fcfs$(EXE): $(filter-out $(OBJ_DIR)/src/job_scheduling/fcfs.o,$(OBJS)) tests/test_fcfs.c
+$(TEST_DIR)/test_fcfs$(EXE): $(filter-out $(OBJ_DIR)/src/job_scheduling/fcfs.o,$(OBJS)) tests/job_scheduling/test_fcfs.c
 	@$(call MKDIR_P,$(TEST_DIR))
 	$(CC) $(CFLAGS) $^ -o $@ $(LDFLAGS)
 
 test_sjf: $(TEST_DIR)/test_sjf$(EXE)
 	$(TEST_DIR)/test_sjf$(EXE)
-$(TEST_DIR)/test_sjf$(EXE): $(filter-out $(OBJ_DIR)/src/job_scheduling/sjf.o,$(OBJS)) tests/test_sjf.c
+$(TEST_DIR)/test_sjf$(EXE): $(filter-out $(OBJ_DIR)/src/job_scheduling/sjf.o,$(OBJS)) tests/job_scheduling/test_sjf.c
 	@$(call MKDIR_P,$(TEST_DIR))
 	$(CC) $(CFLAGS) $^ -o $@ $(LDFLAGS)
 
 test_srtf: $(TEST_DIR)/test_srtf$(EXE)
 	$(TEST_DIR)/test_srtf$(EXE)
-$(TEST_DIR)/test_srtf$(EXE): $(filter-out $(OBJ_DIR)/src/job_scheduling/srtf.o,$(OBJS)) tests/test_srtf.c
+$(TEST_DIR)/test_srtf$(EXE): $(filter-out $(OBJ_DIR)/src/job_scheduling/srtf.o,$(OBJS)) tests/job_scheduling/test_srtf.c
 	@$(call MKDIR_P,$(TEST_DIR))
 	$(CC) $(CFLAGS) $^ -o $@ $(LDFLAGS)
 
 test_round_robin: $(TEST_DIR)/test_round_robin$(EXE)
 	$(TEST_DIR)/test_round_robin$(EXE)
-$(TEST_DIR)/test_round_robin$(EXE): $(filter-out $(OBJ_DIR)/src/job_scheduling/round_robin.o,$(OBJS)) tests/test_round_robin.c
+$(TEST_DIR)/test_round_robin$(EXE): $(filter-out $(OBJ_DIR)/src/job_scheduling/round_robin.o,$(OBJS)) tests/job_scheduling/test_round_robin.c
 	@$(call MKDIR_P,$(TEST_DIR))
 	$(CC) $(CFLAGS) $^ -o $@ $(LDFLAGS)
 
 test_priority_scheduling: $(TEST_DIR)/test_priority_scheduling$(EXE)
 	$(TEST_DIR)/test_priority_scheduling$(EXE)
-$(TEST_DIR)/test_priority_scheduling$(EXE): $(filter-out $(OBJ_DIR)/src/job_scheduling/priority_scheduling.o,$(OBJS)) tests/test_priority_scheduling.c
+$(TEST_DIR)/test_priority_scheduling$(EXE): $(filter-out $(OBJ_DIR)/src/job_scheduling/priority_scheduling.o,$(OBJS)) tests/job_scheduling/test_priority_scheduling.c
 	@$(call MKDIR_P,$(TEST_DIR))
 	$(CC) $(CFLAGS) $^ -o $@ $(LDFLAGS)
 
 test_preemptive_priority: $(TEST_DIR)/test_preemptive_priority$(EXE)
 	$(TEST_DIR)/test_preemptive_priority$(EXE)
-$(TEST_DIR)/test_preemptive_priority$(EXE): $(filter-out $(OBJ_DIR)/src/job_scheduling/preemptive_priority.o,$(OBJS)) tests/test_preemptive_priority.c
+$(TEST_DIR)/test_preemptive_priority$(EXE): $(filter-out $(OBJ_DIR)/src/job_scheduling/preemptive_priority.o,$(OBJS)) tests/job_scheduling/test_preemptive_priority.c
 	@$(call MKDIR_P,$(TEST_DIR))
 	$(CC) $(CFLAGS) $^ -o $@ $(LDFLAGS)
 
 test_dijkstra: $(TEST_DIR)/test_dijkstra$(EXE)
 	$(TEST_DIR)/test_dijkstra$(EXE)
-$(TEST_DIR)/test_dijkstra$(EXE): $(filter-out $(OBJ_DIR)/src/graph_traversals/dijkstra.o,$(OBJS)) tests/test_dijkstra.c
+$(TEST_DIR)/test_dijkstra$(EXE): $(filter-out $(OBJ_DIR)/src/graph_traversals/dijkstra.o,$(OBJS)) tests/graph_traversals/test_dijkstra.c
 	@$(call MKDIR_P,$(TEST_DIR))
 	$(CC) $(CFLAGS) $^ -o $@ $(LDFLAGS)
 
 test_bellman_ford: $(TEST_DIR)/test_bellman_ford$(EXE)
 	$(TEST_DIR)/test_bellman_ford$(EXE)
-$(TEST_DIR)/test_bellman_ford$(EXE): $(filter-out $(OBJ_DIR)/src/graph_traversals/bellman_ford.o,$(OBJS)) tests/test_bellman_ford.c
+$(TEST_DIR)/test_bellman_ford$(EXE): $(filter-out $(OBJ_DIR)/src/graph_traversals/bellman_ford.o,$(OBJS)) tests/graph_traversals/test_bellman_ford.c
 	@$(call MKDIR_P,$(TEST_DIR))
 	$(CC) $(CFLAGS) $^ -o $@ $(LDFLAGS)
 
 test_bfs: $(TEST_DIR)/test_bfs$(EXE)
 	$(TEST_DIR)/test_bfs$(EXE)
-$(TEST_DIR)/test_bfs$(EXE): $(filter-out $(OBJ_DIR)/src/graph_traversals/bfs.o,$(OBJS)) tests/test_bfs.c
+$(TEST_DIR)/test_bfs$(EXE): $(filter-out $(OBJ_DIR)/src/graph_traversals/bfs.o,$(OBJS)) tests/graph_traversals/test_bfs.c
 	@$(call MKDIR_P,$(TEST_DIR))
 	$(CC) $(CFLAGS) $^ -o $@ $(LDFLAGS)
 
 test_dfs: $(TEST_DIR)/test_dfs$(EXE)
 	$(TEST_DIR)/test_dfs$(EXE)
-$(TEST_DIR)/test_dfs$(EXE): $(filter-out $(OBJ_DIR)/src/graph_traversals/dfs.o,$(OBJS)) tests/test_dfs.c
+$(TEST_DIR)/test_dfs$(EXE): $(filter-out $(OBJ_DIR)/src/graph_traversals/dfs.o,$(OBJS)) tests/graph_traversals/test_dfs.c
 	@$(call MKDIR_P,$(TEST_DIR))
 	$(CC) $(CFLAGS) $^ -o $@ $(LDFLAGS)
 
 test_topological_sort: $(TEST_DIR)/test_topological_sort$(EXE)
 	$(TEST_DIR)/test_topological_sort$(EXE)
-$(TEST_DIR)/test_topological_sort$(EXE): $(filter-out $(OBJ_DIR)/src/graph_traversals/topological_sort.o,$(OBJS)) tests/test_topological_sort.c
+$(TEST_DIR)/test_topological_sort$(EXE): $(filter-out $(OBJ_DIR)/src/graph_traversals/topological_sort.o,$(OBJS)) tests/graph_traversals/test_topological_sort.c
 	@$(call MKDIR_P,$(TEST_DIR))
 	$(CC) $(CFLAGS) $^ -o $@ $(LDFLAGS)
 

--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,9 @@ TEST_BINS = test_circ_queue test_bst test_search test_hash_func \
             test_greedy_bfs test_sorting_n2 test_advanced_sorting \
             test_history_logger test_shell_sort test_trie test_btree test_bplus_tree test_parity_bit \
             test_prim test_kruskal test_floyd_warshall test_mcm \
-            test_string_algorithms test_expression_evaluation
+            test_string_algorithms test_expression_evaluation \
+            test_fcfs test_sjf test_srtf test_round_robin test_priority_scheduling test_preemptive_priority \
+            test_dijkstra test_bellman_ford test_bfs test_dfs test_topological_sort
 
 test: $(TEST_BINS)
 
@@ -368,6 +370,72 @@ $(TEST_DIR)/test_expression_evaluation$(EXE): \
 	$(OBJ_DIR)/src/utils/cross_platform_timer.o \
 	$(OBJ_DIR)/src/utils/config.o \
 	tests/expression_evaluation/test_expression_evaluation.c
+	@$(call MKDIR_P,$(TEST_DIR))
+	$(CC) $(CFLAGS) $^ -o $@ $(LDFLAGS)
+
+test_fcfs: $(TEST_DIR)/test_fcfs$(EXE)
+	$(TEST_DIR)/test_fcfs$(EXE)
+$(TEST_DIR)/test_fcfs$(EXE): $(filter-out $(OBJ_DIR)/src/job_scheduling/fcfs.o,$(OBJS)) tests/test_fcfs.c
+	@$(call MKDIR_P,$(TEST_DIR))
+	$(CC) $(CFLAGS) $^ -o $@ $(LDFLAGS)
+
+test_sjf: $(TEST_DIR)/test_sjf$(EXE)
+	$(TEST_DIR)/test_sjf$(EXE)
+$(TEST_DIR)/test_sjf$(EXE): $(filter-out $(OBJ_DIR)/src/job_scheduling/sjf.o,$(OBJS)) tests/test_sjf.c
+	@$(call MKDIR_P,$(TEST_DIR))
+	$(CC) $(CFLAGS) $^ -o $@ $(LDFLAGS)
+
+test_srtf: $(TEST_DIR)/test_srtf$(EXE)
+	$(TEST_DIR)/test_srtf$(EXE)
+$(TEST_DIR)/test_srtf$(EXE): $(filter-out $(OBJ_DIR)/src/job_scheduling/srtf.o,$(OBJS)) tests/test_srtf.c
+	@$(call MKDIR_P,$(TEST_DIR))
+	$(CC) $(CFLAGS) $^ -o $@ $(LDFLAGS)
+
+test_round_robin: $(TEST_DIR)/test_round_robin$(EXE)
+	$(TEST_DIR)/test_round_robin$(EXE)
+$(TEST_DIR)/test_round_robin$(EXE): $(filter-out $(OBJ_DIR)/src/job_scheduling/round_robin.o,$(OBJS)) tests/test_round_robin.c
+	@$(call MKDIR_P,$(TEST_DIR))
+	$(CC) $(CFLAGS) $^ -o $@ $(LDFLAGS)
+
+test_priority_scheduling: $(TEST_DIR)/test_priority_scheduling$(EXE)
+	$(TEST_DIR)/test_priority_scheduling$(EXE)
+$(TEST_DIR)/test_priority_scheduling$(EXE): $(filter-out $(OBJ_DIR)/src/job_scheduling/priority_scheduling.o,$(OBJS)) tests/test_priority_scheduling.c
+	@$(call MKDIR_P,$(TEST_DIR))
+	$(CC) $(CFLAGS) $^ -o $@ $(LDFLAGS)
+
+test_preemptive_priority: $(TEST_DIR)/test_preemptive_priority$(EXE)
+	$(TEST_DIR)/test_preemptive_priority$(EXE)
+$(TEST_DIR)/test_preemptive_priority$(EXE): $(filter-out $(OBJ_DIR)/src/job_scheduling/preemptive_priority.o,$(OBJS)) tests/test_preemptive_priority.c
+	@$(call MKDIR_P,$(TEST_DIR))
+	$(CC) $(CFLAGS) $^ -o $@ $(LDFLAGS)
+
+test_dijkstra: $(TEST_DIR)/test_dijkstra$(EXE)
+	$(TEST_DIR)/test_dijkstra$(EXE)
+$(TEST_DIR)/test_dijkstra$(EXE): $(filter-out $(OBJ_DIR)/src/graph_traversals/dijkstra.o,$(OBJS)) tests/test_dijkstra.c
+	@$(call MKDIR_P,$(TEST_DIR))
+	$(CC) $(CFLAGS) $^ -o $@ $(LDFLAGS)
+
+test_bellman_ford: $(TEST_DIR)/test_bellman_ford$(EXE)
+	$(TEST_DIR)/test_bellman_ford$(EXE)
+$(TEST_DIR)/test_bellman_ford$(EXE): $(filter-out $(OBJ_DIR)/src/graph_traversals/bellman_ford.o,$(OBJS)) tests/test_bellman_ford.c
+	@$(call MKDIR_P,$(TEST_DIR))
+	$(CC) $(CFLAGS) $^ -o $@ $(LDFLAGS)
+
+test_bfs: $(TEST_DIR)/test_bfs$(EXE)
+	$(TEST_DIR)/test_bfs$(EXE)
+$(TEST_DIR)/test_bfs$(EXE): $(filter-out $(OBJ_DIR)/src/graph_traversals/bfs.o,$(OBJS)) tests/test_bfs.c
+	@$(call MKDIR_P,$(TEST_DIR))
+	$(CC) $(CFLAGS) $^ -o $@ $(LDFLAGS)
+
+test_dfs: $(TEST_DIR)/test_dfs$(EXE)
+	$(TEST_DIR)/test_dfs$(EXE)
+$(TEST_DIR)/test_dfs$(EXE): $(filter-out $(OBJ_DIR)/src/graph_traversals/dfs.o,$(OBJS)) tests/test_dfs.c
+	@$(call MKDIR_P,$(TEST_DIR))
+	$(CC) $(CFLAGS) $^ -o $@ $(LDFLAGS)
+
+test_topological_sort: $(TEST_DIR)/test_topological_sort$(EXE)
+	$(TEST_DIR)/test_topological_sort$(EXE)
+$(TEST_DIR)/test_topological_sort$(EXE): $(filter-out $(OBJ_DIR)/src/graph_traversals/topological_sort.o,$(OBJS)) tests/test_topological_sort.c
 	@$(call MKDIR_P,$(TEST_DIR))
 	$(CC) $(CFLAGS) $^ -o $@ $(LDFLAGS)
 

--- a/src/graph_traversals/dijkstra.c
+++ b/src/graph_traversals/dijkstra.c
@@ -243,7 +243,7 @@ void add_edge_directed(weightedGraph* graph, int src, int dest, int wt)
     if (!graph)
         return;
 
-    if (src < 0 || src >= graph->V || dest < 0 || dest >= graph->V || wt < 0)
+    if (src < 0 || src >= graph->V || dest < 0 || dest >= graph->V)
     {
         printf("Invalid edge: %d -> %d with weight %d\n", src, dest, wt);
         return;

--- a/src/utils/mock_printf.c
+++ b/src/utils/mock_printf.c
@@ -1,0 +1,20 @@
+#include "mock_printf.h"
+#include <stdio.h>
+
+char g_printf_buf[65536];
+int g_printf_len = 0;
+
+void reset_printf_buf(void)
+{
+    g_printf_buf[0] = '\0';
+    g_printf_len = 0;
+}
+
+int mock_printf(const char* format, ...)
+{
+    va_list args;
+    va_start(args, format);
+    g_printf_len += vsnprintf(g_printf_buf + g_printf_len, sizeof(g_printf_buf) - g_printf_len, format, args);
+    va_end(args);
+    return 0;
+}

--- a/src/utils/mock_printf.h
+++ b/src/utils/mock_printf.h
@@ -1,0 +1,12 @@
+#ifndef MOCK_PRINTF_H
+#define MOCK_PRINTF_H
+
+#include <stdarg.h>
+
+extern char g_printf_buf[65536];
+extern int g_printf_len;
+
+void reset_printf_buf(void);
+int mock_printf(const char* format, ...);
+
+#endif // MOCK_PRINTF_H

--- a/tests/graph_traversals/test_bellman_ford.c
+++ b/tests/graph_traversals/test_bellman_ford.c
@@ -6,24 +6,7 @@
 #include <string.h>
 #include "graph_traversals.h"
 
-// Buffer to capture printf outputs from the algorithm
-static char g_printf_buf[4096];
-static int g_printf_len = 0;
-
-void reset_printf_buf()
-{
-    g_printf_buf[0] = '\0';
-    g_printf_len = 0;
-}
-
-int mock_printf(const char* format, ...)
-{
-    va_list args;
-    va_start(args, format);
-    g_printf_len += vsnprintf(g_printf_buf + g_printf_len, sizeof(g_printf_buf) - g_printf_len, format, args);
-    va_end(args);
-    return 0;
-}
+#include "mock_printf.h"
 
 // Redirect printf to our mock
 #define printf mock_printf

--- a/tests/graph_traversals/test_bfs.c
+++ b/tests/graph_traversals/test_bfs.c
@@ -5,24 +5,7 @@
 #include <string.h>
 #include "graph_traversals.h"
 
-// Buffer to capture printf outputs from the algorithm
-static char g_printf_buf[4096];
-static int g_printf_len = 0;
-
-void reset_printf_buf()
-{
-    g_printf_buf[0] = '\0';
-    g_printf_len = 0;
-}
-
-int mock_printf(const char* format, ...)
-{
-    va_list args;
-    va_start(args, format);
-    g_printf_len += vsnprintf(g_printf_buf + g_printf_len, sizeof(g_printf_buf) - g_printf_len, format, args);
-    va_end(args);
-    return 0;
-}
+#include "mock_printf.h"
 
 // Redirect printf to our mock
 #define printf mock_printf

--- a/tests/graph_traversals/test_dfs.c
+++ b/tests/graph_traversals/test_dfs.c
@@ -5,24 +5,7 @@
 #include <string.h>
 #include "graph_traversals.h"
 
-// Buffer to capture printf outputs from the algorithm
-static char g_printf_buf[4096];
-static int g_printf_len = 0;
-
-void reset_printf_buf()
-{
-    g_printf_buf[0] = '\0';
-    g_printf_len = 0;
-}
-
-int mock_printf(const char* format, ...)
-{
-    va_list args;
-    va_start(args, format);
-    g_printf_len += vsnprintf(g_printf_buf + g_printf_len, sizeof(g_printf_buf) - g_printf_len, format, args);
-    va_end(args);
-    return 0;
-}
+#include "mock_printf.h"
 
 // Redirect printf to our mock
 #define printf mock_printf

--- a/tests/graph_traversals/test_dijkstra.c
+++ b/tests/graph_traversals/test_dijkstra.c
@@ -6,24 +6,7 @@
 #include <string.h>
 #include "graph_traversals.h"
 
-// Buffer to capture printf outputs from the algorithm
-static char g_printf_buf[4096];
-static int g_printf_len = 0;
-
-void reset_printf_buf()
-{
-    g_printf_buf[0] = '\0';
-    g_printf_len = 0;
-}
-
-int mock_printf(const char* format, ...)
-{
-    va_list args;
-    va_start(args, format);
-    g_printf_len += vsnprintf(g_printf_buf + g_printf_len, sizeof(g_printf_buf) - g_printf_len, format, args);
-    va_end(args);
-    return 0;
-}
+#include "mock_printf.h"
 
 // Redirect printf to our mock
 #define printf mock_printf

--- a/tests/graph_traversals/test_topological_sort.c
+++ b/tests/graph_traversals/test_topological_sort.c
@@ -5,24 +5,7 @@
 #include <string.h>
 #include "graph_traversals.h"
 
-// Buffer to capture printf outputs from the algorithm
-static char g_printf_buf[4096];
-static int g_printf_len = 0;
-
-void reset_printf_buf()
-{
-    g_printf_buf[0] = '\0';
-    g_printf_len = 0;
-}
-
-int mock_printf(const char* format, ...)
-{
-    va_list args;
-    va_start(args, format);
-    g_printf_len += vsnprintf(g_printf_buf + g_printf_len, sizeof(g_printf_buf) - g_printf_len, format, args);
-    va_end(args);
-    return 0;
-}
+#include "mock_printf.h"
 
 // Redirect printf to our mock
 #define printf mock_printf


### PR DESCRIPTION
### **Description**
This PR addresses code quality issues, compilation warnings, and test coverage gaps for the Graph Traversal algorithms:
1. Extracting the redundant `mock_printf()` definitions into a centralized utility in `src/utils`.
2. Fixing a validation bug in `add_edge_directed()` that caused the Bellman-Ford unit test to fail.
3. Integrating the Graph Traversal tests and missing CPU Scheduling tests into the root `Makefile` so they are executed in the CI pipeline.

---

### **Key Changes**

#### **1. Centralized Mock Printf Utility**
* Created **`src/utils/mock_printf.h`** and **`src/utils/mock_printf.c`** to define a single, shared implementation of `mock_printf`, `g_printf_buf`, and `reset_printf_buf`.
* Refactored all 5 graph traversal tests to include `mock_printf.h` and removed their local duplicate implementations:
  * `tests/test_dijkstra.c`
  * `tests/test_bellman_ford.c`
  * `tests/test_bfs.c`
  * `tests/test_dfs.c`
  * `tests/test_topological_sort.c`

#### **2. Fixed Bellman-Ford Edge Validation Bug**
* **Root Cause**: `add_edge_directed()` in `src/graph_traversals/dijkstra.c` was rejecting negative edge weights (`wt < 0`). Since Bellman-Ford requires negative edges to check shortest paths and negative cycles, this constraint blocked the setup of test cases, causing assertions to fail.
* **Fix**: Removed the `wt < 0` validation check from `add_edge_directed()`. Enforcing non-negative weights is already handled at the user-input UI layer for algorithms that require it (Dijkstra, A*, Kruskal, Prim).

#### **3. Makefile Integration**
* Added the Graph Traversal tests (`test_dijkstra`, `test_bellman_ford`, `test_bfs`, `test_dfs`, `test_topological_sort`) and missing CPU Job Scheduling tests to the root `Makefile`'s `TEST_BINS`.
* Used GNU Make `filter-out` to exclude corresponding implementation objects (e.g. `bellman_ford.o`) from `$(OBJS)` when building test binaries that include the `.c` file directly, preventing duplicate symbol linker errors.

---

### **Verification**
Cleaned and ran all tests locally:
```bash
make clean && make test