### PR TITLE
fix(radix): add malloc NULL check in counting_sort

### DIFF
--- a/src/advanced_sorting_algorithms/radix_sort.c
+++ b/src/advanced_sorting_algorithms/radix_sort.c
@@ -22,6 +22,10 @@ static int get_max(int arr[], int n)
 static void counting_sort(int arr[], int n, int exp)
 {
     int* output = malloc(sizeof(int) * n);
+    if (output == NULL)
+    {
+        return;
+    }
     int count[10] = {0};
 
     for (int i = 0; i < n; i++)


### PR DESCRIPTION
This PR adds a safety verification step on the dynamic array allocated inside `counting_sort`. 

### Changes:
- Checked that the `output` pointer returned by `malloc` is not `NULL` before proceeding to write values to it in `src/advanced_sorting_algorithms/radix_sort.c`.
- Prevents potential Null Pointer Dereferences under memory exhaustion.

Fixes: #590