### PR TITLE
feat(sorting-n2): clear screen and show a header before each sub-demo

### DIFF
--- a/src/sorting_algorithms_n2/sorting_algorithms_n2_demo.c
+++ b/src/sorting_algorithms_n2/sorting_algorithms_n2_demo.c
@@ -1,3 +1,4 @@
+#include "display_header.h"
 #include "safe_input.h"
 #include "sorting_algorithms_n2.h"
 #include <stdio.h>
@@ -27,15 +28,19 @@ void sorting_algorithms_n2_demo(void)
         switch (sorting_algo_choice)
         {
             case 1:
+                display_header("Bubble Sort");
                 bubble_sort_optimized_demo();
                 break;
             case 2:
+                display_header("Insertion Sort");
                 insertion_sort_demo();
                 break;
             case 3:
+                display_header("Selection Sort");
                 selection_sort_demo();
                 break;
             case 4:
+                display_header("Shell Sort");
                 shell_sort_demo();
                 break;
         }


### PR DESCRIPTION
Closes #549

## Context

Continuing the screen-clear + header standardization from the module level (TUI #414, legacy menu #450) one level deeper — into the demo files, so each individual sub-demo starts on a clean screen with its own header, exactly like the legacy menu does before each module dispatch.

This PR covers the **Sorting Algorithms (n^2)** module.

## Change

In `sorting_algorithms_n2_demo.c`, added `display_header("<Sub-demo name>")` before each sub-demo dispatch: Bubble Sort, Insertion Sort, Selection Sort, Shell Sort. Added the `display_header.h` include (`src/utils` is already on the compile include path).

## Verification

- `make` builds clean.
- Driving the legacy menu into each Sorting (n^2) sub-demo shows the cyan header (ANSI colours) on a cleared screen before the sub-demo runs.
