### PR TITLE
fix(backtracking): align menu option input range validation to accept -1 exit code (Resolves #511)

### DIFF
--- a/src/backtracking/graph_coloring.c
+++ b/src/backtracking/graph_coloring.c
@@ -342,7 +342,7 @@ void graph_coloring_demo(void)
         {
             printf("%d. %s (%d vertices)\n", i + 1, topologies[i].name, topologies[i].num_vertices);
         }
-        int status = safe_input_int(&graph_choice, "Select topology (1-6), or -1 to exit: ", 1,
+        int status = safe_input_int(&graph_choice, "Select topology (1-6), or -1 to exit: ", -1,
                                     num_topologies);
 
         if (status == INPUT_EXIT_SIGNAL)
@@ -361,7 +361,7 @@ void graph_coloring_demo(void)
 
         int M;
         status = safe_input_int(
-            &M, "\nEnter the number of colors M (between 1 and 5), or -1 to exit: ", 1, 5);
+            &M, "\nEnter the number of colors M (between 1 and 5), or -1 to exit: ", -1, 5);
         if (status == INPUT_EXIT_SIGNAL)
         {
 #ifdef _WIN32

--- a/src/backtracking/knights_tour.c
+++ b/src/backtracking/knights_tour.c
@@ -175,7 +175,7 @@ void knights_tour_demo(void)
     {
         int N;
         int status =
-            safe_input_int(&N, "\nEnter the board size N (between 4 and 8), or -1 to exit: ", 4, 8);
+            safe_input_int(&N, "\nEnter the board size N (between 4 and 8), or -1 to exit: ", -1, 8);
 
         if (status == INPUT_EXIT_SIGNAL)
         {

--- a/src/backtracking/rat_in_maze.c
+++ b/src/backtracking/rat_in_maze.c
@@ -120,7 +120,7 @@ void rat_in_maze_demo(void)
     {
         int choice;
         int status = safe_input_int(
-            &choice, "\nEnter 1 to solve the predefined 6x6 Rat in a Maze, or -1 to exit: ", 1, 1);
+            &choice, "\nEnter 1 to solve the predefined 6x6 Rat in a Maze, or -1 to exit: ", -1, 1);
 
         if (status == INPUT_EXIT_SIGNAL)
         {

--- a/src/backtracking/sudoku.c
+++ b/src/backtracking/sudoku.c
@@ -146,7 +146,7 @@ void sudoku_demo(void)
         int choice;
         // safe_input_int prevents crashes from ANY invalid value (letters, symbols, out of range)
         int status = safe_input_int(
-            &choice, "\nEnter 1 to solve the predefined 6x6 Sudoku puzzle, or -1 to exit: ", 1, 1);
+            &choice, "\nEnter 1 to solve the predefined 6x6 Sudoku puzzle, or -1 to exit: ", -1, 1);
 
         if (status == INPUT_EXIT_SIGNAL)
         {


### PR DESCRIPTION

### Description
In `sudoku.c`, `rat_in_maze.c`, `knights_tour.c`, and `graph_coloring.c`, the user prompts request entering `-1` to exit the demo menus. However, the validation ranges in the `safe_input_int` calls were using positive numbers as the minimum value bounds. This PR aligns the validator ranges to allow `-1` as the lower bound.

Resolves #511