### PR TITLE
fix: Add NULL checks for malloc in DP algorithms

### DIFF
--- a/src/dynamic_programming/fibonacci.c
+++ b/src/dynamic_programming/fibonacci.c
@@ -22,6 +22,11 @@ long long fibonacci_iterative(int n)
         return n;
 
     long long* dp = malloc((n + 1) * sizeof(long long));
+    if (dp == NULL)
+    {
+        printf("Memory allocation failed for DP array.\n");
+        return -1;
+    }
     dp[0] = 0;
     dp[1] = 1;
 
@@ -53,6 +58,11 @@ void fibonacci_demo(void)
             continue;
 
         long long* memo = malloc((n + 1) * sizeof(long long));
+        if (memo == NULL)
+        {
+            printf("Memory allocation failed for memoization array.\n");
+            continue;
+        }
         for (int i = 0; i <= n; i++)
         {
             memo[i] = -1;

--- a/src/dynamic_programming/knapsack.c
+++ b/src/dynamic_programming/knapsack.c
@@ -14,9 +14,24 @@ int knapsack(int W, int wt[], int val[], int n)
 {
     int i, w;
     int** K = malloc((n + 1) * sizeof(int*));
+    if (K == NULL)
+    {
+        printf("Memory allocation failed for DP table.\n");
+        return -1;
+    }
     for (i = 0; i <= n; i++)
     {
         K[i] = malloc((W + 1) * sizeof(int));
+        if (K[i] == NULL)
+        {
+            printf("Memory allocation failed for DP table row %d.\n", i);
+            for (int j = 0; j < i; j++)
+            {
+                free(K[j]);
+            }
+            free(K);
+            return -1;
+        }
     }
 
     for (i = 0; i <= n; i++)

--- a/src/dynamic_programming/lcs.c
+++ b/src/dynamic_programming/lcs.c
@@ -14,9 +14,24 @@ static int max(int a, int b)
 int lcs(char* X, char* Y, int m, int n)
 {
     int** L = malloc((m + 1) * sizeof(int*));
+    if (L == NULL)
+    {
+        printf("Memory allocation failed for DP table.\n");
+        return -1;
+    }
     for (int i = 0; i <= m; i++)
     {
         L[i] = malloc((n + 1) * sizeof(int));
+        if (L[i] == NULL)
+        {
+            printf("Memory allocation failed for DP table row %d.\n", i);
+            for (int j = 0; j < i; j++)
+            {
+                free(L[j]);
+            }
+            free(L);
+            return -1;
+        }
     }
 
     int i, j;


### PR DESCRIPTION
### Description
This PR addresses a critical stability issue within the dynamic programming algorithms. Several implementations dynamically allocated memory for 2D DP arrays but failed to verify if `malloc` succeeded. In situations involving large inputs or low system memory, this would cause the program to crash with an unhandled segmentation fault.
Fixes #565 
This PR introduces necessary `NULL` checks immediately following all `malloc()` calls in:
- `src/dynamic_programming/lcs.c`
- `src/dynamic_programming/knapsack.c`
- `src/dynamic_programming/fibonacci.c`

If memory allocation fails, the functions will now print an error, free any previously allocated rows, and gracefully return `-1` to prevent the application from crashing.

### Motivation and Context
Prevents fatal application crashes during interactive use when users enter unusually large constraints. This aligns the newer algorithms with the existing safety standards seen in `mcm.c`.
