### PR TITLE
fix(hashing): correct misleading full table warning in linear probing demo (Resolves #509)

### DIFF
--- a/src/hashing/linear_probing.c
+++ b/src/hashing/linear_probing.c
@@ -95,7 +95,7 @@ void linear_probing_demo(void)
                 if (hash_location == start)
                 {
                     array_full = true;
-                    printf("\nhash table full, old table destroyed, new table created\n");
+                    printf("\nhash table full\n");
                     break;
                 }
             } while (arr[hash_location]);


### PR DESCRIPTION
### Description
In `src/hashing/linear_probing.c`, when the hash table becomes full, the demo prints a warning: `hash table full, old table destroyed, new table created`. However, the table is not actually destroyed, and the user is redirected to search the existing table elements. This PR corrects the warning message to simply print `hash table full` to reflect the actual program behavior.

Resolves #509