### PR TITLE
fix(avl): return to main operations menu on cancellation (Resolves #483)

### DIFF
--- a/src/trees/avl.c
+++ b/src/trees/avl.c
@@ -367,6 +367,7 @@ void avl_demo(void)
             {
                 int delete_value;
                 int delete_status;
+                bool cancelled = false;
                 while (1)
                 {
                     delete_status = safe_input_int(
@@ -375,14 +376,15 @@ void avl_demo(void)
                         100);
                     if (delete_status == INPUT_EXIT_SIGNAL)
                     {
-                        printf("\nExiting AVL tree demo\n");
-                        destroy_avl(root);
-                        return;
+                        cancelled = true;
+                        break;
                     }
                     if (delete_status == 0)
                         continue;
                     break;
                 }
+                if (cancelled)
+                    continue;
                 int status = avl_delete(&root, delete_value);
                 if (status == 0)
                 {


### PR DESCRIPTION
### Summary
This PR fixes AVL Tree interactive demo menu behaviour where cancelling the deletion sub-operation destroys the AVL Tree and exits the demo completely.

Resolves #483

### Changes
- **File:** `src/trees/avl.c`
- **Details:** 
  In the delete operation, if the delete input status is `INPUT_EXIT_SIGNAL` (`-1`), we break the loop and return to the main operations selection menu instead of invoking `destroy_avl(root)` and returning early from the demo.