### PR TITLE
fix(expression_evaluation): reject empty expression in postfix evaluator validation (Resolves #506)

### DIFF
--- a/src/expression_evaluation/safe_input_postfix.c
+++ b/src/expression_evaluation/safe_input_postfix.c
@@ -26,6 +26,12 @@ int validate_postfix_expr(char* buff, size_t size, const char* prompt)
 
     buff[strcspn(buff, "\n")] = '\0';
 
+    if (buff[0] == '\0')
+    {
+        printf("\ninvalid: empty expression");
+        return 0;
+    }
+
     if (buff[0] == 'X' && buff[1] == '\0')
     { // when user enters 'X'
         return INPUT_EXIT_SIGNAL;


### PR DESCRIPTION

### Description
In `src/expression_evaluation/safe_input_postfix.c`, if a user enters an empty string or just a newline, the validation loop is skipped entirely. Since the validation depth starts at `0`, the logic bypasses both `depth > 1` and `depth == 1` checks and returns `1` (indicating a valid expression). This PR adds a check to reject empty expressions immediately.

Resolves #506