### PR TITLE
fix(lrc): validate fgets return value to avoid UB on stack buffer

### DIFF
--- a/src/error_correction_algorithms/lrc.c
+++ b/src/error_correction_algorithms/lrc.c
@@ -40,7 +40,11 @@ void lrc_demo(void)
     {
         // Fix 2: Use fgets() instead of scanf() for strings
         printf("  Word %d: ", i + 1);
-        fgets(data[i], sizeof(data[i]), stdin);
+        if (fgets(data[i], sizeof(data[i]), stdin) == NULL)
+        {
+            printf("Error reading input.\n");
+            return;
+        }
 
         // Remove trailing newline; if absent, input exceeded buffer — flush stdin
         int len = strlen(data[i]);

--- a/src/error_correction_algorithms/lrc_receiver.c
+++ b/src/error_correction_algorithms/lrc_receiver.c
@@ -36,7 +36,11 @@ void lrc_receiver_demo(void)
     {
         printf("  Word %d: ", i + 1);
 
-        fgets(data[i], sizeof(data[i]), stdin);
+        if (fgets(data[i], sizeof(data[i]), stdin) == NULL)
+        {
+            printf("Error reading input.\n");
+            return;
+        }
 
         int len = (int)strlen(data[i]);
 
@@ -82,7 +86,11 @@ void lrc_receiver_demo(void)
 
     printf("Enter received LRC: ");
 
-    fgets(received_lrc, sizeof(received_lrc), stdin);
+    if (fgets(received_lrc, sizeof(received_lrc), stdin) == NULL)
+    {
+        printf("Error reading input.\n");
+        return;
+    }
 
     int lrc_len = (int)strlen(received_lrc);
 


### PR DESCRIPTION
This PR validates stream reads in the Longitudinal Redundancy Check demos.

### Changes:
- Verified that `fgets` does not return `NULL` before performing `strlen` on row inputs and checksum prompts in `src/error_correction_algorithms/lrc.c` and `src/error_correction_algorithms/lrc_receiver.c`.
- Avoids reading uninitialized stack data and crashing when hitting EOF.

Fixes: #590