### PR TITLE
Fix input validation lower bounds from -1 to 1 across interactive demos (#564)

### DIFF
--- a/src/backtracking/graph_coloring.c
+++ b/src/backtracking/graph_coloring.c
@@ -342,7 +342,7 @@ void graph_coloring_demo(void)
         {
             printf("%d. %s (%d vertices)\n", i + 1, topologies[i].name, topologies[i].num_vertices);
         }
-        int status = safe_input_int(&graph_choice, "Select topology (1-6), or -1 to exit: ", -1,
+        int status = safe_input_int(&graph_choice, "Select topology (1-6), or -1 to exit: ", 1,
                                     num_topologies);
 
         if (status == INPUT_EXIT_SIGNAL)
@@ -361,7 +361,7 @@ void graph_coloring_demo(void)
 
         int M;
         status = safe_input_int(
-            &M, "\nEnter the number of colors M (between 1 and 5), or -1 to exit: ", -1, 5);
+            &M, "\nEnter the number of colors M (between 1 and 5), or -1 to exit: ", 1, 5);
         if (status == INPUT_EXIT_SIGNAL)
         {
 #ifdef _WIN32

--- a/src/backtracking/knights_tour.c
+++ b/src/backtracking/knights_tour.c
@@ -175,7 +175,7 @@ void knights_tour_demo(void)
     {
         int N;
         int status = safe_input_int(
-            &N, "\nEnter the board size N (between 4 and 8), or -1 to exit: ", -1, 8);
+            &N, "\nEnter the board size N (between 4 and 8), or -1 to exit: ", 1, 8);
 
         if (status == INPUT_EXIT_SIGNAL)
         {

--- a/src/backtracking/knights_tour.c
+++ b/src/backtracking/knights_tour.c
@@ -174,8 +174,8 @@ void knights_tour_demo(void)
     while (1)
     {
         int N;
-        int status = safe_input_int(
-            &N, "\nEnter the board size N (between 4 and 8), or -1 to exit: ", 1, 8);
+        int status =
+            safe_input_int(&N, "\nEnter the board size N (between 4 and 8), or -1 to exit: ", 1, 8);
 
         if (status == INPUT_EXIT_SIGNAL)
         {

--- a/src/backtracking/rat_in_maze.c
+++ b/src/backtracking/rat_in_maze.c
@@ -120,7 +120,7 @@ void rat_in_maze_demo(void)
     {
         int choice;
         int status = safe_input_int(
-            &choice, "\nEnter 1 to solve the predefined 6x6 Rat in a Maze, or -1 to exit: ", -1, 1);
+            &choice, "\nEnter 1 to solve the predefined 6x6 Rat in a Maze, or -1 to exit: ", 1, 1);
 
         if (status == INPUT_EXIT_SIGNAL)
         {

--- a/src/backtracking/sudoku.c
+++ b/src/backtracking/sudoku.c
@@ -146,7 +146,7 @@ void sudoku_demo(void)
         int choice;
         // safe_input_int prevents crashes from ANY invalid value (letters, symbols, out of range)
         int status = safe_input_int(
-            &choice, "\nEnter 1 to solve the predefined 6x6 Sudoku puzzle, or -1 to exit: ", -1, 1);
+            &choice, "\nEnter 1 to solve the predefined 6x6 Sudoku puzzle, or -1 to exit: ", 1, 1);
 
         if (status == INPUT_EXIT_SIGNAL)
         {

--- a/src/process_synchronization/dining_philosophers.c
+++ b/src/process_synchronization/dining_philosophers.c
@@ -402,7 +402,7 @@ void dining_philosophers_demo(void)
         fflush(stdout);
 
         int choice;
-        int status = safe_input_int(&choice, "", -1, 4);
+        int status = safe_input_int(&choice, "", 1, 4);
         if (status == INPUT_EXIT_SIGNAL || choice == -1)
         {
             break;

--- a/src/process_synchronization/petersons_algorithm.c
+++ b/src/process_synchronization/petersons_algorithm.c
@@ -251,7 +251,7 @@ void petersons_algorithm_demo(void)
         fflush(stdout);
 
         int choice;
-        int status = safe_input_int(&choice, "", -1, 4);
+        int status = safe_input_int(&choice, "", 1, 4);
         if (status == INPUT_EXIT_SIGNAL || choice == -1)
         {
             break;

--- a/src/process_synchronization/petersons_algorithm.c
+++ b/src/process_synchronization/petersons_algorithm.c
@@ -239,7 +239,8 @@ void petersons_algorithm_demo(void)
         // Safety verification check: verify mutual exclusion is never violated
         if (pc[0] == 4 && pc[1] == 4)
         {
-            printf("\n\033[1;31m⚠️ MUTUAL EXCLUSION VIOLATED! (This should be impossible)\033[0m\n");
+            printf("\n\033[1;31m⚠️ MUTUAL EXCLUSION VIOLATED! (This should be "
+                   "impossible)\033[0m\n");
         }
 
         printf("\nOptions:\n");

--- a/src/process_synchronization/producer_consumer.c
+++ b/src/process_synchronization/producer_consumer.c
@@ -83,7 +83,7 @@ void producer_consumer_demo(void)
         fflush(stdout);
 
         int choice;
-        int status = safe_input_int(&choice, "", -1, 4);
+        int status = safe_input_int(&choice, "", 1, 4);
         if (status == INPUT_EXIT_SIGNAL || choice == -1)
         {
             break;

--- a/src/trees/bst.c
+++ b/src/trees/bst.c
@@ -212,7 +212,7 @@ void binary_search_tree_demo(void)
         total_bst_nodes_status = safe_input_int(&total_bst_nodes,
                                                 "enter total number of nodes you want in the bst, "
                                                 "(between 1 and 100), enter '-1' to exit:- ",
-                                                -1, 100);
+                                                1, 100);
 
         if (total_bst_nodes_status == INPUT_EXIT_SIGNAL)
         {
@@ -270,7 +270,7 @@ void binary_search_tree_demo(void)
                 &bst_traversal_choice,
                 "\nenter '1' for inorder, '2' for preorder and "
                 "'3' for postorder, '4' for level order, '5' to delete a node  and '-1' to exit: ",
-                -1, 5);
+                1, 5);
 
             if (bst_traversal_status == INPUT_EXIT_SIGNAL)
             {
@@ -306,7 +306,7 @@ void binary_search_tree_demo(void)
                 {
                     delete_status = safe_input_int(
                         &delete_value,
-                        "\nenter value to delete, (between 1 and 100), enter '-1' to exit:- ", -1,
+                        "\nenter value to delete, (between 1 and 100), enter '-1' to exit:- ", 1,
                         100);
                     if (delete_status == INPUT_EXIT_SIGNAL)
                     {


### PR DESCRIPTION
Standardizes the lower bound checks in `safe_input_int()` from `-1` to `1` across various interactive demos. This prevents invalid options (such as `0` or other negative values) from being incorrectly accepted, while still preserving `-1` as the exit/return signal.

### Modified Files & Inputs:
* **Backtracking**:
  * `graph_coloring.c` (topology choice and color count inputs)
  * `knights_tour.c` (board size input)
  * `rat_in_maze.c` (maze solving menu option)
  * `sudoku.c` (Sudoku solving menu option)
* **Process Synchronization**:
  * `dining_philosophers.c` (simulation options menu choice)
  * `petersons_algorithm.c` (simulation options menu choice)
  * `producer_consumer.c` (simulator options menu choice)
* **Trees**:
  * `bst.c` (total nodes input, traversal menu, and node deletion value)

Closes #564
