### PR TITLE
fix(peterson): remove misleading unimplemented print statement 

### DIFF
--- a/src/process_synchronization/petersons_algorithm.c
+++ b/src/process_synchronization/petersons_algorithm.c
@@ -201,10 +201,6 @@ void petersons_algorithm_demo(void)
     {
         clear_screen();
     }
-    printf(
-        "\nPeterson's Algorithm simulation is not implemented yet (Structural baseline active).\n");
-    printf("Press Enter to continue...");
-    getchar();
     int flag[2] = {0, 0};
     int turn = 0;
     int pc[2] = {0, 0};


### PR DESCRIPTION
### Summary
This PR removes a misleading placeholder print statement and blocking `getchar()` wait in Peterson's algorithm demo that falsely claimed the simulation is not implemented.

Resolves #485

### Changes
- **File:** `src/process_synchronization/petersons_algorithm.c`
- **Details:** 
  Removed the print statement asserting the simulation is not implemented, along with the blocking `getchar()` prompt. The actual simulation runs immediately upon launching the demo.