### PR TITLE
fix(backtracking): align range limits in graph_coloring.c menus to accept -1 exit code (Resolves #514, Resolves #515)

### DIFF
--- a/src/backtracking/graph_coloring.c
+++ b/src/backtracking/graph_coloring.c
@@ -342,7 +342,7 @@ void graph_coloring_demo(void)
         {
             printf("%d. %s (%d vertices)\n", i + 1, topologies[i].name, topologies[i].num_vertices);
         }
-        int status = safe_input_int(&graph_choice, "Select topology (1-6), or -1 to exit: ", 1,
+        int status = safe_input_int(&graph_choice, "Select topology (1-6), or -1 to exit: ", -1,
                                     num_topologies);
 
         if (status == INPUT_EXIT_SIGNAL)
@@ -361,7 +361,7 @@ void graph_coloring_demo(void)
 
         int M;
         status = safe_input_int(
-            &M, "\nEnter the number of colors M (between 1 and 5), or -1 to exit: ", 1, 5);
+            &M, "\nEnter the number of colors M (between 1 and 5), or -1 to exit: ", -1, 5);
         if (status == INPUT_EXIT_SIGNAL)
         {
 #ifdef _WIN32


### PR DESCRIPTION

### Description
In `src/backtracking/graph_coloring.c`, both the topology selection menu and the color count selection menu ask the user to enter `"-1 to exit"`. However, the range boundary limits in the `safe_input_int` calls were set to `1` as the minimum bound. This PR aligns the validation ranges to allow `-1` as the lower boundary.

Resolves #514
Resolves #515