### PR TITLE
fix: Ignore missing directory errors in clean target on Windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,9 +90,9 @@ fmt:
 
 clean:
 ifeq ($(OS),Windows_NT)
-	$(RM) $(TARGET)$(EXE)
-	$(RM_DIR) $(OBJ_DIR)
-	$(RM_DIR) $(TEST_DIR)
+	-$(RM) $(TARGET)$(EXE)
+	-$(RM_DIR) $(OBJ_DIR)
+	-$(RM_DIR) $(TEST_DIR)
 else
 	$(RM) $(TARGET)$(EXE)
 	$(RM_DIR) $(OBJ_DIR)


### PR DESCRIPTION
### Description
This PR fixes a build issue where running `mingw32-make clean` on a Windows environment would crash and halt execution if the build directories (`object_files` or `test_binaries`) did not already exist.
Fixes #566 
Because Windows `cmd /c rmdir /s /q` exits with a non-zero status code (Code 2) when attempting to delete a missing directory, `make` treats this as a fatal error. 

By prepending a hyphen (`-`) to the `$(RM)` and `$(RM_DIR)` execution commands within the Windows conditional block, we instruct Make to safely ignore these expected exit codes.

### Steps to Test
1. Clone the project on Windows (ensure `object_files` does not exist).
2. Run `mingw32-make clean`.
3. Observe that it successfully completes without throwing `recipe for target 'clean' failed`.
