### PR TITLE
fix(gbfs): free priority queue on malloc failures (fixes #472)

### DIFF
--- a/src/graph_traversals/greedy_best_first_search.c
+++ b/src/graph_traversals/greedy_best_first_search.c
@@ -34,8 +34,9 @@ int greedy_best_first_search_solve(weightedGraph* graph, int start, int dest, in
     if (!insert_pq_graph(&pq, start, h[start]))
     {
         printf("Malloc failed\n");
-        free(visited);
-        return -1;
+        found = -1;
+        free_pq_graph(&pq);
+        goto cleanup;
     }
 
     *traversal_len = 0;
@@ -72,8 +73,9 @@ int greedy_best_first_search_solve(weightedGraph* graph, int start, int dest, in
                 if (!insert_pq_graph(&pq, v, h[v]))
                 {
                     printf("Malloc failed\n");
-                    free(visited);
-                    return -1;
+                    found = -1;
+                    free_pq_graph(&pq);
+                    goto cleanup;
                 }
             }
             current = current->next;


### PR DESCRIPTION
### Summary
This PR fixes a memory leak in the Greedy Best-First Search algorithm (`greedy_best_first_search_solve`) when the priority queue `insert_pq_graph` allocation fails.

Resolves #472

### Changes
- **File:** `src/graph_traversals/greedy_best_first_search.c`
- **Details:** 
  On early returns due to priority queue insertion failures, instead of returning `-1` directly and leaking `pq.heap`, we now set `found = -1`, invoke `free_pq_graph(&pq)` to clean up the queue's heap buffer, and jump to the `cleanup` label to free the locally allocated `visited` array.

### Testing
- Verified compilation is clean under C11 `-Wall -Wextra -Werror`.
- Ran the test suite (`make test`) and verified that all benchmark and algorithm tests pass.