### PR TITLE
feat(advanced-sorting): clear screen and show a header before each sub-demo

### DIFF
--- a/src/advanced_sorting_algorithms/advanced_sorting_demo.c
+++ b/src/advanced_sorting_algorithms/advanced_sorting_demo.c
@@ -1,4 +1,5 @@
 #include "advanced_sorting.h"
+#include "display_header.h"
 #include "safe_input.h"
 #include <stdio.h>
 
@@ -30,26 +31,31 @@ void advanced_sorting_demo(void)
 
         if (sorting_algo_choice == 1)
         {
+            display_header("Quick Sort");
             quicksort_demo();
         }
 
         else if (sorting_algo_choice == 2)
         {
+            display_header("Merge Sort");
             merge_sort_demo();
         }
 
         else if (sorting_algo_choice == 3)
         {
+            display_header("Heap Sort");
             heap_sort_demo();
         }
 
         else if (sorting_algo_choice == 4)
         {
+            display_header("Radix Sort");
             radix_sort_demo();
         }
 
         else if (sorting_algo_choice == 5)
         {
+            display_header("Bucket Sort");
             bucket_sort_demo();
         }
     }


### PR DESCRIPTION
Closes #533

## Context

Continuing the screen-clear + header standardization from the module level (TUI #414, legacy menu #450) one level deeper — into the demo files, so each individual sub-demo starts on a clean screen with its own header, exactly like the legacy menu does before each module dispatch.

This PR covers the **Advanced Sorting** module.

## Change

In `advanced_sorting_demo.c`, added `display_header("<Sub-demo name>")` before each sub-demo dispatch: Quick Sort, Merge Sort, Heap Sort, Radix Sort, Bucket Sort. Added the `display_header.h` include (`src/utils` is already on the compile include path).

## Verification

- `make` builds clean.
- Driving the legacy menu into each Advanced Sorting sub-demo shows the cyan header (ANSI colours) on a cleared screen before the sub-demo runs.
