### PR TITLE
fix(bplus_tree): prevent inserting garbage value on cancellation (Resolves #475)

### DIFF
--- a/src/trees/bplus_tree.c
+++ b/src/trees/bplus_tree.c
@@ -611,16 +611,22 @@ void bplus_tree_demo(void)
                         break;
                     if (s == 0)
                         continue;
+                    bool cancelled = false;
                     while (1)
                     {
                         int s2 = safe_input_int(
                             &val, "Enter corresponding value (positive integer): ", 1, 10000);
                         if (s2 == INPUT_EXIT_SIGNAL)
+                        {
+                            cancelled = true;
                             break;
+                        }
                         if (s2 == 0)
                             continue;
                         break;
                     }
+                    if (cancelled)
+                        break;
                     if (bplus_tree_insert(tree, key, val))
                         printf("Successfully inserted [%d: %d]\n", key, val);
                     else


### PR DESCRIPTION
### Summary
This PR fixes a bug in the B+ Tree interactive demo menu (`case 1`) where cancelling the value input prompts the program to proceed and insert an uninitialized/garbage value into the B+ Tree.

Resolves #475

### Changes
- **File:** `src/trees/bplus_tree.c`
- **Details:** 
  Introduced a boolean tracking flag `cancelled` inside `case 1`. If the user inputs `-1` (`INPUT_EXIT_SIGNAL`) when prompted for the value corresponding to a key, `cancelled` is set to `true`, the inner loop breaks, and we skip invoking `bplus_tree_insert` completely.

### Testing
- Verified compilation is clean under C11 `-Wall -Wextra -Werror`.
- Tested the interactive input loop logic and verified all unit tests pass successfully.