### PR TITLE
fix(process-sync): keep the legacy menu header from being wiped by the demo

### DIFF
--- a/src/process_synchronization/process_synchronization_demo.c
+++ b/src/process_synchronization/process_synchronization_demo.c
@@ -1,5 +1,3 @@
-#include "../utils/config.h"
-#include "clear_screen.h"
 #include "process_synchronization.h"
 #include "safe_input.h"
 #include <stdio.h>
@@ -8,10 +6,6 @@ void process_synchronization_demo(void)
 {
     while (1)
     {
-        if (!is_instant())
-        {
-            clear_screen();
-        }
         int choice;
         int status = safe_input_int(&choice,
                                     "\n\n--- Process Synchronization Demos ---\n"


### PR DESCRIPTION
Closes #529

## Problem

In the legacy menu, every module case in `run_legacy_menu()` calls `display_header("...")` before running the demo, so each module starts on a clean screen with the cyan bordered banner. This worked for every module except **Process Synchronization**, where only the plain `--- Process Synchronization Demos ---` sub-menu showed up with no banner.

`process_synchronization_demo()` was the only demo that called `clear_screen()` itself at the top of its loop, so it wiped the `=== Process Synchronization ===` banner that the caller had just printed.

## Fix

Removed the in-demo `clear_screen()` and its `is_instant()` guard so the demo no longer clears the screen out from under the caller — matching the behaviour of every other module demo. The now-unused `clear_screen.h` and `config.h` includes were dropped as well.

## Verification

- `make` builds clean.
- Driving the legacy menu to Process Synchronization now shows the cyan `=== Process Synchronization ===` banner directly above the sub-menu, consistent with all other modules.
