### PR TITLE
feat(data-structures): clear screen and show a header before each sub-demo

### DIFF
--- a/src/data_structures/data_structures_demo.c
+++ b/src/data_structures/data_structures_demo.c
@@ -1,4 +1,5 @@
 #include "data_structures.h"
+#include "display_header.h"
 #include "safe_input.h"
 #include <stdio.h>
 
@@ -51,26 +52,31 @@ void data_structures_demo(void)
 
                     if (linear_ds_choice == 1)
                     {
+                        display_header("Singly Linked List");
                         sll_demo();
                         continue;
                     }
                     if (linear_ds_choice == 2)
                     {
+                        display_header("Doubly Linked List");
                         dll_demo();
                         continue;
                     }
                     if (linear_ds_choice == 3)
                     {
+                        display_header("Arrays");
                         array_demo();
                         continue;
                     }
                     if (linear_ds_choice == 4)
                     {
+                        display_header("Priority Queue");
                         priority_queue_demo();
                         continue;
                     }
                     if (linear_ds_choice == 5)
                     {
+                        display_header("Simple Queue");
                         simple_queue_demo();
                         continue;
                     }
@@ -96,18 +102,22 @@ void data_structures_demo(void)
                         break;
                     if (circular_variant_choice == 1)
                     {
+                        display_header("Circular Queue");
                         circular_queue_demo();
                     }
                     if (circular_variant_choice == 2)
                     {
+                        display_header("Singly Circular Linked List");
                         scll_demo();
                     }
                     if (circular_variant_choice == 3)
                     {
+                        display_header("Doubly Circular Linked List");
                         dcll_demo();
                     }
                     if (circular_variant_choice == 4)
                     {
+                        display_header("Double-Ended Queue (Deque)");
                         deque_demo();
                     }
                 }
@@ -115,6 +125,7 @@ void data_structures_demo(void)
                 break;
 
             case 3:
+                display_header("Segment Tree");
                 segment_tree_demo();
                 break;
         }


### PR DESCRIPTION
Closes #555

## Context

Continuing the screen-clear + header standardization from the module level (TUI #414, legacy menu #450) one level deeper — into the demo files, so each individual sub-demo starts on a clean screen with its own header, exactly like the legacy menu does before each module dispatch.

This PR covers the **Data Structures** module. It has nested sub-menus (linear / circular variants / segment tree), so the header is placed before each leaf demo.

## Change

In `data_structures_demo.c`, added `display_header("<Sub-demo name>")` before each leaf sub-demo dispatch: Singly Linked List, Doubly Linked List, Arrays, Priority Queue, Simple Queue, Circular Queue, Singly Circular Linked List, Doubly Circular Linked List, Double-Ended Queue (Deque), Segment Tree. Added the `display_header.h` include (`src/utils` is already on the compile include path).

## Verification

- `make` builds clean.
- Driving the legacy menu into each Data Structures sub-demo shows the cyan header (ANSI colours) on a cleared screen before the sub-demo runs.
