### PR TITLE
Improve API consistency + safe input coverage for all interactive paths

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,7 @@ TEST_BINS = test_circ_queue test_bst test_search test_hash_func \
             test_priority_queue test_scll test_dcll test_simple_queue \
             test_deque test_astar test_avl test_segment_tree \
             test_greedy_bfs test_sorting_n2 test_advanced_sorting \
-            test_history_logger test_shell_sort test_trie test_btree test_bplus_tree test_parity_bit \
+            test_history_logger test_shell_sort test_trie test_btree test_bplus_tree test_parity_bit test_safe_input \
             test_prim test_kruskal test_floyd_warshall test_mcm test_fibonacci test_knapsack test_lcs \
             test_string_algorithms test_expression_evaluation \
             test_fcfs test_sjf test_srtf test_round_robin test_priority_scheduling test_preemptive_priority \
@@ -360,6 +360,13 @@ test_history_logger: $(TEST_DIR)/test_history_logger$(EXE)
 	$(TEST_DIR)/test_history_logger$(EXE)
 
 $(TEST_DIR)/test_history_logger$(EXE): $(OBJ_DIR)/src/utils/history_logger.o tests/utils/test_history_logger.c
+	@$(call MKDIR_P,$(TEST_DIR))
+	$(CC) $(CFLAGS) $^ -o $@ $(LDFLAGS)
+
+test_safe_input: $(TEST_DIR)/test_safe_input$(EXE)
+	$(TEST_DIR)/test_safe_input$(EXE)
+
+$(TEST_DIR)/test_safe_input$(EXE): $(OBJ_DIR)/src/utils/safe_input_int.o $(OBJ_DIR)/src/utils/safe_input_string.o $(OBJ_DIR)/src/utils/mock_printf.o $(OBJ_DIR)/src/utils/history_logger.o tests/utils/test_safe_input.c
 	@$(call MKDIR_P,$(TEST_DIR))
 	$(CC) $(CFLAGS) $^ -o $@ $(LDFLAGS)
 

--- a/src/dynamic_programming/lcs.c
+++ b/src/dynamic_programming/lcs.c
@@ -87,7 +87,7 @@ void lcs_demo(void)
         printf("\nLCS Demo\n");
 
         int status_X =
-            safe_input_string(X, "Enter first string (no spaces, max 99 chars), or 'X' to exit: ");
+            safe_input_string(X, sizeof(X), "Enter first string (no spaces, max 99 chars), or 'X' to exit: ");
         if (status_X == INPUT_EXIT_SIGNAL)
         {
             printf("\nExiting LCS demo...\n");
@@ -95,7 +95,7 @@ void lcs_demo(void)
         }
 
         int status_Y =
