### PR TITLE
feat(backtracking): clear screen and show a header before each sub-demo

### DIFF
--- a/src/backtracking/backtracking_demo.c
+++ b/src/backtracking/backtracking_demo.c
@@ -1,4 +1,5 @@
 #include "backtracking.h"
+#include "display_header.h"
 #include "safe_input.h"
 #include <stdio.h>
 
@@ -29,18 +30,23 @@ void backtracking_demo(void)
         switch (bt_choice)
         {
             case 1:
+                display_header("N-Queens Problem");
                 n_queens_demo();
                 break;
             case 2:
+                display_header("Sudoku Solver");
                 sudoku_demo();
                 break;
             case 3:
+                display_header("Rat in a Maze");
                 rat_in_maze_demo();
                 break;
             case 4:
+                display_header("Graph Coloring");
                 graph_coloring_demo();
                 break;
             case 5:
+                display_header("Knight's Tour");
                 knights_tour_demo();
                 break;
         }


### PR DESCRIPTION
Closes #535

## Context

Continuing the screen-clear + header standardization from the module level (TUI #414, legacy menu #450) one level deeper — into the demo files, so each individual sub-demo starts on a clean screen with its own header, exactly like the legacy menu does before each module dispatch.

This PR covers the **Backtracking** module.

## Change

In `backtracking_demo.c`, added `display_header("<Sub-demo name>")` before each sub-demo dispatch: N-Queens Problem, Sudoku Solver, Rat in a Maze, Graph Coloring, Knight's Tour. Added the `display_header.h` include (`src/utils` is already on the compile include path).

## Verification

- `make` builds clean.
- Driving the legacy menu into each Backtracking sub-demo shows the cyan header (ANSI colours) on a cleared screen before the sub-demo runs.
