### PR TITLE
fix(kmp): check match_count bounds to avoid stack overflow

### DIFF
--- a/src/string_algorithms/kmp.c
+++ b/src/string_algorithms/kmp.c
@@ -173,7 +173,10 @@ void kmp_visualization(char* text, char* pattern)
 
         if (j == m)
         {
-            matches[match_count++] = i - j;
+            if (match_count < 100)
+            {
+                matches[match_count++] = i - j;
+            }
             printf("Pattern found at index %d\n", i - j);
             printf("LPS Jump      : j = lps[%d] = %d\n", j - 1, lps[j - 1]);
             found++;


### PR DESCRIPTION
This PR adds safety guards to prevent stack corruption inside KMP visualization.

### Changes:
- Added a bounds check to verify that `match_count < 100` before writing to the matches list in `src/string_algorithms/kmp.c`.
- Protects the stack frame from buffer overflow when processing large texts containing more than 100 pattern occurrences.

Fixes: #590