### PR TITLE
fix(scheduling): add segment logger boundary check

### DIFF
--- a/src/job_scheduling/job_scheduling_demo.c
+++ b/src/job_scheduling/job_scheduling_demo.c
@@ -124,6 +124,11 @@ void js_add_segment(GanttSegment* segments, int* count, int id, int time)
         return;
     }
 
+    if (*count >= JS_MAX_SEGMENTS)
+    {
+        return;
+    }
+
     segments[*count].id = id;
     segments[*count].start = time;
     segments[*count].end = time + 1;


### PR DESCRIPTION
This PR adds safety checks to the Gantt Chart segment collector.

### Changes:
- Added a bound check `if (*count >= JS_MAX_SEGMENTS)` inside `js_add_segment` in `src/job_scheduling/job_scheduling_demo.c`.
- Prevents out-of-bounds writes on the fixed-size segments logging buffer on processes with extremely large arrival times.

Fixes: #590