### PR TITLE
fix(dijkstra): free priority queue on malloc failures

### DIFF
--- a/src/graph_traversals/dijkstra.c
+++ b/src/graph_traversals/dijkstra.c
@@ -137,6 +137,7 @@ void dijkstra(weightedGraph* graph, int start)
     if (!insert_pq_graph(&pq, start, 0))
     {
         printf("Malloc failed\n");
+        free_pq_graph(&pq);
         return;
     }
 
@@ -161,6 +162,7 @@ void dijkstra(weightedGraph* graph, int start)
                 if (!insert_pq_graph(&pq, v, dist[v]))
                 {
                     printf("Malloc Failed\n");
+                    free_pq_graph(&pq);
                     return;
                 }
             }


### PR DESCRIPTION
### Summary
This PR fixes a memory leak in the Dijkstra search algorithm (`dijkstra`) when the priority queue `insert_pq_graph` allocation fails.

Resolves #473

### Changes
- **File:** `src/graph_traversals/dijkstra.c`
- **Details:** 
  On early returns due to priority queue insertion failures, instead of returning directly and leaking `pq.heap`, we now invoke `free_pq_graph(&pq)` to clean up the queue's heap buffer.

### Testing
- Verified compilation is clean under C11 `-Wall -Wextra -Werror`.
- Ran the test suite (`make test`) and verified that all benchmark and algorithm tests pass.