-            safe_input_string(Y, "Enter second string (no spaces, max 99 chars), or 'X' to exit: ");
+            safe_input_string(Y, sizeof(Y), "Enter second string (no spaces, max 99 chars), or 'X' to exit: ");
         if (status_Y == INPUT_EXIT_SIGNAL)
         {
             printf("\nExiting LCS demo...\n");

--- a/src/error_correction_algorithms/checksum.c
+++ b/src/error_correction_algorithms/checksum.c
@@ -30,7 +30,7 @@ int safe_input_binary_string(char* buff, size_t size, const char* prompt)
     { // EOF or read error
         clearerr(stdin);
         printf("\ninput ended unexpectedly");
-        return 0;
+        return INPUT_EXIT_SIGNAL;
     }
     buff[strcspn(buff, "\n")] = '\0';
 

--- a/src/error_correction_algorithms/lrc.c
+++ b/src/error_correction_algorithms/lrc.c
@@ -38,23 +38,16 @@ void lrc_demo(void)
     printf("Enter binary data words (same length, e.g. 10110011):\n");
     for (int i = 0; i < rows; i++)
     {
-        // Fix 2: Use fgets() instead of scanf() for strings
-        printf("  Word %d: ", i + 1);
-        fgets(data[i], sizeof(data[i]), stdin);
+        char prompt_buf[32];
+        snprintf(prompt_buf, sizeof(prompt_buf), "  Word %d: ", i + 1);
+        int status_w = safe_input_string(data[i], sizeof(data[i]), prompt_buf);
+        if (status_w == INPUT_EXIT_SIGNAL)
+        {
+            printf("Exiting LRC demo...\n");
+            return;
+        }
 
-        // Remove trailing newline; if absent, input exceeded buffer — flush stdin
         int len = strlen(data[i]);
-        if (len > 0 && data[i][len - 1] == '\n')
-        {
-            data[i][len - 1] = '\0';
-            len--;
-        }
-        else
-        {
-            int c;
-            while ((c = getchar()) != '\n' && c != EOF)
-                ;
-        }
 
         /* validate: only '0' and '1' allowed */
         if (len == 0)

--- a/src/error_correction_algorithms/lrc_receiver.c
+++ b/src/error_correction_algorithms/lrc_receiver.c
@@ -34,23 +34,16 @@ void lrc_receiver_demo(void)
 
     for (int i = 0; i < rows; i++)
     {
-        printf("  Word %d: ", i + 1);
-
-        fgets(data[i], sizeof(data[i]), stdin);
+        char prompt_buf[32];
+        snprintf(prompt_buf, sizeof(prompt_buf), "  Word %d: ", i + 1);
+        int status_w = safe_input_string(data[i], sizeof(data[i]), prompt_buf);
+        if (status_w == INPUT_EXIT_SIGNAL)
+        {
+            printf("Exiting LRC receiver demo...\n");
+            return;
+        }
 
         int len = (int)strlen(data[i]);
-
-        if (len > 0 && data[i][len - 1] == '\n')
-        {
-            data[i][len - 1] = '\0';
-            len--;
-        }
-        else
-        {
-            int c;
-            while ((c = getchar()) != '\n' && c != EOF)
-                ;
-        }
 
         if (len == 0)
         {
@@ -80,23 +73,14 @@ void lrc_receiver_demo(void)
 
     char received_lrc[LRC_MAX_COLS + 1];
 
-    printf("Enter received LRC: ");
-
-    fgets(received_lrc, sizeof(received_lrc), stdin);
+    int status_lrc = safe_input_string(received_lrc, sizeof(received_lrc), "Enter received LRC: ");
+    if (status_lrc == INPUT_EXIT_SIGNAL)
+    {
+        printf("Exiting LRC receiver demo...\n");
+        return;
+    }
 
     int lrc_len = (int)strlen(received_lrc);
-
-    if (lrc_len > 0 && received_lrc[lrc_len - 1] == '\n')
-    {
-        received_lrc[lrc_len - 1] = '\0';
-        lrc_len--;
-    }
-    else
-    {
-        int c;
-        while ((c = getchar()) != '\n' && c != EOF)
-            ;
-    }
 
     if (lrc_len != cols)
     {

--- a/src/expression_evaluation/parantheses_checker.c
+++ b/src/expression_evaluation/parantheses_checker.c
@@ -130,7 +130,7 @@ int get_validated_input_parantheses(char* buff, size_t size, const char* prompt)
     {
         clearerr(stdin);
         printf("\ninput ended unexpectedly");
-        return 0;
+        return INPUT_EXIT_SIGNAL;
     }
     buff[strcspn(buff, "\n")] = '\0';
 

--- a/src/expression_evaluation/safe_input_infix.c
+++ b/src/expression_evaluation/safe_input_infix.c
@@ -15,10 +15,10 @@ int validate_infix_expr(char* buff, size_t size, const char* prompt)
         fflush(stdout);
     }
     if (!fgets(buff, size, stdin))
-    { // return code 0 represents EOF
+    { // return code INPUT_EXIT_SIGNAL represents EOF
         clearerr(stdin);
         printf("\ninput ended unexpectedly");
-        return 0;
+        return INPUT_EXIT_SIGNAL;
     }
     buff[strcspn(buff, "\n")] = '\0';
     if (buff[0] == 'X' && buff[1] == '\0')

--- a/src/expression_evaluation/safe_input_postfix.c
+++ b/src/expression_evaluation/safe_input_postfix.c
@@ -18,10 +18,10 @@ int validate_postfix_expr(char* buff, size_t size, const char* prompt)
     }
 
     if (!fgets(buff, size, stdin))
-    { // return code 0 represents EOF
+    { // return code INPUT_EXIT_SIGNAL represents EOF
         clearerr(stdin);
         printf("\ninput ended unexpectedly");
-        return 0;
+        return INPUT_EXIT_SIGNAL;
     }
 
     buff[strcspn(buff, "\n")] = '\0';

--- a/src/string_algorithms/kmp.c
+++ b/src/string_algorithms/kmp.c
@@ -236,7 +236,7 @@ void kmp_demo(void)
         printf("\nKnuth-Morris-Pratt (KMP) Demo\n");
 
         int status_T =
-            safe_input_string(text, "Enter text (no spaces, max 99 chars), or 'X' to exit: ");
+            safe_input_string(text, sizeof(text), "Enter text (no spaces, max 99 chars), or 'X' to exit: ");
         if (status_T == INPUT_EXIT_SIGNAL)
         {
             printf("\nExiting demo...\n");
@@ -244,7 +244,7 @@ void kmp_demo(void)
         }
 
         int status_P =
-            safe_input_string(pattern, "Enter pattern (no spaces, max 99 chars), or 'X' to exit: ");
+            safe_input_string(pattern, sizeof(pattern), "Enter pattern (no spaces, max 99 chars), or 'X' to exit: ");
         if (status_P == INPUT_EXIT_SIGNAL)
         {
             printf("\nExiting demo...\n");

--- a/src/string_algorithms/naive_string_matching.c
+++ b/src/string_algorithms/naive_string_matching.c
@@ -46,7 +46,7 @@ void naive_string_matching_demo(void)
         printf("\nNaive String Matching Demo\n");
 
         int status_T =
-            safe_input_string(text, "Enter text (no spaces, max 99 chars), or 'X' to exit: ");
+            safe_input_string(text, sizeof(text), "Enter text (no spaces, max 99 chars), or 'X' to exit: ");
         if (status_T == INPUT_EXIT_SIGNAL)
         {
             printf("\nExiting demo...\n");
@@ -54,7 +54,7 @@ void naive_string_matching_demo(void)
         }
 
         int status_P =
-            safe_input_string(pattern, "Enter pattern (no spaces, max 99 chars), or 'X' to exit: ");
+            safe_input_string(pattern, sizeof(pattern), "Enter pattern (no spaces, max 99 chars), or 'X' to exit: ");
         if (status_P == INPUT_EXIT_SIGNAL)
         {
             printf("\nExiting demo...\n");

--- a/src/string_algorithms/rabin_karp.c
+++ b/src/string_algorithms/rabin_karp.c
@@ -175,7 +175,7 @@ void rabin_karp_demo(void)
         printf("\nRabin-Karp Algorithm Demo\n");
 
         int status_T =
-            safe_input_string(text, "Enter text (no spaces, max 99 chars), or 'X' to exit: ");
+            safe_input_string(text, sizeof(text), "Enter text (no spaces, max 99 chars), or 'X' to exit: ");
         if (status_T == INPUT_EXIT_SIGNAL)
         {
             printf("\nExiting demo...\n");
@@ -183,7 +183,7 @@ void rabin_karp_demo(void)
         }
 
         int status_P =
-            safe_input_string(pattern, "Enter pattern (no spaces, max 99 chars), or 'X' to exit: ");
+            safe_input_string(pattern, sizeof(pattern), "Enter pattern (no spaces, max 99 chars), or 'X' to exit: ");
         if (status_P == INPUT_EXIT_SIGNAL)
         {
             printf("\nExiting demo...\n");

--- a/src/trees/trie.c
+++ b/src/trees/trie.c
@@ -147,16 +147,42 @@ void trie_demo(void)
 
         if (choice == 1)
         {
-            printf("enter word (lowercase letters only): ");
-            if (scanf("%255s", word) != 1)
+            int status_w = safe_input_string(word, sizeof(word), "enter word (lowercase letters only): ");
+            if (status_w == INPUT_EXIT_SIGNAL)
+            {
+                trie_free(root);
+                printf("\nexiting trie demo....\n");
+                return;
+            }
+            if (status_w == 0)
                 continue;
+            int valid = 1;
+            for (int i = 0; word[i] != '\0'; i++)
+            {
+                if (word[i] < 'a' || word[i] > 'z')
+                {
+                    valid = 0;
+                    break;
+                }
+            }
+            if (!valid)
+            {
+                printf("Error: word must contain only lowercase letters.\n");
+                continue;
+            }
             trie_insert(root, word);
             printf("inserted: %s\n", word);
         }
         else if (choice == 2)
         {
-            printf("enter word to search: ");
-            if (scanf("%255s", word) != 1)
+            int status_w = safe_input_string(word, sizeof(word), "enter word to search: ");
+            if (status_w == INPUT_EXIT_SIGNAL)
+            {
+                trie_free(root);
+                printf("\nexiting trie demo....\n");
+                return;
+            }
+            if (status_w == 0)
                 continue;
             if (trie_search(root, word))
                 printf("'%s' found in trie.\n", word);
@@ -165,8 +191,14 @@ void trie_demo(void)
         }
         else if (choice == 3)
         {
-            printf("enter prefix: ");
-            if (scanf("%255s", word) != 1)
+            int status_w = safe_input_string(word, sizeof(word), "enter prefix: ");
+            if (status_w == INPUT_EXIT_SIGNAL)
+            {
+                trie_free(root);
+                printf("\nexiting trie demo....\n");
+                return;
+            }
+            if (status_w == 0)
                 continue;
             if (trie_starts_with_prefix(root, word))
                 printf("words with prefix '%s' exist.\n", word);
@@ -175,8 +207,14 @@ void trie_demo(void)
         }
         else if (choice == 4)
         {
-            printf("enter word to delete: ");
-            if (scanf("%255s", word) != 1)
+            int status_w = safe_input_string(word, sizeof(word), "enter word to delete: ");
+            if (status_w == INPUT_EXIT_SIGNAL)
+            {
+                trie_free(root);
+                printf("\nexiting trie demo....\n");
+                return;
+            }
+            if (status_w == 0)
                 continue;
             trie_delete(root, word);
             printf("delete attempted for: %s\n", word);

--- a/src/utils/safe_input.h
+++ b/src/utils/safe_input.h
@@ -7,6 +7,6 @@
 int safe_input_int(int* input, const char* prompt, int min_val, int max_val);
 int validate_infix_expr(char* buff, size_t size, const char* prompt);
 int validate_postfix_expr(char* buff, size_t size, const char* prompt);
-int safe_input_string(char* buffer, const char* prompt);
+int safe_input_string(char* buffer, size_t size, const char* prompt);
 
 #endif

--- a/src/utils/safe_input_int.c
+++ b/src/utils/safe_input_int.c
@@ -1,4 +1,4 @@
-#include "data_structures.h"
+#include "safe_input.h"
 #include <stdio.h>
 
 // this function return 1 on successful insertion, 0 on failure (invalid input or EOF or number out
@@ -19,6 +19,13 @@ int safe_input_int(int* input, const char* prompt, int min_val, int max_val)
 
     if (scanf("%d", &value) != 1)
     {
+        // Check if EOF was encountered during scanf
+        if (feof(stdin))
+        {
+            clearerr(stdin);
+            printf("input ended unexpectedly\n");
+            return INPUT_EXIT_SIGNAL;
+        }
         printf("That's not a number. Please try again: \n");
         goto clear_buffer;
     }
@@ -30,7 +37,7 @@ int safe_input_int(int* input, const char* prompt, int min_val, int max_val)
     if (value == -1)
     {
         *input = -1;
-        return -111; // special exit code indicating user entered '-1' ie a signal to exit.
+        return INPUT_EXIT_SIGNAL; // special exit code indicating user entered '-1' ie a signal to exit.
     }
     if (value < min_val || value > max_val)
     {
@@ -51,7 +58,7 @@ clear_buffer:
         clearerr(stdin);
         fflush(stdin);
         printf("input ended unexpectedly\n");
-        return 0;
+        return INPUT_EXIT_SIGNAL;
     }
     return 0; // failure to take input, due to invalid input (characters, special characters or out
               // of range)

--- a/src/utils/safe_input_string.c
+++ b/src/utils/safe_input_string.c
@@ -2,25 +2,59 @@
 #include <stdio.h>
 #include <string.h>
 
-int safe_input_string(char* buffer, const char* prompt)
+int safe_input_string(char* buffer, size_t size, const char* prompt)
 {
     while (1)
     {
-        printf("%s", prompt);
-        fflush(stdout);
-
-        if (scanf("%99s", buffer) != 1)
+        if (prompt)
         {
+            printf("%s", prompt);
+            fflush(stdout);
+        }
+
+        if (!fgets(buffer, size, stdin))
+        {
+            printf("\ninput ended unexpectedly\n");
+            return INPUT_EXIT_SIGNAL;
+        }
+
+        // Clean newline or flush excess characters
+        size_t len = strlen(buffer);
+        if (len > 0 && buffer[len - 1] == '\n')
+        {
+            buffer[len - 1] = '\0';
+            len--;
+        }
+        else if (len == size - 1)
+        {
+            // Input was truncated because it exceeded buffer size
             int c;
             while ((c = getchar()) != '\n' && c != EOF)
                 ;
-            printf("Invalid input. Please try again.\n");
+        }
+
+        // Check empty
+        if (len == 0)
+        {
+            printf("Invalid input. Empty string. Please try again.\n");
             continue;
         }
 
-        int c;
-        while ((c = getchar()) != '\n' && c != EOF)
-            ; // Clear the rest of the line
+        // Check if there is any space character in the string
+        int has_space = 0;
+        for (size_t i = 0; i < len; i++)
+        {
+            if (buffer[i] == ' ' || buffer[i] == '\t' || buffer[i] == '\r')
+            {
+                has_space = 1;
+                break;
+            }
+        }
+        if (has_space)
+        {
+            printf("Invalid input. No spaces allowed. Please try again.\n");
+            continue;
+        }
 
         if (strcmp(buffer, "X") == 0)
         {

--- a/tests/utils/test_safe_input.c
+++ b/tests/utils/test_safe_input.c
@@ -1,0 +1,144 @@
+#include "safe_input.h"
+#include "mock_printf.h"
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define printf mock_printf
+
+static void write_mock_input(const char* content)
+{
+    FILE* f = fopen("temp_input.txt", "w");
+    assert(f != NULL);
+    if (content)
+    {
+        fputs(content, f);
+    }
+    fclose(f);
+    FILE* redirected = freopen("temp_input.txt", "r", stdin);
+    assert(redirected != NULL);
+}
+
+static void cleanup_mock_input(void)
+{
+    // Reopen standard input from console if possible, or just remove temp file.
+    // On tests, we don't need to restore stdin to actual terminal, but let's clean up files.
+    remove("temp_input.txt");
+}
+
+void test_safe_input_int(void)
+{
+    int val = 0;
+    int status;
+
+    // Test case 1: Valid input in range
+    reset_printf_buf();
+    write_mock_input("5\n");
+    status = safe_input_int(&val, "Enter number: ", 1, 10);
+    assert(status == 1);
+    assert(val == 5);
+
+    // Test case 2: Out of range input (too low)
+    reset_printf_buf();
+    write_mock_input("0\n");
+    val = 999;
+    status = safe_input_int(&val, "Enter number: ", 1, 10);
+    assert(status == 0);
+    assert(val == 999); // val unchanged on failure
+
+    // Test case 3: Out of range input (too high)
+    reset_printf_buf();
+    write_mock_input("11\n");
+    val = 999;
+    status = safe_input_int(&val, "Enter number: ", 1, 10);
+    assert(status == 0);
+    assert(val == 999);
+
+    // Test case 4: Non-integer input
+    reset_printf_buf();
+    write_mock_input("abc\n");
+    val = 999;
+    status = safe_input_int(&val, "Enter number: ", 1, 10);
+    assert(status == 0);
+    assert(val == 999);
+
+    // Test case 5: Exit signal (-1)
+    reset_printf_buf();
+    write_mock_input("-1\n");
+    val = 999;
+    status = safe_input_int(&val, "Enter number: ", 1, 10);
+    assert(status == INPUT_EXIT_SIGNAL);
+
+    // Test case 6: EOF on empty stream
+    reset_printf_buf();
+    write_mock_input("");
+    val = 999;
+    status = safe_input_int(&val, "Enter number: ", 1, 10);
+    assert(status == INPUT_EXIT_SIGNAL);
+}
+
+void test_safe_input_string(void)
+{
+    char buf[10];
+    int status;
+
+    // Test case 1: Valid string
+    reset_printf_buf();
+    write_mock_input("hello\n");
+    status = safe_input_string(buf, sizeof(buf), "Enter string: ");
+    assert(status == 1);
+    assert(strcmp(buf, "hello") == 0);
+
+    // Test case 2: Exit signal (X)
+    reset_printf_buf();
+    write_mock_input("X\n");
+    status = safe_input_string(buf, sizeof(buf), "Enter string: ");
+    assert(status == INPUT_EXIT_SIGNAL);
+
+    // Test case 3: String with spaces (should retry and then succeed/EOF)
+    reset_printf_buf();
+    write_mock_input("hello world\nworld\n");
+    status = safe_input_string(buf, sizeof(buf), "Enter string: ");
+    assert(status == 1);
+    assert(strcmp(buf, "world") == 0);
+
+    // Test case 4: Empty string retries
+    reset_printf_buf();
+    write_mock_input("\n\ntest\n");
+    status = safe_input_string(buf, sizeof(buf), "Enter string: ");
+    assert(status == 1);
+    assert(strcmp(buf, "test") == 0);
+
+    // Test case 5: EOF handling
+    reset_printf_buf();
+    write_mock_input("");
+    status = safe_input_string(buf, sizeof(buf), "Enter string: ");
+    assert(status == INPUT_EXIT_SIGNAL);
+
+    // Test case 6: Exceeding buffer size (should truncate and flush remainder)
+    reset_printf_buf();
+    // Buffer size is 5, so max read length is 4 characters.
+    // "longerstring" -> read "long", flush "erstring\n", next read should get "next"
+    write_mock_input("longerstring\nnext\n");
+    char short_buf[5];
+    status = safe_input_string(short_buf, sizeof(short_buf), "Enter short: ");
+    assert(status == 1);
+    assert(strcmp(short_buf, "long") == 0);
+
+    // Verify stdin was flushed properly by reading the next string
+    status = safe_input_string(short_buf, sizeof(short_buf), "Enter next: ");
+    assert(status == 1);
+    assert(strcmp(short_buf, "next") == 0);
+}
+
+int main(void)
+{
+    test_safe_input_int();
+    test_safe_input_string();
+    cleanup_mock_input();
+
+    #undef printf
+    fprintf(stdout, "All safe input tests passed successfully!\n");
+    return 0;
+}


### PR DESCRIPTION
Changes Made
1. Central Utilities safe_input.h
 Updated safe_input_string prototype to accept a buffer size parameter: int safe_input_string(char* buffer, size_t size, const char* prompt);.
safe_input_int.c: Updated safe_input_int to return INPUT_EXIT_SIGNAL on EOF instead of 0. This forces caller loops to exit cleanly.
safe_input_string.c: Rewrote safe_input_string to:
Take the buffer size and read using fgets().
Handle EOF by returning INPUT_EXIT_SIGNAL.
Detect input truncation (exceeding buffer size) and flush the remaining characters in stdin to prevent subsequent prompt corruption.
Enforce "no spaces" and non-empty string checks.
2. Caller Refactoring for safe_input_string
Updated all calls of safe_input_string to pass the target buffer size:

rabin_karp.c
naive_string_matching.c
kmp.c
lcs.c
3. Auditing and Converting Interactive Entry Paths
trie.c: Converted all direct scanf calls in trie_demo to use safe_input_string with appropriate validation.
lrc.c: Replaced direct fgets with safe_input_string for reading binary data words.
lrc_receiver.c: Replaced direct fgets with safe_input_string for both received data words and received LRC input.
4. Updating Other Input Helpers for Consistent EOF Exits
safe_input_infix.c: Changed EOF return from 0 to INPUT_EXIT_SIGNAL.
safe_input_postfix.c: Changed EOF return from 0 to INPUT_EXIT_SIGNAL.
parantheses_checker.c: Changed EOF return in get_validated_input_parantheses from 0 to INPUT_EXIT_SIGNAL.
checksum.c: Changed EOF return in safe_input_binary_string from 0 to INPUT_EXIT_SIGNAL.
5. Unit Tests
test_safe_input.c: Implemented a new test suite testing:
safe_input_int (in-range values, out-of-range values, non-integer input, exit signals, and EOF).
safe_input_string (valid strings, spaces detection and retry, empty input, exit signals, EOF, and overflow-truncation/flushing behavior).
Makefile: Added compilation and run rules for test_safe_input.


closes #560