### PR TITLE
fix: memory leak of pq.heap in prism_mst

### DIFF
--- a/src/graph_traversals/prim.c
+++ b/src/graph_traversals/prim.c
@@ -55,6 +55,7 @@ int prim_mst(weightedGraph* graph, int start_node)
     if (!insert_pq_graph(&pq, start_node, 0))
     {
         printf("Malloc failed\n");
+        free_pq_graph(&pq);
         free(key);
         free(parent);
         free(in_mst);
@@ -110,6 +111,7 @@ int prim_mst(weightedGraph* graph, int start_node)
                 if (!insert_pq_graph(&pq, v, key[v]))
                 {
                     printf("Malloc failed\n");
+                    free_pq_graph(&pq);
                     free(key);
                     free(parent);
                     free(in_mst);


### PR DESCRIPTION
Fixes #474 

## Changes

- Added `free_pq_graph(&pq)` before the early return when the initial
  `insert_pq_graph()` call fails.
- Added `free_pq_graph(&pq)` before the early return when
  `insert_pq_graph()` fails while processing adjacent vertices.

This ensures the priority queue is properly released on all early return
paths after initialization.