### PR TITLE
feat(trees): clear screen and show a header before each sub-demo

### DIFF
--- a/src/trees/trees_demo.c
+++ b/src/trees/trees_demo.c
@@ -1,3 +1,4 @@
+#include "display_header.h"
 #include "safe_input.h"
 #include "trees.h"
 #include <stdio.h>
@@ -30,26 +31,32 @@ void trees_demo(void)
         switch (tree_choice)
         {
             case 1:
+                display_header("Binary Search Tree");
                 binary_search_tree_demo();
                 break;
 
             case 2:
+                display_header("AVL Tree");
                 avl_demo();
                 break;
 
             case 3:
+                display_header("Threaded Binary Tree");
                 TBT_demo();
                 break;
 
             case 4:
+                display_header("Trie");
                 trie_demo();
                 break;
 
             case 5:
+                display_header("B-Tree");
                 btree_demo();
                 break;
 
             case 6:
+                display_header("B+ Tree");
                 bplus_tree_demo();
                 break;
         }


### PR DESCRIPTION
Closes #553

## Context

Continuing the screen-clear + header standardization from the module level (TUI #414, legacy menu #450) one level deeper — into the demo files, so each individual sub-demo starts on a clean screen with its own header, exactly like the legacy menu does before each module dispatch.

This PR covers the **Trees** module.

## Change

In `trees_demo.c`, added `display_header("<Sub-demo name>")` before each sub-demo dispatch: Binary Search Tree, AVL Tree, Threaded Binary Tree, Trie, B-Tree, B+ Tree. Added the `display_header.h` include (`src/utils` is already on the compile include path).

## Verification

- `make` builds clean.
- Driving the legacy menu into each Trees sub-demo shows the cyan header (ANSI colours) on a cleared screen before the sub-demo runs.
