### PR TITLE
fix(backtracking): align range limit in knights_tour.c menu to accept -1 exit code (Resolves #513)

### DIFF
--- a/src/backtracking/knights_tour.c
+++ b/src/backtracking/knights_tour.c
@@ -175,7 +175,7 @@ void knights_tour_demo(void)
     {
         int N;
         int status =
-            safe_input_int(&N, "\nEnter the board size N (between 4 and 8), or -1 to exit: ", 4, 8);
+            safe_input_int(&N, "\nEnter the board size N (between 4 and 8), or -1 to exit: ", -1, 8);
 
         if (status == INPUT_EXIT_SIGNAL)
         {


### PR DESCRIPTION

### Description
In `src/backtracking/knights_tour.c`, the user is prompted to enter a board size `N` between 4 and 8, or `"-1 to exit"`. Because the validation range was defined as `[4, 8]`, typing `-1` was marked as invalid. This PR updates the validation limit to allow `-1` as the lower boundary.

Resolves #513