### PR TITLE
feat(string-algos): clear screen and show a header before each sub-demo

### DIFF
--- a/src/string_algorithms/string_algorithms_demo.c
+++ b/src/string_algorithms/string_algorithms_demo.c
@@ -1,3 +1,4 @@
+#include "display_header.h"
 #include "safe_input.h"
 #include "string_algorithms.h"
 #include <stdio.h>
@@ -26,12 +27,15 @@ void string_algorithms_demo(void)
         switch (choice)
         {
             case 1:
+                display_header("Naive String Matching");
                 naive_string_matching_demo();
                 break;
             case 2:
+                display_header("Knuth-Morris-Pratt (KMP)");
                 kmp_demo();
                 break;
             case 3:
+                display_header("Rabin-Karp");
                 rabin_karp_demo();
                 break;
         }


### PR DESCRIPTION
Closes #551

## Context

Continuing the screen-clear + header standardization from the module level (TUI #414, legacy menu #450) one level deeper — into the demo files, so each individual sub-demo starts on a clean screen with its own header, exactly like the legacy menu does before each module dispatch.

This PR covers the **String Algorithms** module.

## Change

In `string_algorithms_demo.c`, added `display_header("<Sub-demo name>")` before each sub-demo dispatch: Naive String Matching, Knuth-Morris-Pratt (KMP), Rabin-Karp. Added the `display_header.h` include (`src/utils` is already on the compile include path).

## Verification

- `make` builds clean.
- Driving the legacy menu into each String Algorithms sub-demo shows the cyan header (ANSI colours) on a cleared screen before the sub-demo runs.
