### PR TITLE
refactor: centralize Priority Queue lifecycle in graph solvers to prevent memory leaks

### DIFF
--- a/src/graph_traversals/astar.c
+++ b/src/graph_traversals/astar.c
@@ -14,6 +14,7 @@ int astar_solve(weightedGraph* graph, int start, int dest, int h[], int parent[]
     int* dist = malloc(size * sizeof(int));
     int* fScore = malloc(size * sizeof(int));
     int result = INT_MAX;
+    PQ_graph pq = {0};
 
     if (!visited || !dist || !fScore)
         goto cleanup;
@@ -31,11 +32,13 @@ int astar_solve(weightedGraph* graph, int start, int dest, int h[], int parent[]
     // Reuse the shared graph priority queue: a min-heap keyed on the node's
     // "distance" field, which here carries the f-score (f = g + h). Duplicate
     // entries are handled lazily via the visited[] check on pop.
-    PQ_graph pq;
     init_pq_graph(&pq, 10);
 
     if (!pq.heap)
+    {
+        result = -1;
         goto cleanup;
+    }
 
     dist[start] = 0;
     fScore[start] = h[start];
@@ -44,7 +47,6 @@ int astar_solve(weightedGraph* graph, int start, int dest, int h[], int parent[]
     {
         printf("Malloc failed\n");
         result = -1;
-        free_pq_graph(&pq);
         goto cleanup;
     }
 
@@ -99,9 +101,7 @@ int astar_solve(weightedGraph* graph, int start, int dest, int h[], int parent[]
                     {
                         printf("Malloc failed\n");
                         result = -1;
-                        free_pq_graph(&pq);
                         goto cleanup;
-                        
                     }
                 }
             }
@@ -109,9 +109,8 @@ int astar_solve(weightedGraph* graph, int start, int dest, int h[], int parent[]
         }
     }
 
-    free_pq_graph(&pq);
-
 cleanup:
+    PQ_Destroy(&pq);
     free(visited);
     free(dist);
     free(fScore);

--- a/src/graph_traversals/dijkstra.c
+++ b/src/graph_traversals/dijkstra.c
@@ -27,14 +27,22 @@ void init_pq_graph(PQ_graph* pq, int initial_capacity)
     pq->heap = malloc(pq->capacity * sizeof(PQ_graph_node));
 }
 
-void free_pq_graph(PQ_graph* pq)
+void PQ_Destroy(PQ_graph* pq)
 {
     if (pq == NULL)
         return;
-    free(pq->heap);
-    pq->heap = NULL;
+    if (pq->heap != NULL)
+    {
+        free(pq->heap);
+        pq->heap = NULL;
+    }
     pq->size = 0;
     pq->capacity = 0;
+}
+
+void free_pq_graph(PQ_graph* pq)
+{
+    PQ_Destroy(pq);
 }
 
 int insert_pq_graph(PQ_graph* pq, int vertex, int distance)
@@ -126,19 +134,18 @@ void dijkstra(weightedGraph* graph, int start)
 
     dist[start] = 0;
 
-    PQ_graph pq;
+    PQ_graph pq = {0};
     init_pq_graph(&pq, 10);
 
     clock_t start_t, end_t;
-    double total_t;
+    double total_t = 0.0;
 
     start_t = clock();
 
     if (!insert_pq_graph(&pq, start, 0))
     {
         printf("Malloc failed\n");
-        free_pq_graph(&pq);
-        return;
+        goto cleanup;
     }
 
     PQ_graph_node currentNode;
@@ -162,8 +169,7 @@ void dijkstra(weightedGraph* graph, int start)
                 if (!insert_pq_graph(&pq, v, dist[v]))
                 {
                     printf("Malloc Failed\n");
-                    free_pq_graph(&pq);
-                    return;
+                    goto cleanup;
                 }
             }
 
@@ -173,8 +179,6 @@ void dijkstra(weightedGraph* graph, int start)
 
     end_t = clock();
     total_t = (double)(end_t - start_t) / CLOCKS_PER_SEC;
-
-    free_pq_graph(&pq);
 
     printf("Start -> Vertex  \t  Distance\n");
     printf("---------------  \t  --------\n");
@@ -189,6 +193,9 @@ void dijkstra(weightedGraph* graph, int start)
 
     printf("\ntotal CPU time taken for Dijkstra's algorithm:- %f seconds\n", total_t);
     add_to_history("Dijkstra", size, total_t);
+
+cleanup:
+    PQ_Destroy(&pq);
 }
 
 weightedGraph* create_weightedGraph(int V)

--- a/src/graph_traversals/graph_traversals.h
+++ b/src/graph_traversals/graph_traversals.h
@@ -49,6 +49,7 @@ typedef struct
 
 void init_pq_graph(PQ_graph* pq, int initial_capacity);
 void free_pq_graph(PQ_graph* pq);
