### PR TITLE
fix(data_structures): adjust minimum capacity for circular queue and align menu options in priority queue (Resolves #510)

### DIFF
--- a/src/data_structures/circular_queue.c
+++ b/src/data_structures/circular_queue.c
@@ -18,9 +18,9 @@ void circular_queue_demo(void)
         int queue_capacity_value;
         int queue_capacity_status =
             safe_input_int(&queue_capacity_value,
-                           "\n\nenter capacity number (N) of circular queue, (between 1 and 100), "
+                           "\n\nenter capacity number (N) of circular queue, (between 2 and 100), "
                            "enter '-1' to exit:- ",
-                           1, 100);
+                           2, 100);
 
         if (queue_capacity_status == INPUT_EXIT_SIGNAL)
         {

--- a/src/data_structures/priority_queue.c
+++ b/src/data_structures/priority_queue.c
@@ -202,7 +202,7 @@ void priority_queue_demo(void)
             int pq_choice_status = safe_input_int(&pq_choice,
                                                   "\nEnter 1 to insert, 2 to remove and extract "
                                                   "top, 3 to peek at top, -1 to exit demo: ",
-                                                  1, 3);
+                                                  -1, 3);
 
             if (pq_choice_status == INPUT_EXIT_SIGNAL)
             {


### PR DESCRIPTION


### Description
1. Circular Queue (`circular_queue.c`): Enforces the minimum capacity input parameter as `2` instead of `1`. Since 1 slot is kept empty to differentiate between full/empty states, a capacity of `1` would make the queue unusable.
2. Priority Queue (`priority_queue.c`): Aligns `safe_input_int` lower boundary limit to `-1` to match the menu prompt `-1 to exit demo`.

Resolves #510