### PR TITLE
feat(hashing): clear screen and show a header before each sub-demo

### DIFF
--- a/src/hashing/hashing_algorithms_demo.c
+++ b/src/hashing/hashing_algorithms_demo.c
@@ -1,3 +1,4 @@
+#include "display_header.h"
 #include "hash.h"
 #include "safe_input.h"
 #include <stdio.h>
@@ -26,18 +27,22 @@ void hashing_algorithms_demo(void)
         switch (hash_algo_choice)
         {
             case 1:
+                display_header("Linear Probing");
                 linear_probing_demo();
                 break;
 
             case 2:
+                display_header("Separate Chaining");
                 separate_chaining_demo();
                 break;
 
             case 3:
+                display_header("Quadratic Probing");
                 quadratic_probing_demo();
                 break;
 
             case 4:
+                display_header("Double Hashing");
                 double_hashing_demo();
                 break;
         }


### PR DESCRIPTION
Closes #543

## Context

Continuing the screen-clear + header standardization from the module level (TUI #414, legacy menu #450) one level deeper — into the demo files, so each individual sub-demo starts on a clean screen with its own header, exactly like the legacy menu does before each module dispatch.

This PR covers the **Hashing Algorithms** module.

## Change

In `hashing_algorithms_demo.c`, added `display_header("<Sub-demo name>")` before each sub-demo dispatch: Linear Probing, Separate Chaining, Quadratic Probing, Double Hashing. Added the `display_header.h` include (`src/utils` is already on the compile include path).

## Verification

- `make` builds clean.
- Driving the legacy menu into each Hashing sub-demo shows the cyan header (ANSI colours) on a cleared screen before the sub-demo runs.