+void PQ_Destroy(PQ_graph* pq);
 int insert_pq_graph(PQ_graph* pq, int vertex, int distance);
 bool extractTop_pq_graph(PQ_graph* pq, PQ_graph_node* result);
 

--- a/src/graph_traversals/greedy_best_first_search.c
+++ b/src/graph_traversals/greedy_best_first_search.c
@@ -13,6 +13,7 @@ int greedy_best_first_search_solve(weightedGraph* graph, int start, int dest, in
     int size = graph->V;
     int* visited = calloc(size, sizeof(int));
     int found = 0;
+    PQ_graph pq = {0};
 
     if (!visited)
         goto cleanup;
@@ -25,17 +26,18 @@ int greedy_best_first_search_solve(weightedGraph* graph, int start, int dest, in
     // Reuse the shared graph priority queue: a min-heap keyed on the node's
     // "distance" field, which here carries the heuristic h. Duplicate entries
     // are handled lazily via the visited[] check on pop.
-    PQ_graph pq;
     init_pq_graph(&pq, 10);
 
     if (!pq.heap)
+    {
+        found = -1;
         goto cleanup;
+    }
 
     if (!insert_pq_graph(&pq, start, h[start]))
     {
         printf("Malloc failed\n");
         found = -1;
-        free_pq_graph(&pq);
         goto cleanup;
     }
 
@@ -74,7 +76,6 @@ int greedy_best_first_search_solve(weightedGraph* graph, int start, int dest, in
                 {
                     printf("Malloc failed\n");
                     found = -1;
-                    free_pq_graph(&pq);
                     goto cleanup;
                 }
             }
@@ -82,9 +83,8 @@ int greedy_best_first_search_solve(weightedGraph* graph, int start, int dest, in
         }
     }
 
-    free_pq_graph(&pq);
-
 cleanup:
+    PQ_Destroy(&pq);
     free(visited);
     return found;
 }

--- a/src/graph_traversals/prim.c
+++ b/src/graph_traversals/prim.c
@@ -25,13 +25,12 @@ int prim_mst(weightedGraph* graph, int start_node)
     int* key = (int*)malloc(V * sizeof(int));
     int* parent = (int*)malloc(V * sizeof(int));
     bool* in_mst = (bool*)malloc(V * sizeof(bool));
+    PQ_graph pq = {0};
+    int mst_weight = -1;
 
     if (!key || !parent || !in_mst)
     {
-        free(key);
-        free(parent);
-        free(in_mst);
-        return -1;
+        goto cleanup;
     }
 
     for (int i = 0; i < V; i++)
@@ -41,28 +40,20 @@ int prim_mst(weightedGraph* graph, int start_node)
         in_mst[i] = false;
     }
 
-    PQ_graph pq;
     init_pq_graph(&pq, V);
     if (!pq.heap)
     {
-        free(key);
-        free(parent);
-        free(in_mst);
-        return -1;
+        goto cleanup;
     }
 
     key[start_node] = 0;
     if (!insert_pq_graph(&pq, start_node, 0))
     {
         printf("Malloc failed\n");
-        free_pq_graph(&pq);
-        free(key);
-        free(parent);
-        free(in_mst);
-        return -1;
+        goto cleanup;
     }
 
-    int mst_weight = 0;
+    mst_weight = 0;
     int nodes_in_mst = 0;
 
     clock_t start_t, end_t;
@@ -111,11 +102,8 @@ int prim_mst(weightedGraph* graph, int start_node)
                 if (!insert_pq_graph(&pq, v, key[v]))
                 {
                     printf("Malloc failed\n");
-                    free_pq_graph(&pq);
-                    free(key);
-                    free(parent);
-                    free(in_mst);
-                    return -1;
+                    mst_weight = -1;
+                    goto cleanup;
                 }
             }
             curr = curr->next;
@@ -135,7 +123,8 @@ int prim_mst(weightedGraph* graph, int start_node)
 
     add_to_history("Prim's MST", V, total_t);
 
-    free_pq_graph(&pq);
+cleanup:
+    PQ_Destroy(&pq);
     free(key);
     free(parent);
     free(in_mst);


### PR DESCRIPTION
### Description
Resolves memory leaks associated with `PQ_graph` dynamic allocations in graph traversal algorithms (A*, Dijkstra, Prim's, Greedy BFS) when allocation failures occur.

### Changes
- **PQ Lifecycle Management:** Implemented `PQ_Destroy()` in `dijkstra.c` (declared in `graph_traversals.h`) to handle deallocation of the internal priority queue heap array.
- **Unified Cleanup Blocks:** Refactored graph solvers to zero-initialize the Priority Queue stack variable and route all returns through a unified `cleanup` block executing `PQ_Destroy()`.

### Closes #488 