### PR TITLE
test(dp): Add unit test coverage for LCS DP algorithm and update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,7 +111,7 @@ TEST_BINS = test_circ_queue test_bst test_search test_hash_func \
             test_deque test_astar test_avl \
             test_greedy_bfs test_sorting_n2 test_advanced_sorting \
             test_history_logger test_shell_sort test_trie test_btree test_bplus_tree test_parity_bit \
-            test_prim test_kruskal test_floyd_warshall test_mcm \
+            test_prim test_kruskal test_floyd_warshall test_mcm test_fibonacci test_knapsack test_lcs \
             test_string_algorithms test_expression_evaluation \
             test_fcfs test_sjf test_srtf test_round_robin test_priority_scheduling test_preemptive_priority \
             test_dijkstra test_bellman_ford test_bfs test_dfs test_topological_sort
@@ -122,6 +122,27 @@ test_mcm: $(TEST_DIR)/test_mcm$(EXE)
 	$(TEST_DIR)/test_mcm$(EXE)
 
 $(TEST_DIR)/test_mcm$(EXE): $(OBJ_DIR)/src/dynamic_programming/mcm.o $(OBJ_DIR)/src/utils/safe_input_int.o $(OBJ_DIR)/src/utils/history_logger.o tests/dynamic_programming/test_mcm.c
+	@$(call MKDIR_P,$(TEST_DIR))
+	$(CC) $(CFLAGS) $^ -o $@ $(LDFLAGS)
+
+test_fibonacci: $(TEST_DIR)/test_fibonacci$(EXE)
+	$(TEST_DIR)/test_fibonacci$(EXE)
+
+$(TEST_DIR)/test_fibonacci$(EXE): $(OBJ_DIR)/src/utils/mock_printf.o $(OBJ_DIR)/src/utils/safe_input_int.o $(OBJ_DIR)/src/utils/safe_input_string.o $(OBJ_DIR)/src/utils/history_logger.o tests/dynamic_programming/test_fibonacci.c
+	@$(call MKDIR_P,$(TEST_DIR))
+	$(CC) $(CFLAGS) $^ -o $@ $(LDFLAGS)
+
+test_knapsack: $(TEST_DIR)/test_knapsack$(EXE)
+	$(TEST_DIR)/test_knapsack$(EXE)
+
+$(TEST_DIR)/test_knapsack$(EXE): $(OBJ_DIR)/src/utils/mock_printf.o $(OBJ_DIR)/src/utils/safe_input_int.o $(OBJ_DIR)/src/utils/safe_input_string.o $(OBJ_DIR)/src/utils/history_logger.o tests/dynamic_programming/test_knapsack.c
+	@$(call MKDIR_P,$(TEST_DIR))
+	$(CC) $(CFLAGS) $^ -o $@ $(LDFLAGS)
+
+test_lcs: $(TEST_DIR)/test_lcs$(EXE)
+	$(TEST_DIR)/test_lcs$(EXE)
+
+$(TEST_DIR)/test_lcs$(EXE): $(OBJ_DIR)/src/utils/mock_printf.o $(OBJ_DIR)/src/utils/safe_input_int.o $(OBJ_DIR)/src/utils/safe_input_string.o $(OBJ_DIR)/src/utils/history_logger.o tests/dynamic_programming/test_lcs.c
 	@$(call MKDIR_P,$(TEST_DIR))
 	$(CC) $(CFLAGS) $^ -o $@ $(LDFLAGS)
 

--- a/tests/dynamic_programming/test_fibonacci.c
+++ b/tests/dynamic_programming/test_fibonacci.c
@@ -1,0 +1,54 @@
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "dynamic_programming.h"
+#include "mock_printf.h"
+
+// Define overrides to suppress history logging prints
+#define printf mock_printf
+#include "../../src/dynamic_programming/fibonacci.c"
+#undef printf
+
+void test_fibonacci_base_cases()
+{
+    long long memo_0[1] = {-1};
+    assert(fibonacci_recursive(0, memo_0) == 0);
+    assert(fibonacci_iterative(0) == 0);
+
+    long long memo_1[2] = {-1, -1};
+    assert(fibonacci_recursive(1, memo_1) == 1);
+    assert(fibonacci_iterative(1) == 1);
+}
+
+void test_fibonacci_recursive_memoized()
+{
+    int n = 10;
+    long long* memo = malloc((n + 1) * sizeof(long long));
+    for (int i = 0; i <= n; i++) memo[i] = -1;
+    
+    assert(fibonacci_recursive(n, memo) == 55);
+    free(memo);
+
+    n = 45;
+    memo = malloc((n + 1) * sizeof(long long));
+    for (int i = 0; i <= n; i++) memo[i] = -1;
+    assert(fibonacci_recursive(n, memo) == 1134903170LL);
+    free(memo);
+}
+
+void test_fibonacci_tabulation()
+{
+    assert(fibonacci_iterative(10) == 55);
+    assert(fibonacci_iterative(45) == 1134903170LL);
+    assert(fibonacci_iterative(90) == 2880067194370816120LL);
+}
+
+int main()
+{
+    test_fibonacci_base_cases();
+    test_fibonacci_recursive_memoized();
+    test_fibonacci_tabulation();
+
+    fprintf(stdout, "All Fibonacci tests passed successfully!\n");
+    return 0;
+}

