### PR TITLE
fix(queue): check queue_ptr before dereferencing in destroy_simple_queue

### DIFF
--- a/src/data_structures/simple_queue.c
+++ b/src/data_structures/simple_queue.c
@@ -141,7 +141,7 @@ int init_simple_queue(int N, Queue* queue_ptr)
 
 void destroy_simple_queue(Queue* queue_ptr)
 {
-    if (queue_ptr->arr == NULL)
+    if (queue_ptr == NULL || queue_ptr->arr == NULL)
         return;
 
     if (queue_ptr->front != -1)


### PR DESCRIPTION
This PR fixes simple queue cleanup procedures.

### Changes:
- Added `if (queue_ptr == NULL || queue_ptr->arr == NULL)` at the start of `destroy_simple_queue` in `src/data_structures/simple_queue.c`.
- Ensures passing `NULL` to the cleanup routine returns early instead of dereferencing a NULL pointer.

Fixes: #590