### PR TITLE
fix(stack): add NULL check to destroyStack to avoid dereference crash

### DIFF
--- a/src/data_structures/stack.c
+++ b/src/data_structures/stack.c
@@ -36,6 +36,8 @@ int isEmpty(const stack* s)
 
 void destroyStack(stack* s)
 {
+    if (s == NULL)
+        return;
     while (!isEmpty(s))
     {
         pop(s);


### PR DESCRIPTION
This PR adds robustness to stack garbage collection routines.

### Changes:
- Added a check `if (s == NULL) return;` at the start of `destroyStack` in `src/data_structures/stack.c`.
- Safely handles destruction of uninitialized stacks during program failures without triggering null pointer crashes.

Fixes: #590