### PR TITLE
fix(fcfs): replace unstable selection sort with stable insertion sort

### DIFF
--- a/src/job_scheduling/fcfs.c
+++ b/src/job_scheduling/fcfs.c
@@ -26,25 +26,17 @@ void fcfs_demo(void)
 
     start_t = clock();
 
-    // selection-style ordering by arrival time, keeping input order on ties
-    for (int i = 0; i < n - 1; i++)
+    // Stable insertion sort to keep input order on ties
+    for (int i = 1; i < n; i++)
     {
-        int earliest = i;
-
-        for (int j = i + 1; j < n; j++)
+        Process key = procs[i];
+        int j = i - 1;
+        while (j >= 0 && procs[j].arrival > key.arrival)
         {
-            if (procs[j].arrival < procs[earliest].arrival)
-            {
-                earliest = j;
-            }
+            procs[j + 1] = procs[j];
+            j = j - 1;
         }
-
-        if (earliest != i)
-        {
-            Process tmp = procs[i];
-            procs[i] = procs[earliest];
-            procs[earliest] = tmp;
-        }
+        procs[j + 1] = key;
     }
 
     GanttSegment segments[JS_MAX_SEGMENTS];


### PR DESCRIPTION
This PR replaces the selection sort logic used to order jobs in the First-Come-First-Served scheduler.

### Changes:
- Replaced the unstable selection sort in `src/job_scheduling/fcfs.c` with a stable **Insertion Sort**.
- Ensures that when processes share identical arrival times, they are executed in their original input order as per the FCFS specification.

Fixes: #590