--- a/tests/dynamic_programming/test_knapsack.c
+++ b/tests/dynamic_programming/test_knapsack.c
@@ -1,0 +1,72 @@
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "dynamic_programming.h"
+#include "mock_printf.h"
+
+// Define overrides to suppress history logging and DP table prints
+#define printf mock_printf
+#include "../../src/dynamic_programming/knapsack.c"
+#undef printf
+
+void test_knapsack_base_cases()
+{
+    reset_printf_buf();
+    int wt[] = {2, 3, 4};
+    int val[] = {3, 4, 5};
+
+    // Zero capacity W = 0
+    assert(knapsack(0, wt, val, 3) == 0);
+    // Verify table printed empty capacity values
+    assert(strstr(g_printf_buf, "--- 0/1 Knapsack DP Table ---") != NULL);
+
+    reset_printf_buf();
+    // Zero items n = 0
+    assert(knapsack(5, wt, val, 0) == 0);
+    assert(strstr(g_printf_buf, "--- 0/1 Knapsack DP Table ---") != NULL);
+}
+
+void test_knapsack_all_fit()
+{
+    reset_printf_buf();
+    int wt[] = {1, 2, 3};
+    int val[] = {10, 15, 40};
+    int n = 3;
+    int W = 6; // All fit: total weight = 6, total value = 65
+
+    assert(knapsack(W, wt, val, n) == 65);
+}
+
+void test_knapsack_subset_fit()
+{
+    reset_printf_buf();
+    int wt[] = {1, 2, 3, 5};
+    int val[] = {1, 6, 18, 22};
+    int n = 4;
+    int W = 5; // Best: item 2 (wt 2, val 6) and item 3 (wt 3, val 18) total wt 5, val 24. (Item 4 is wt 5 val 22)
+
+    assert(knapsack(W, wt, val, n) == 24);
+}
+
+void test_knapsack_none_fit()
+{
+    reset_printf_buf();
+    int wt[] = {5, 6, 7};
+    int val[] = {10, 20, 30};
+    int n = 3;
+    int W = 3; // None fit
+
+    assert(knapsack(W, wt, val, n) == 0);
+}
+
+int main()
+{
+    test_knapsack_base_cases();
+    test_knapsack_all_fit();
+    test_knapsack_subset_fit();
+    test_knapsack_none_fit();
+
+    fprintf(stdout, "All Knapsack tests passed successfully!\n");
+    return 0;
+}

--- a/tests/dynamic_programming/test_lcs.c
+++ b/tests/dynamic_programming/test_lcs.c
@@ -1,0 +1,62 @@
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "dynamic_programming.h"
+#include "mock_printf.h"
+
+// Define overrides to suppress history logging and DP table prints
+#define printf mock_printf
+#include "../../src/dynamic_programming/lcs.c"
+#undef printf
+
+void test_lcs_base_cases(void)
+{
+    reset_printf_buf();
+    char* X = "";
+    char* Y = "ABC";
+    assert(lcs(X, Y, 0, 3) == 0);
+    assert(strstr(g_printf_buf, "Traceback: Longest Common Subsequence is \"\"") != NULL);
+
+    reset_printf_buf();
+    assert(lcs(Y, X, 3, 0) == 0);
+    assert(strstr(g_printf_buf, "Traceback: Longest Common Subsequence is \"\"") != NULL);
+}
+
+void test_lcs_normal_case(void)
+{
+    reset_printf_buf();
+    char* X = "ABCDGH";
+    char* Y = "AEDFHR";
+    assert(lcs(X, Y, 6, 6) == 3);
+    assert(strstr(g_printf_buf, "Traceback: Longest Common Subsequence is \"ADH\"") != NULL);
+}
+
+void test_lcs_no_common(void)
+{
+    reset_printf_buf();
+    char* X = "ABC";
+    char* Y = "XYZ";
+    assert(lcs(X, Y, 3, 3) == 0);
+    assert(strstr(g_printf_buf, "Traceback: Longest Common Subsequence is \"\"") != NULL);
+}
+
+void test_lcs_identical(void)
+{
+    reset_printf_buf();
+    char* X = "abcdef";
+    char* Y = "abcdef";
+    assert(lcs(X, Y, 6, 6) == 6);
+    assert(strstr(g_printf_buf, "Traceback: Longest Common Subsequence is \"abcdef\"") != NULL);
+}
+
+int main(void)
+{
+    test_lcs_base_cases();
+    test_lcs_normal_case();
+    test_lcs_no_common();
+    test_lcs_identical();
+
+    fprintf(stdout, "All LCS tests passed successfully!\n");
+    return 0;
+}


### PR DESCRIPTION
### **Description**
This PR adds unit test coverage for the Longest Common Subsequence (LCS) Dynamic Programming algorithm and integrates all new DP tests into the root Makefile:
1. Tests base cases (one or both empty strings).
2. Tests standard matching, identical, and completely distinct string combinations.
3. Suppresses and verifies traceback printing using the `mock_printf` utility.
4. Integrates `test_fibonacci`, `test_knapsack`, and `test_lcs` targets into the root Makefile test suite.
closes #434 