### PR TITLE
fix: memory leak of pq.heap in astar_solve

### DIFF
--- a/src/graph_traversals/astar.c
+++ b/src/graph_traversals/astar.c
@@ -43,10 +43,9 @@ int astar_solve(weightedGraph* graph, int start, int dest, int h[], int parent[]
     if (!insert_pq_graph(&pq, start, fScore[start]))
     {
         printf("Malloc failed\n");
-        free(visited);
-        free(dist);
-        free(fScore);
-        return -1;
+        result = -1;
+        free_pq_graph(&pq);
+        goto cleanup;
     }
 
     PQ_graph_node popped;
@@ -99,10 +98,10 @@ int astar_solve(weightedGraph* graph, int start, int dest, int h[], int parent[]
                     if (!insert_pq_graph(&pq, v, fScore[v]))
                     {
                         printf("Malloc failed\n");
-                        free(visited);
-                        free(dist);
-                        free(fScore);
-                        return -1;
+                        result = -1;
+                        free_pq_graph(&pq);
+                        goto cleanup;
+                        
                     }
                 }
             }


### PR DESCRIPTION
Fixes #471 

Changes
- Replaced the early return with `result = -1`, `free_pq_graph(&pq)`, and `goto cleanup` when the initial `insert_pq_graph()` call fails.
- Replaced the early return with `result = -1`, `free_pq_graph(&pq)`, and `goto cleanup` when `insert_pq_graph()` fails while processing adjacent vertices.
- This ensures the priority queue is properly released on all allocation failure paths after initialization while preserving the existing cleanup flow.