### PR TITLE
feat(advanced_graph_algorithms): relocate advanced graph algorithms and network flows to a dedicated module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@ set(SRC_DIRS
     src/advanced_sorting_algorithms
     src/searching_algorithms
     src/graph_traversals
+    src/advanced_graph_algorithms
     src/hashing
     src/utils
     src/trees

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ CFLAGS = -Wall -Wextra -Werror -std=c11 -g \
 	-Isrc/advanced_sorting_algorithms \
 	-Isrc/searching_algorithms \
 	-Isrc/graph_traversals \
+	-Isrc/advanced_graph_algorithms \
 	-Isrc/hashing \
 	-Isrc/utils \
 	-Isrc/trees \
@@ -33,6 +34,7 @@ SRC_DIRS = \
 	src/advanced_sorting_algorithms \
 	src/searching_algorithms \
 	src/graph_traversals \
+	src/advanced_graph_algorithms \
 	src/hashing \
 	src/utils \
 	src/trees \
@@ -623,43 +625,43 @@ $(TEST_DIR)/test_topological_sort$(EXE): $(filter-out $(OBJ_DIR)/src/graph_trave
 
 test_scc: $(TEST_DIR)/test_scc$(EXE)
 	$(TEST_DIR)/test_scc$(EXE)
-$(TEST_DIR)/test_scc$(EXE): $(filter-out $(OBJ_DIR)/src/graph_traversals/scc.o,$(OBJS)) tests/graph_traversals/test_scc.c
+$(TEST_DIR)/test_scc$(EXE): $(filter-out $(OBJ_DIR)/src/advanced_graph_algorithms/scc.o,$(OBJS)) tests/advanced_graph_algorithms/test_scc.c
 	@$(call MKDIR_P,$(TEST_DIR))
 	$(CC) $(CFLAGS) $^ -o $@ $(LDFLAGS)
 
 test_ford_fulkerson: $(TEST_DIR)/test_ford_fulkerson$(EXE)
 	$(TEST_DIR)/test_ford_fulkerson$(EXE)
-$(TEST_DIR)/test_ford_fulkerson$(EXE): $(filter-out $(OBJ_DIR)/src/graph_traversals/ford_fulkerson.o,$(OBJS)) tests/graph_traversals/test_ford_fulkerson.c
+$(TEST_DIR)/test_ford_fulkerson$(EXE): $(filter-out $(OBJ_DIR)/src/advanced_graph_algorithms/ford_fulkerson.o,$(OBJS)) tests/advanced_graph_algorithms/test_ford_fulkerson.c
 	@$(call MKDIR_P,$(TEST_DIR))
 	$(CC) $(CFLAGS) $^ -o $@ $(LDFLAGS)
 
 test_edmonds_karp: $(TEST_DIR)/test_edmonds_karp$(EXE)
 	$(TEST_DIR)/test_edmonds_karp$(EXE)
-$(TEST_DIR)/test_edmonds_karp$(EXE): $(filter-out $(OBJ_DIR)/src/graph_traversals/edmonds_karp.o,$(OBJS)) tests/graph_traversals/test_edmonds_karp.c
+$(TEST_DIR)/test_edmonds_karp$(EXE): $(filter-out $(OBJ_DIR)/src/advanced_graph_algorithms/edmonds_karp.o,$(OBJS)) tests/advanced_graph_algorithms/test_edmonds_karp.c
 	@$(call MKDIR_P,$(TEST_DIR))
 	$(CC) $(CFLAGS) $^ -o $@ $(LDFLAGS)
 
 test_dinic: $(TEST_DIR)/test_dinic$(EXE)
 	$(TEST_DIR)/test_dinic$(EXE)
-$(TEST_DIR)/test_dinic$(EXE): $(filter-out $(OBJ_DIR)/src/graph_traversals/dinic.o,$(OBJS)) tests/graph_traversals/test_dinic.c
+$(TEST_DIR)/test_dinic$(EXE): $(filter-out $(OBJ_DIR)/src/advanced_graph_algorithms/dinic.o,$(OBJS)) tests/advanced_graph_algorithms/test_dinic.c
 	@$(call MKDIR_P,$(TEST_DIR))
 	$(CC) $(CFLAGS) $^ -o $@ $(LDFLAGS)
 
 test_bipartite_matching: $(TEST_DIR)/test_bipartite_matching$(EXE)
 	$(TEST_DIR)/test_bipartite_matching$(EXE)
-$(TEST_DIR)/test_bipartite_matching$(EXE): $(filter-out $(OBJ_DIR)/src/graph_traversals/bipartite_matching.o,$(OBJS)) tests/graph_traversals/test_bipartite_matching.c
+$(TEST_DIR)/test_bipartite_matching$(EXE): $(filter-out $(OBJ_DIR)/src/advanced_graph_algorithms/bipartite_matching.o,$(OBJS)) tests/advanced_graph_algorithms/test_bipartite_matching.c
 	@$(call MKDIR_P,$(TEST_DIR))
 	$(CC) $(CFLAGS) $^ -o $@ $(LDFLAGS)
 
 test_hopcroft_karp: $(TEST_DIR)/test_hopcroft_karp$(EXE)
 	$(TEST_DIR)/test_hopcroft_karp$(EXE)
-$(TEST_DIR)/test_hopcroft_karp$(EXE): $(filter-out $(OBJ_DIR)/src/graph_traversals/hopcroft_karp.o,$(OBJS)) tests/graph_traversals/test_hopcroft_karp.c
+$(TEST_DIR)/test_hopcroft_karp$(EXE): $(filter-out $(OBJ_DIR)/src/advanced_graph_algorithms/hopcroft_karp.o,$(OBJS)) tests/advanced_graph_algorithms/test_hopcroft_karp.c
 	@$(call MKDIR_P,$(TEST_DIR))
 	$(CC) $(CFLAGS) $^ -o $@ $(LDFLAGS)
 
 test_eulerian_path: $(TEST_DIR)/test_eulerian_path$(EXE)
 	$(TEST_DIR)/test_eulerian_path$(EXE)
-$(TEST_DIR)/test_eulerian_path$(EXE): $(filter-out $(OBJ_DIR)/src/graph_traversals/eulerian_path.o,$(OBJS)) tests/graph_traversals/test_eulerian_path.c
+$(TEST_DIR)/test_eulerian_path$(EXE): $(filter-out $(OBJ_DIR)/src/advanced_graph_algorithms/eulerian_path.o,$(OBJS)) tests/advanced_graph_algorithms/test_eulerian_path.c
 	@$(call MKDIR_P,$(TEST_DIR))
 	$(CC) $(CFLAGS) $^ -o $@ $(LDFLAGS)
 

--- a/benchmark/benchmark_flow.c
+++ b/benchmark/benchmark_flow.c
@@ -1,4 +1,5 @@
 #define _GNU_SOURCE
+#include "advanced_graph_algorithms.h"
 #include "benchmark.h"
 #include "graph_traversals.h"
 #include <stdio.h>

--- a/src/advanced_graph_algorithms/advanced_graph_algorithms.h
+++ b/src/advanced_graph_algorithms/advanced_graph_algorithms.h
@@ -1,0 +1,31 @@
+#ifndef ADVANCED_GRAPH_ALGORITHMS_H
+#define ADVANCED_GRAPH_ALGORITHMS_H
+
+#include "graph_traversals.h"
+#include <stdbool.h>
+
+// ------------------For Strongly Connected Components (SCC)-----------------
+Graph* transpose_graph(Graph* graph);
+int** find_scc_tarjan(Graph* graph, int* scc_count, int** scc_sizes);
+int** find_scc_kosaraju(Graph* graph, int* scc_count, int** scc_sizes);
+void free_scc_result(int** sccs, int* scc_sizes, int scc_count);
+void scc_demo(void);
+
+// ------------------For Maximum Flow-----------------------------------------
+int ford_fulkerson(weightedGraph* graph, int source, int sink);
+int edmonds_karp(weightedGraph* graph, int source, int sink);
+int dinic(weightedGraph* graph, int source, int sink);
+void max_flow_demo(void);
+bool bipartite_color(Graph* graph, int* color);
+
+// ------------------For Bipartite Matching-----------------------------------
+int max_bipartite_matching(Graph* graph, int** match_pairs, int* match_count);
+int hopcroft_karp(Graph* graph, int** match_pairs, int* match_count);
+
+// ------------------For Eulerian Path----------------------------------------
+int find_eulerian_path(Graph* graph, int** path, int* path_len);
+
+void bipartite_matching_demo(void);
+void eulerian_path_demo(void);
+
+#endif

--- a/src/advanced_graph_algorithms/bipartite_matching.c
+++ b/src/advanced_graph_algorithms/bipartite_matching.c
@@ -1,4 +1,4 @@
-#include "graph_traversals.h"
+#include "advanced_graph_algorithms.h"
 #include <limits.h>
 #include <stdlib.h>
 #include <string.h>

--- a/src/advanced_graph_algorithms/dinic.c
+++ b/src/advanced_graph_algorithms/dinic.c
@@ -1,4 +1,4 @@
-#include "graph_traversals.h"
+#include "advanced_graph_algorithms.h"
 #include <limits.h>
 #include <stdlib.h>
 #include <string.h>

--- a/src/advanced_graph_algorithms/edmonds_karp.c
+++ b/src/advanced_graph_algorithms/edmonds_karp.c
@@ -1,4 +1,4 @@
-#include "graph_traversals.h"
+#include "advanced_graph_algorithms.h"
 #include <limits.h>
 #include <stdlib.h>
 #include <string.h>

--- a/src/advanced_graph_algorithms/eulerian_path.c
+++ b/src/advanced_graph_algorithms/eulerian_path.c
@@ -1,4 +1,4 @@
-#include "graph_traversals.h"
+#include "advanced_graph_algorithms.h"
 #include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>

--- a/src/advanced_graph_algorithms/ford_fulkerson.c
+++ b/src/advanced_graph_algorithms/ford_fulkerson.c
@@ -1,4 +1,4 @@
-#include "graph_traversals.h"
+#include "advanced_graph_algorithms.h"
 #include <limits.h>
 #include <stdlib.h>
 #include <string.h>

--- a/src/advanced_graph_algorithms/ford_fulkerson_visualize.c
+++ b/src/advanced_graph_algorithms/ford_fulkerson_visualize.c
@@ -1,6 +1,6 @@
 #include "clear_screen.h"
 #include "config.h"
-#include "graph_traversals.h"
+#include "advanced_graph_algorithms.h"
 #include "safe_input.h"
 #include <limits.h>
 #include <stdio.h>

--- a/src/advanced_graph_algorithms/ford_fulkerson_visualize.c
+++ b/src/advanced_graph_algorithms/ford_fulkerson_visualize.c
@@ -1,6 +1,6 @@
+#include "advanced_graph_algorithms.h"
 #include "clear_screen.h"
 #include "config.h"
-#include "advanced_graph_algorithms.h"
 #include "safe_input.h"
 #include <limits.h>
 #include <stdio.h>

--- a/src/advanced_graph_algorithms/hopcroft_karp.c
+++ b/src/advanced_graph_algorithms/hopcroft_karp.c
@@ -1,4 +1,4 @@
-#include "graph_traversals.h"
+#include "advanced_graph_algorithms.h"
 #include <limits.h>
 #include <stdlib.h>
 #include <string.h>

--- a/src/advanced_graph_algorithms/scc.c
+++ b/src/advanced_graph_algorithms/scc.c
@@ -1,4 +1,4 @@
-#include "graph_traversals.h"
+#include "advanced_graph_algorithms.h"
 #include <stdlib.h>
 #include <string.h>
 

--- a/src/advanced_graph_algorithms/scc_visualize.c
+++ b/src/advanced_graph_algorithms/scc_visualize.c
@@ -1,6 +1,6 @@
 #include "clear_screen.h"
 #include "config.h"
-#include "graph_traversals.h"
+#include "advanced_graph_algorithms.h"
 #include "safe_input.h"
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/advanced_graph_algorithms/scc_visualize.c
+++ b/src/advanced_graph_algorithms/scc_visualize.c
@@ -1,6 +1,6 @@
+#include "advanced_graph_algorithms.h"
 #include "clear_screen.h"
 #include "config.h"
-#include "advanced_graph_algorithms.h"
 #include "safe_input.h"
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/graph_traversals/graph_traversals.h
+++ b/src/graph_traversals/graph_traversals.h
@@ -114,27 +114,4 @@ void prim_demo(void);
 weightedGraph* load_weightedGraph_from_csv(const char* path);
 weightedGraph* load_weightedGraph_with_heuristic_from_csv(const char* path, int** out_h);
 Graph* load_graph_from_csv(const char* path);
-
-// ------------------For Strongly Connected Components (SCC)-----------------
-Graph* transpose_graph(Graph* graph);
-int** find_scc_tarjan(Graph* graph, int* scc_count, int** scc_sizes);
-int** find_scc_kosaraju(Graph* graph, int* scc_count, int** scc_sizes);
-void free_scc_result(int** sccs, int* scc_sizes, int scc_count);
-void scc_demo(void);
-// ------------------For Maximum Flow-----------------------------------------
-int ford_fulkerson(weightedGraph* graph, int source, int sink);
-int edmonds_karp(weightedGraph* graph, int source, int sink);
-int dinic(weightedGraph* graph, int source, int sink);
-void max_flow_demo(void);
-bool bipartite_color(Graph* graph, int* color);
-// ------------------For Bipartite Matching-----------------------------------
-int max_bipartite_matching(Graph* graph, int** match_pairs, int* match_count);
-int hopcroft_karp(Graph* graph, int** match_pairs, int* match_count);
-
-// ------------------For Eulerian Path----------------------------------------
-int find_eulerian_path(Graph* graph, int** path, int* path_len);
-
-void bipartite_matching_demo(void);
-void eulerian_path_demo(void);
-
 #endif

--- a/src/graph_traversals/graph_traversals_demo.c
+++ b/src/graph_traversals/graph_traversals_demo.c
@@ -1,3 +1,4 @@
+#include "advanced_graph_algorithms.h"
 #include "display_header.h"
 #include "graph_traversals.h"
 #include "safe_input.h"

--- a/tests/advanced_graph_algorithms/test_bipartite_matching.c
+++ b/tests/advanced_graph_algorithms/test_bipartite_matching.c
@@ -1,5 +1,5 @@
-#include "../../src/graph_traversals/bipartite_matching.c"
-#include "graph_traversals.h"
+#include "../../src/advanced_graph_algorithms/bipartite_matching.c"
+#include "advanced_graph_algorithms.h"
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/tests/advanced_graph_algorithms/test_dinic.c
+++ b/tests/advanced_graph_algorithms/test_dinic.c
@@ -1,13 +1,13 @@
-#include "../../src/graph_traversals/edmonds_karp.c"
-#include "graph_traversals.h"
+#include "../../src/advanced_graph_algorithms/dinic.c"
+#include "advanced_graph_algorithms.h"
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
-void test_ek_simple()
+void test_dinic_simple()
 {
-    printf("Running test_ek_simple...\n");
+    printf("Running test_dinic_simple...\n");
     weightedGraph* g = create_weightedGraph(4);
     add_edge_directed(g, 0, 1, 3);
     add_edge_directed(g, 0, 2, 2);
@@ -15,16 +15,16 @@ void test_ek_simple()
     add_edge_directed(g, 2, 3, 3);
     add_edge_directed(g, 1, 2, 1);
 
-    int flow = edmonds_karp(g, 0, 3);
+    int flow = dinic(g, 0, 3);
     assert(flow == 5);
 
     free_weightedGraph(g);
-    printf("test_ek_simple passed.\n");
+    printf("test_dinic_simple passed.\n");
 }
 
 int main()
 {
-    test_ek_simple();
-    printf("All Edmonds-Karp Tests Passed!\n");
+    test_dinic_simple();
+    printf("All Dinic Tests Passed!\n");
     return 0;
 }

--- a/tests/advanced_graph_algorithms/test_edmonds_karp.c
+++ b/tests/advanced_graph_algorithms/test_edmonds_karp.c
@@ -1,13 +1,13 @@
-#include "../../src/graph_traversals/ford_fulkerson.c"
-#include "graph_traversals.h"
+#include "../../src/advanced_graph_algorithms/edmonds_karp.c"
+#include "advanced_graph_algorithms.h"
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
-void test_ff_simple()
+void test_ek_simple()
 {
-    printf("Running test_ff_simple...\n");
+    printf("Running test_ek_simple...\n");
     weightedGraph* g = create_weightedGraph(4);
     add_edge_directed(g, 0, 1, 3);
     add_edge_directed(g, 0, 2, 2);
@@ -15,16 +15,16 @@ void test_ff_simple()
     add_edge_directed(g, 2, 3, 3);
     add_edge_directed(g, 1, 2, 1);
 
-    int flow = ford_fulkerson(g, 0, 3);
+    int flow = edmonds_karp(g, 0, 3);
     assert(flow == 5);
 
     free_weightedGraph(g);
-    printf("test_ff_simple passed.\n");
+    printf("test_ek_simple passed.\n");
 }
 
 int main()
 {
-    test_ff_simple();
-    printf("All Ford-Fulkerson Tests Passed!\n");
+    test_ek_simple();
+    printf("All Edmonds-Karp Tests Passed!\n");
     return 0;
 }

--- a/tests/advanced_graph_algorithms/test_eulerian_path.c
+++ b/tests/advanced_graph_algorithms/test_eulerian_path.c
@@ -1,5 +1,5 @@
-#include "../../src/graph_traversals/eulerian_path.c"
-#include "graph_traversals.h"
+#include "../../src/advanced_graph_algorithms/eulerian_path.c"
+#include "advanced_graph_algorithms.h"
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/tests/advanced_graph_algorithms/test_ford_fulkerson.c
+++ b/tests/advanced_graph_algorithms/test_ford_fulkerson.c
@@ -1,13 +1,13 @@
-#include "../../src/graph_traversals/dinic.c"
-#include "graph_traversals.h"
+#include "../../src/advanced_graph_algorithms/ford_fulkerson.c"
+#include "advanced_graph_algorithms.h"
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
-void test_dinic_simple()
+void test_ff_simple()
 {
-    printf("Running test_dinic_simple...\n");
+    printf("Running test_ff_simple...\n");
     weightedGraph* g = create_weightedGraph(4);
     add_edge_directed(g, 0, 1, 3);
     add_edge_directed(g, 0, 2, 2);
@@ -15,16 +15,16 @@ void test_dinic_simple()
     add_edge_directed(g, 2, 3, 3);
     add_edge_directed(g, 1, 2, 1);
 
-    int flow = dinic(g, 0, 3);
+    int flow = ford_fulkerson(g, 0, 3);
     assert(flow == 5);
 
     free_weightedGraph(g);
-    printf("test_dinic_simple passed.\n");
+    printf("test_ff_simple passed.\n");
 }
 
 int main()
 {
-    test_dinic_simple();
-    printf("All Dinic Tests Passed!\n");
+    test_ff_simple();
+    printf("All Ford-Fulkerson Tests Passed!\n");
     return 0;
 }

--- a/tests/advanced_graph_algorithms/test_hopcroft_karp.c
+++ b/tests/advanced_graph_algorithms/test_hopcroft_karp.c
@@ -1,5 +1,5 @@
-#include "../../src/graph_traversals/hopcroft_karp.c"
-#include "graph_traversals.h"
+#include "../../src/advanced_graph_algorithms/hopcroft_karp.c"
+#include "advanced_graph_algorithms.h"
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/tests/advanced_graph_algorithms/test_scc.c
+++ b/tests/advanced_graph_algorithms/test_scc.c
@@ -1,5 +1,5 @@
-#include "../../src/graph_traversals/scc.c"
-#include "graph_traversals.h"
+#include "../../src/advanced_graph_algorithms/scc.c"
+#include "advanced_graph_algorithms.h"
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>


### PR DESCRIPTION
This PR refactors the directory structure to reduce clutter in the `src/graph_traversals/` module:
- Relocates all network flow, bipartite matching, Eulerian paths, and strongly connected components (SCC) source files to `src/advanced_graph_algorithms/`.
- Declares their interfaces in a new header file `src/advanced_graph_algorithms/advanced_graph_algorithms.h`.
- Relocates corresponding test files to `tests/advanced_graph_algorithms/`.
- Updates references and include paths in the `Makefile` and `CMakeLists.txt`.

Resolves #588 