### PR TITLE
feat(graph-traversals): clear screen and show a header before each sub-demo

### DIFF
--- a/src/graph_traversals/graph_traversals_demo.c
+++ b/src/graph_traversals/graph_traversals_demo.c
@@ -1,3 +1,4 @@
+#include "display_header.h"
 #include "graph_traversals.h"
 #include "safe_input.h"
 #include <stdio.h>
@@ -39,36 +40,47 @@ void graph_traversals_demo(void)
         switch (graph_traversal_choice)
         {
             case 1:
+                display_header("BFS");
                 bfs_demo();
                 break;
             case 2:
+                display_header("DFS");
                 dfs_demo();
                 break;
             case 3:
+                display_header("Dijkstra");
                 dijkstra_demo();
                 break;
             case 4:
+                display_header("A*");
                 astar_demo();
                 break;
             case 5:
+                display_header("Greedy Best-First Search");
                 greedy_best_first_search_demo();
                 break;
             case 6:
+                display_header("Bellman-Ford");
                 bellman_ford_demo();
                 break;
             case 7:
+                display_header("Topological Sort");
                 topological_sort_demo();
                 break;
             case 8:
+                display_header("Visualize Graph");
                 visualize_graph_demo();
                 break;
             case 9:
+                display_header("Kruskal MST");
                 kruskal_demo();
                 break;
             case 10:
+                display_header("Prim MST");
                 prim_demo();
                 break;
             case 11:
+                display_header("Floyd-Warshall");
                 floyd_warshall_demo();
                 break;
         }


### PR DESCRIPTION
Closes #541

## Context

Continuing the screen-clear + header standardization from the module level (TUI #414, legacy menu #450) one level deeper — into the demo files, so each individual sub-demo starts on a clean screen with its own header, exactly like the legacy menu does before each module dispatch.

This PR covers the **Graph Traversals** module.

## Change

In `graph_traversals_demo.c`, added `display_header("<Sub-demo name>")` before each sub-demo dispatch: BFS, DFS, Dijkstra, A*, Greedy Best-First Search, Bellman-Ford, Topological Sort, Visualize Graph, Kruskal MST, Prim MST, Floyd-Warshall. Added the `display_header.h` include (`src/utils` is already on the compile include path).

## Verification

- `make` builds clean.
- Driving the legacy menu into each Graph Traversals sub-demo shows the cyan header (ANSI colours) on a cleared screen before the sub-demo runs.
