### PR TITLE
fix(bst): return to main operations menu on cancellation (Resolves #484)

### DIFF
--- a/src/trees/bst.c
+++ b/src/trees/bst.c
@@ -301,6 +301,7 @@ void binary_search_tree_demo(void)
             {
                 int delete_value;
                 int delete_status;
+                bool cancelled = false;
                 while (1)
                 {
                     delete_status = safe_input_int(
@@ -309,13 +310,15 @@ void binary_search_tree_demo(void)
                         100);
                     if (delete_status == INPUT_EXIT_SIGNAL)
                     {
-                        destroy_bst(head);
-                        return;
+                        cancelled = true;
+                        break;
                     }
                     if (delete_status == 0)
                         continue;
                     break;
                 }
+                if (cancelled)
+                    continue;
                 head = bst_delete(head, delete_value);
                 printf("\nnode deleted. updated inorder traversal: ");
                 bst_inorder(head);


### PR DESCRIPTION
### Summary
This PR fixes Binary Search Tree interactive demo menu behaviour where cancelling the deletion sub-operation destroys the BST and exits the demo completely.

Resolves #484

### Changes
- **File:** `src/trees/bst.c`
- **Details:** 
  In the delete operation, if the delete input status is `INPUT_EXIT_SIGNAL` (`-1`), we break the loop and return to the main operations selection menu instead of invoking `destroy_bst(head)` and returning early from the demo.