### PR TITLE
feat(dynamic-programming): clear screen and show a header before each sub-demo

### DIFF
--- a/src/dynamic_programming/dynamic_programming_demo.c
+++ b/src/dynamic_programming/dynamic_programming_demo.c
@@ -1,3 +1,4 @@
+#include "display_header.h"
 #include "dynamic_programming.h"
 #include "safe_input.h"
 #include <stdio.h>
@@ -27,15 +28,19 @@ void dynamic_programming_demo(void)
         switch (dp_choice)
         {
             case 1:
+                display_header("0/1 Knapsack");
                 knapsack_demo();
                 break;
             case 2:
+                display_header("Longest Common Subsequence");
                 lcs_demo();
                 break;
             case 3:
+                display_header("Fibonacci Sequence");
                 fibonacci_demo();
                 break;
             case 4:
+                display_header("Matrix Chain Multiplication");
                 mcm_demo();
                 break;
         }


### PR DESCRIPTION
Closes #537

## Context

Continuing the screen-clear + header standardization from the module level (TUI #414, legacy menu #450) one level deeper — into the demo files, so each individual sub-demo starts on a clean screen with its own header, exactly like the legacy menu does before each module dispatch.

This PR covers the **Dynamic Programming** module.

## Change

In `dynamic_programming_demo.c`, added `display_header("<Sub-demo name>")` before each sub-demo dispatch: 0/1 Knapsack, Longest Common Subsequence, Fibonacci Sequence, Matrix Chain Multiplication. Added the `display_header.h` include (`src/utils` is already on the compile include path).

## Verification

- `make` builds clean.
- Driving the legacy menu into each Dynamic Programming sub-demo shows the cyan header (ANSI colours) on a cleared screen before the sub-demo runs.
