### PR TITLE
feat(graph_traversals): implement Tarjan and Kosaraju SCC algorithms

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -120,7 +120,7 @@ TEST_BINS = test_circ_queue test_bst test_search test_hash_func \
             test_string_algorithms test_expression_evaluation \
             test_fcfs test_sjf test_srtf test_round_robin test_priority_scheduling test_preemptive_priority \
             test_dining_philosophers test_petersons test_producer_consumer \
-            test_dijkstra test_bellman_ford test_bfs test_dfs test_topological_sort test_benchmark
+            test_dijkstra test_bellman_ford test_bfs test_dfs test_topological_sort test_benchmark test_scc
 
 ifneq ($(wildcard tests/benchmark/test_benchmark_sorting.c),)
 TEST_BINS += test_benchmark_sorting
@@ -607,6 +607,12 @@ $(TEST_DIR)/test_dfs$(EXE): $(filter-out $(OBJ_DIR)/src/graph_traversals/dfs.o,$
 test_topological_sort: $(TEST_DIR)/test_topological_sort$(EXE)
 	$(TEST_DIR)/test_topological_sort$(EXE)
 $(TEST_DIR)/test_topological_sort$(EXE): $(filter-out $(OBJ_DIR)/src/graph_traversals/topological_sort.o,$(OBJS)) tests/graph_traversals/test_topological_sort.c
+	@$(call MKDIR_P,$(TEST_DIR))
+	$(CC) $(CFLAGS) $^ -o $@ $(LDFLAGS)
+
+test_scc: $(TEST_DIR)/test_scc$(EXE)
+	$(TEST_DIR)/test_scc$(EXE)
+$(TEST_DIR)/test_scc$(EXE): $(filter-out $(OBJ_DIR)/src/graph_traversals/scc.o,$(OBJS)) tests/graph_traversals/test_scc.c
 	@$(call MKDIR_P,$(TEST_DIR))
 	$(CC) $(CFLAGS) $^ -o $@ $(LDFLAGS)
 

--- a/src/graph_traversals/graph_traversals.h
+++ b/src/graph_traversals/graph_traversals.h
@@ -114,4 +114,10 @@ void prim_demo(void);
 weightedGraph* load_weightedGraph_from_csv(const char* path);
 weightedGraph* load_weightedGraph_with_heuristic_from_csv(const char* path, int** out_h);
 Graph* load_graph_from_csv(const char* path);
+
+// ------------------For Strongly Connected Components (SCC)-----------------
+int** find_scc_tarjan(Graph* graph, int* scc_count, int** scc_sizes);
+int** find_scc_kosaraju(Graph* graph, int* scc_count, int** scc_sizes);
+void free_scc_result(int** sccs, int* scc_sizes, int scc_count);
+
 #endif

--- a/src/graph_traversals/scc.c
+++ b/src/graph_traversals/scc.c
@@ -1,0 +1,279 @@
+#include "graph_traversals.h"
+#include <stdlib.h>
+#include <string.h>
+
+static void tarjan_dfs(Graph* graph, int u, int* disc, int* low, bool* on_stack,
+                       stack* st, int* time, int*** sccs, int** sizes, int* count)
+{
+    disc[u] = low[u] = ++(*time);
+    push(st, u);
+    on_stack[u] = true;
+
+    Node* temp = graph->array[u];
+    while (temp != NULL)
+    {
+        int v = temp->data;
+        if (disc[v] == -1)
+        {
+            tarjan_dfs(graph, v, disc, low, on_stack, st, time, sccs, sizes, count);
+            if (low[v] < low[u])
+            {
+                low[u] = low[v];
+            }
+        }
+        else if (on_stack[v])
+        {
+            if (disc[v] < low[u])
+            {
+                low[u] = disc[v];
+            }
+        }
+        temp = temp->next;
+    }
+
+    if (low[u] == disc[u])
+    {
+        int* comp = NULL;
+        int comp_size = 0;
+        int w = -1;
+        while (w != u)
+        {
+            w = pop(st);
+            on_stack[w] = false;
+            comp_size++;
+            int* new_comp = realloc(comp, sizeof(int) * comp_size);
+            if (new_comp == NULL)
+            {
+                free(comp);
+                return;
+            }
+            comp = new_comp;
+            comp[comp_size - 1] = w;
+        }
+
+        (*count)++;
+        int** new_sccs = realloc(*sccs, sizeof(int*) * (*count));
+        int* new_sizes = realloc(*sizes, sizeof(int) * (*count));
+        if (new_sccs == NULL || new_sizes == NULL)
+        {
+            free(comp);
+            return;
+        }
+        *sccs = new_sccs;
+        *sizes = new_sizes;
+        (*sccs)[*count - 1] = comp;
+        (*sizes)[*count - 1] = comp_size;
+    }
+}
+
+int** find_scc_tarjan(Graph* graph, int* scc_count, int** scc_sizes)
+{
+    if (graph == NULL || scc_count == NULL || scc_sizes == NULL)
+        return NULL;
+
+    int V = graph->V;
+    int* disc = malloc(sizeof(int) * V);
+    int* low = malloc(sizeof(int) * V);
+    bool* on_stack = malloc(sizeof(bool) * V);
+    if (disc == NULL || low == NULL || on_stack == NULL)
+    {
+        free(disc);
+        free(low);
+        free(on_stack);
+        return NULL;
+    }
+
+    for (int i = 0; i < V; i++)
+    {
+        disc[i] = -1;
+        low[i] = -1;
+        on_stack[i] = false;
+    }
+
+    stack* st = createStack();
+    if (st == NULL)
+    {
+        free(disc);
+        free(low);
+        free(on_stack);
+        return NULL;
+    }
+
+    int time = 0;
+    int** sccs = NULL;
+    int* sizes = NULL;
+    int count = 0;
+
+    for (int i = 0; i < V; i++)
+    {
+        if (disc[i] == -1)
+        {
+            tarjan_dfs(graph, i, disc, low, on_stack, st, &time, &sccs, &sizes, &count);
+        }
+    }
+
+    destroyStack(st);
+    free(disc);
+    free(low);
+    free(on_stack);
+
+    *scc_count = count;
+    *scc_sizes = sizes;
+    return sccs;
+}
+
+static void kosaraju_dfs1(Graph* graph, int u, bool* visited, stack* st)
+{
+    visited[u] = true;
+    Node* temp = graph->array[u];
+    while (temp != NULL)
+    {
+        int v = temp->data;
+        if (!visited[v])
+        {
+            kosaraju_dfs1(graph, v, visited, st);
+        }
+        temp = temp->next;
+    }
+    push(st, u);
+}
+
+static Graph* transpose_graph(Graph* graph)
+{
+    int V = graph->V;
+    Graph* trans = create_graph(V);
+    if (trans == NULL)
+        return NULL;
+
+    for (int u = 0; u < V; u++)
+    {
+        Node* temp = graph->array[u];
+        while (temp != NULL)
+        {
+            int v = temp->data;
+            add_edge_directed_unweighted(trans, v, u);
+            temp = temp->next;
+        }
+    }
+    return trans;
+}
+
+static void kosaraju_dfs2(Graph* graph, int u, bool* visited, int** comp, int* comp_size)
+{
+    visited[u] = true;
+    (*comp_size)++;
+    int* new_comp = realloc(*comp, sizeof(int) * (*comp_size));
+    if (new_comp == NULL)
+    {
+        free(*comp);
+        return;
+    }
+    *comp = new_comp;
+    (*comp)[*comp_size - 1] = u;
+
+    Node* temp = graph->array[u];
+    while (temp != NULL)
+    {
+        int v = temp->data;
+        if (!visited[v])
+        {
+            kosaraju_dfs2(graph, v, visited, comp, comp_size);
+        }
+        temp = temp->next;
+    }
+}
+
+int** find_scc_kosaraju(Graph* graph, int* scc_count, int** scc_sizes)
+{
+    if (graph == NULL || scc_count == NULL || scc_sizes == NULL)
+        return NULL;
+
+    int V = graph->V;
+    bool* visited = malloc(sizeof(bool) * V);
+    if (visited == NULL)
+        return NULL;
+    memset(visited, 0, sizeof(bool) * V);
+
+    stack* st = createStack();
+    if (st == NULL)
+    {
+        free(visited);
+        return NULL;
+    }
+
+    for (int i = 0; i < V; i++)
+    {
+        if (!visited[i])
+        {
+            kosaraju_dfs1(graph, i, visited, st);
+        }
+    }
+
+    Graph* trans = transpose_graph(graph);
+    if (trans == NULL)
+    {
+        destroyStack(st);
+        free(visited);
+        return NULL;
+    }
+
+    memset(visited, 0, sizeof(bool) * V);
+    int** sccs = NULL;
+    int* sizes = NULL;
+    int count = 0;
+
+    while (!isEmpty(st))
+    {
+        int u = pop(st);
+        if (!visited[u])
+        {
+            int* comp = NULL;
+            int comp_size = 0;
+            kosaraju_dfs2(trans, u, visited, &comp, &comp_size);
+
+            count++;
+            int** new_sccs = realloc(sccs, sizeof(int*) * count);
+            int* new_sizes = realloc(sizes, sizeof(int) * count);
+            if (new_sccs == NULL || new_sizes == NULL)
+            {
+                free(comp);
+                free_scc_result(sccs, sizes, count - 1);
+                free_graph(trans);
+                destroyStack(st);
+                free(visited);
+                return NULL;
+            }
+            sccs = new_sccs;
+            sizes = new_sizes;
+            sccs[count - 1] = comp;
+            sizes[count - 1] = comp_size;
+        }
+    }
+
+    free_graph(trans);
+    destroyStack(st);
+    free(visited);
+
+    *scc_count = count;
+    *scc_sizes = sizes;
+    return sccs;
+}
+
+void free_scc_result(int** sccs, int* scc_sizes, int scc_count)
+{
+    if (sccs != NULL)
+    {
+        for (int i = 0; i < scc_count; i++)
+        {
+            if (sccs[i] != NULL)
+            {
+                free(sccs[i]);
+            }
+        }
+        free(sccs);
+    }
+    if (scc_sizes != NULL)
+    {
+        free(scc_sizes);
+    }
+}

--- a/src/graph_traversals/scc.c
+++ b/src/graph_traversals/scc.c
@@ -53,13 +53,19 @@ static void tarjan_dfs(Graph* graph, int u, int* disc, int* low, bool* on_stack,
 
         (*count)++;
         int** new_sccs = realloc(*sccs, sizeof(int*) * (*count));
-        int* new_sizes = realloc(*sizes, sizeof(int) * (*count));
-        if (new_sccs == NULL || new_sizes == NULL)
+        if (new_sccs == NULL)
         {
             free(comp);
             return;
         }
         *sccs = new_sccs;
+
+        int* new_sizes = realloc(*sizes, sizeof(int) * (*count));
+        if (new_sizes == NULL)
+        {
+            free(comp);
+            return;
+        }
         *sizes = new_sizes;
         (*sccs)[*count - 1] = comp;
         (*sizes)[*count - 1] = comp_size;
@@ -233,8 +239,7 @@ int** find_scc_kosaraju(Graph* graph, int* scc_count, int** scc_sizes)
 
             count++;
             int** new_sccs = realloc(sccs, sizeof(int*) * count);
-            int* new_sizes = realloc(sizes, sizeof(int) * count);
-            if (new_sccs == NULL || new_sizes == NULL)
+            if (new_sccs == NULL)
             {
                 free(comp);
                 free_scc_result(sccs, sizes, count - 1);
@@ -244,6 +249,17 @@ int** find_scc_kosaraju(Graph* graph, int* scc_count, int** scc_sizes)
                 return NULL;
             }
             sccs = new_sccs;
+
+            int* new_sizes = realloc(sizes, sizeof(int) * count);
+            if (new_sizes == NULL)
+            {
+                free(comp);
+                free_scc_result(sccs, sizes, count - 1);
+                free_graph(trans);
+                destroyStack(st);
+                free(visited);
+                return NULL;
+            }
             sizes = new_sizes;
             sccs[count - 1] = comp;
             sizes[count - 1] = comp_size;

--- a/src/graph_traversals/scc.c
+++ b/src/graph_traversals/scc.c
@@ -2,8 +2,8 @@
 #include <stdlib.h>
 #include <string.h>
 
-static void tarjan_dfs(Graph* graph, int u, int* disc, int* low, bool* on_stack,
-                       stack* st, int* time, int*** sccs, int** sizes, int* count)
+static void tarjan_dfs(Graph* graph, int u, int* disc, int* low, bool* on_stack, stack* st,
+                       int* time, int*** sccs, int** sizes, int* count)
 {
     disc[u] = low[u] = ++(*time);
     push(st, u);

--- a/tests/graph_traversals/test_scc.c
+++ b/tests/graph_traversals/test_scc.c
@@ -1,0 +1,95 @@
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "graph_traversals.h"
+#include "../../src/graph_traversals/scc.c"
+
+static bool in_same_scc(int** sccs, int* sizes, int count, int u, int v)
+{
+    for (int i = 0; i < count; i++)
+    {
+        bool has_u = false;
+        bool has_v = false;
+        for (int j = 0; j < sizes[i]; j++)
+        {
+            if (sccs[i][j] == u) has_u = true;
+            if (sccs[i][j] == v) has_v = true;
+        }
+        if (has_u && has_v) return true;
+    }
+    return false;
+}
+
+void test_simple_cycle()
+{
+    printf("Running test_simple_cycle...\n");
+    Graph* g = create_graph(3);
+    add_edge_directed_unweighted(g, 0, 1);
+    add_edge_directed_unweighted(g, 1, 2);
+    add_edge_directed_unweighted(g, 2, 0);
+
+    int tarjan_count = 0;
+    int* tarjan_sizes = NULL;
+    int** tarjan_sccs = find_scc_tarjan(g, &tarjan_count, &tarjan_sizes);
+
+    assert(tarjan_count == 1);
+    assert(tarjan_sizes[0] == 3);
+    assert(in_same_scc(tarjan_sccs, tarjan_sizes, tarjan_count, 0, 1));
+    assert(in_same_scc(tarjan_sccs, tarjan_sizes, tarjan_count, 1, 2));
+
+    int kosaraju_count = 0;
+    int* kosaraju_sizes = NULL;
+    int** kosaraju_sccs = find_scc_kosaraju(g, &kosaraju_count, &kosaraju_sizes);
+
+    assert(kosaraju_count == 1);
+    assert(kosaraju_sizes[0] == 3);
+    assert(in_same_scc(kosaraju_sccs, kosaraju_sizes, kosaraju_count, 0, 1));
+    assert(in_same_scc(kosaraju_sccs, kosaraju_sizes, kosaraju_count, 1, 2));
+
+    free_scc_result(tarjan_sccs, tarjan_sizes, tarjan_count);
+    free_scc_result(kosaraju_sccs, kosaraju_sizes, kosaraju_count);
+    free_graph(g);
+    printf("test_simple_cycle passed.\n");
+}
+
+void test_disconnected_components()
+{
+    printf("Running test_disconnected_components...\n");
+    Graph* g = create_graph(5);
+    add_edge_directed_unweighted(g, 0, 1);
+    add_edge_directed_unweighted(g, 1, 2);
+    add_edge_directed_unweighted(g, 2, 0);
+    add_edge_directed_unweighted(g, 3, 4);
+
+    int tarjan_count = 0;
+    int* tarjan_sizes = NULL;
+    int** tarjan_sccs = find_scc_tarjan(g, &tarjan_count, &tarjan_sizes);
+
+    assert(tarjan_count == 3);
+    assert(in_same_scc(tarjan_sccs, tarjan_sizes, tarjan_count, 0, 1));
+    assert(in_same_scc(tarjan_sccs, tarjan_sizes, tarjan_count, 1, 2));
+    assert(!in_same_scc(tarjan_sccs, tarjan_sizes, tarjan_count, 3, 4));
+
+    int kosaraju_count = 0;
+    int* kosaraju_sizes = NULL;
+    int** kosaraju_sccs = find_scc_kosaraju(g, &kosaraju_count, &kosaraju_sizes);
+
+    assert(kosaraju_count == 3);
+    assert(in_same_scc(kosaraju_sccs, kosaraju_sizes, kosaraju_count, 0, 1));
+    assert(in_same_scc(kosaraju_sccs, kosaraju_sizes, kosaraju_count, 1, 2));
+    assert(!in_same_scc(kosaraju_sccs, kosaraju_sizes, kosaraju_count, 3, 4));
+
+    free_scc_result(tarjan_sccs, tarjan_sizes, tarjan_count);
+    free_scc_result(kosaraju_sccs, kosaraju_sizes, kosaraju_count);
+    free_graph(g);
+    printf("test_disconnected_components passed.\n");
+}
+
+int main()
+{
+    test_simple_cycle();
+    test_disconnected_components();
+    printf("All Strongly Connected Components Tests Passed!\n");
+    return 0;
+}

--- a/tests/graph_traversals/test_scc.c
+++ b/tests/graph_traversals/test_scc.c
@@ -1,9 +1,9 @@
+#include "../../src/graph_traversals/scc.c"
+#include "graph_traversals.h"
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include "graph_traversals.h"
-#include "../../src/graph_traversals/scc.c"
 
 static bool in_same_scc(int** sccs, int* sizes, int count, int u, int v)
 {
@@ -13,10 +13,13 @@ static bool in_same_scc(int** sccs, int* sizes, int count, int u, int v)
         bool has_v = false;
         for (int j = 0; j < sizes[i]; j++)
         {
-            if (sccs[i][j] == u) has_u = true;
-            if (sccs[i][j] == v) has_v = true;
+            if (sccs[i][j] == u)
+                has_u = true;
+            if (sccs[i][j] == v)
+                has_v = true;
         }
-        if (has_u && has_v) return true;
+        if (has_u && has_v)
+            return true;
     }
     return false;
 }


### PR DESCRIPTION
This PR implements the core algorithms for finding Strongly Connected Components (SCCs) in a directed graph:
- Tarjan's single-pass DFS algorithm utilizing low-link values and a recursion stack.
- Kosaraju's two-pass DFS algorithm utilizing the transpose graph.

Part of #562