### PR TITLE
fix(postfix): validate operands with isdigit instead of isalnum

### DIFF
--- a/src/expression_evaluation/safe_input_postfix.c
+++ b/src/expression_evaluation/safe_input_postfix.c
@@ -42,7 +42,7 @@ int validate_postfix_expr(char* buff, size_t size, const char* prompt)
     while (buff[i] != '\0')
     { // main loop which validates the string character by character
         unsigned char c = buff[i];
-        if (isalnum(c))
+        if (isdigit(c))
             depth++;
         else if (c == '+' || c == '-' || c == '*' || c == '/')
         {


### PR DESCRIPTION
This PR resolves an input discrepancy between the expression validator and the postfix evaluator.

### Changes:
- Replaced `isalnum(c)` with `isdigit(c)` in the validation function in `src/expression_evaluation/safe_input_postfix.c`.
- Alphabetic characters (which cause silent evaluator skips and stack underflows) are now properly rejected during input validation.

Fixes: #590