### PR TITLE
feat(searching): clear screen and show a header before each sub-demo

### DIFF
--- a/src/searching_algorithms/searching_algorithms_demo.c
+++ b/src/searching_algorithms/searching_algorithms_demo.c
@@ -1,3 +1,4 @@
+#include "display_header.h"
 #include "safe_input.h"
 #include "searching_algorithms.h"
 #include <stdio.h>
@@ -28,18 +29,23 @@ void searching_algorithms_demo(void)
         switch (searching_algo_choice)
         {
             case 1:
+                display_header("Linear Search");
                 linear_search_demo();
                 break;
             case 2:
+                display_header("Binary Search");
                 binary_search_demo();
                 break;
             case 3:
+                display_header("Recursive Binary Search");
                 binary_search_recursive_demo();
                 break;
             case 4:
+                display_header("Interpolation Search");
                 interpolation_search_demo();
                 break;
             case 5:
+                display_header("Jump Search");
                 jump_search_demo();
                 break;
         }


### PR DESCRIPTION
Closes #547

## Context

Continuing the screen-clear + header standardization from the module level (TUI #414, legacy menu #450) one level deeper — into the demo files, so each individual sub-demo starts on a clean screen with its own header, exactly like the legacy menu does before each module dispatch.

This PR covers the **Searching Algorithms** module.

## Change

In `searching_algorithms_demo.c`, added `display_header("<Sub-demo name>")` before each sub-demo dispatch: Linear Search, Binary Search, Recursive Binary Search, Interpolation Search, Jump Search. Added the `display_header.h` include (`src/utils` is already on the compile include path).

## Verification

- `make` builds clean.
- Driving the legacy menu into each Searching sub-demo shows the cyan header (ANSI colours) on a cleared screen before the sub-demo runs.
