### PR TITLE
feat(expression-eval): clear screen and show a header before each sub-demo (#531)

### DIFF
--- a/src/expression_evaluation/expression_evaluation_demo.c
+++ b/src/expression_evaluation/expression_evaluation_demo.c
@@ -1,3 +1,4 @@
+#include "display_header.h"
 #include "expression.h"
 #include "safe_input.h"
 #include <stdio.h>
@@ -27,21 +28,25 @@ void expression_evaluation_demo(void)
 
         if (expr_eval_choice == 1)
         {
+            display_header("Infix to Postfix");
             infix_to_postfix_demo();
             continue;
         }
         else if (expr_eval_choice == 2)
         {
+            display_header("Postfix Evaluation");
             postfix_evaluation_demo();
             continue;
         }
         else if (expr_eval_choice == 3)
         {
+            display_header("Parentheses Checker");
             parantheses_checker_demo();
             continue;
         }
         else if (expr_eval_choice == 4)
         {
+            display_header("Infix to Prefix");
             infix_to_prefix_demo();
             continue;
         }


### PR DESCRIPTION
Closes #531

## Context

Continuing the screen-clear + header standardization from the module level (TUI #414, legacy menu #450) one level deeper — into the demo files, so each individual sub-demo starts on a clean screen with its own header, exactly like the legacy menu does before each module dispatch.

This PR covers the **Expression Evaluation** module.

## Change

In `expression_evaluation_demo.c`, added `display_header("<Sub-demo name>")` before each sub-demo dispatch:

- `display_header("Infix to Postfix")` → `infix_to_postfix_demo()`
- `display_header("Postfix Evaluation")` → `postfix_evaluation_demo()`
- `display_header("Parentheses Checker")` → `parantheses_checker_demo()`
- `display_header("Infix to Prefix")` → `infix_to_prefix_demo()`

Added the `display_header.h` include (`src/utils` is already on the compile include path).

## Verification

- `make` builds clean.
- Driving the legacy menu into each Expression Evaluation sub-demo shows the cyan header on a cleared screen before the sub-demo runs.
