### PR TITLE
fix(expression_evaluation): prevent silent early returns on postfix evaluation errors (Resolves #507)

### DIFF
--- a/src/expression_evaluation/postfix_evaluation.c
+++ b/src/expression_evaluation/postfix_evaluation.c
@@ -40,6 +40,8 @@ void postfix_evaluation_demo(void)
         int step = 1;
         char action_msg[200];
         int current_result = 0;
+        int error_occurred = 0;
+
         while (postfix_expr[i] != '\0')
         {
             if (!is_instant())
@@ -67,14 +69,16 @@ void postfix_evaluation_demo(void)
             {
                 if (isEmpty(operands))
                 {
-                    destroyStack(operands);
-                    return;
+                    printf("\n[Error] Invalid expression: Stack underflow (missing operands for operator '%c')\n", ch);
+                    error_occurred = 1;
+                    break;
                 }
                 int right_operand = pop(operands);
                 if (isEmpty(operands))
                 {
-                    destroyStack(operands);
-                    return;
+                    printf("\n[Error] Invalid expression: Stack underflow (missing operands for operator '%c')\n", ch);
+                    error_occurred = 1;
+                    break;
                 }
                 int left_operand = pop(operands);
                 int result = 0;
@@ -106,8 +110,9 @@ void postfix_evaluation_demo(void)
                 {
                     if (right_operand == 0)
                     {
-                        destroyStack(operands);
-                        return;
+                        printf("\n[Error] Division by zero encountered.\n");
+                        error_occurred = 1;
+                        break;
                     }
                     result = left_operand / right_operand;
                     snprintf(action_msg, sizeof(action_msg),
@@ -130,6 +135,12 @@ void postfix_evaluation_demo(void)
 
             i++;
             dynamic_sleep();
+        }
+
+        if (error_occurred)
+        {
+            destroyStack(operands);
+            continue;
         }
 
         if (isEmpty(operands))


### PR DESCRIPTION

### Description
Errors during postfix evaluation (such as division by zero or stack underflows) previously caused the evaluator demo to call `destroyStack` and return early. This silently booted the user back to the main menu without any error feedback. This PR adds descriptive prints for these errors and sets an `error_occurred` state variable to break out of the parser loop cleanly and return the user back to the evaluator demo loop instead.

Resolves #507