### PR TITLE
feat(job-scheduling): clear screen and show a header before each sub-demo

### DIFF
--- a/src/job_scheduling/job_scheduling_demo.c
+++ b/src/job_scheduling/job_scheduling_demo.c
@@ -1,3 +1,4 @@
+#include "display_header.h"
 #include "job_scheduling.h"
 #include "safe_input.h"
 #include <stdio.h>
@@ -193,26 +194,32 @@ void job_scheduling_demo(void)
         switch (sched_choice)
         {
             case 1:
+                display_header("FCFS");
                 fcfs_demo();
                 break;
 
             case 2:
+                display_header("SJF (Non-Preemptive)");
                 sjf_demo();
                 break;
 
             case 3:
+                display_header("SRTF (Preemptive SJF)");
                 srtf_demo();
                 break;
 
             case 4:
+                display_header("Priority (Non-Preemptive)");
                 priority_scheduling_demo();
                 break;
 
             case 5:
+                display_header("Priority (Preemptive)");
                 preemptive_priority_demo();
                 break;
 
             case 6:
+                display_header("Round Robin");
                 round_robin_demo();
                 break;
         }


### PR DESCRIPTION
Closes #545

## Context

Continuing the screen-clear + header standardization from the module level (TUI #414, legacy menu #450) one level deeper — into the demo files, so each individual sub-demo starts on a clean screen with its own header, exactly like the legacy menu does before each module dispatch.

This PR covers the **Job Scheduling** module.

## Change

In `job_scheduling_demo.c`, added `display_header("<Sub-demo name>")` before each sub-demo dispatch: FCFS, SJF (Non-Preemptive), SRTF (Preemptive SJF), Priority (Non-Preemptive), Priority (Preemptive), Round Robin. Added the `display_header.h` include (`src/utils` is already on the compile include path).

## Verification

- `make` builds clean.
- Driving the legacy menu into each Job Scheduling sub-demo shows the cyan header (ANSI colours) on a cleared screen before the sub-demo runs.
