### PR TITLE
fix(bplus_tree): prevent range query with garbage bound on cancel (Resolves #481)

### DIFF
--- a/src/trees/bplus_tree.c
+++ b/src/trees/bplus_tree.c
@@ -675,15 +675,21 @@ void bplus_tree_demo(void)
                         break;
                     if (s == 0)
                         continue;
+                    bool cancelled = false;
                     while (1)
                     {
                         int s2 = safe_input_int(&upper, "Enter upper bound key: ", lower, 10000);
                         if (s2 == INPUT_EXIT_SIGNAL)
+                        {
+                            cancelled = true;
                             break;
+                        }
                         if (s2 == 0)
                             continue;
                         break;
                     }
+                    if (cancelled)
+                        break;
                     printf("Range query results for [%d, %d]:\n", lower, upper);
                     bplus_tree_range_query(tree, lower, upper);
                     break;


### PR DESCRIPTION
### Summary
This PR fixes a bug in the B+ Tree interactive demo menu (`case 4`) where cancelling the upper bound key input prompts the program to proceed and run the range query with an uninitialized/garbage value.

Resolves #481

### Changes
- **File:** `src/trees/bplus_tree.c`
- **Details:** 
  Introduced a boolean tracking flag `cancelled` inside `case 4`. If the user inputs `-1` (`INPUT_EXIT_SIGNAL`) when prompted for the upper-bound key, `cancelled` is set to `true`, the inner loop breaks, and we skip invoking `bplus_tree_range_query` completely.