### PR TITLE
refactor: relocate Segment Tree to the trees module and update demo menus

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -317,7 +317,7 @@ $(TEST_DIR)/test_deque$(EXE): $(OBJ_DIR)/src/data_structures/deque.o $(OBJ_DIR)/
 test_segment_tree: $(TEST_DIR)/test_segment_tree$(EXE)
 	$(TEST_DIR)/test_segment_tree$(EXE)
 
-$(TEST_DIR)/test_segment_tree$(EXE): $(OBJ_DIR)/src/data_structures/segment_tree.o $(OBJ_DIR)/src/utils/safe_input_int.o tests/data_structures/test_segment_tree.c
+$(TEST_DIR)/test_segment_tree$(EXE): $(OBJ_DIR)/src/trees/segment_tree.o $(OBJ_DIR)/src/utils/safe_input_int.o tests/trees/test_segment_tree.c
 	@$(call MKDIR_P,$(TEST_DIR))
 	$(CC) $(CFLAGS) $^ -o $@ $(LDFLAGS)
 

--- a/src/data_structures/data_structures.h
+++ b/src/data_structures/data_structures.h
@@ -189,28 +189,6 @@ int dcll_getLength(const dcll* list);
 void dcll_printlist(const dcll* list);
 void dcll_destroy(dcll* list);
 void dcll_demo(void);
-// ==========================================
-// Segment Tree (Dynamic Implementation)
-// ==========================================
-
-typedef struct
-{
-    int* tree;
-    int size;
-    int original_array_size;
-} SegmentTree;
-
-SegmentTree* create_segment_tree(int arr[], int n);
-void destroy_segment_tree(SegmentTree* st);
-void build_tree(SegmentTree* st, int arr[], int node, int start, int end);
-void update_point(SegmentTree* st, int node, int start, int end, int idx, int val);
-int query_range(SegmentTree* st, int node, int start, int end, int l, int r);
-
-void preorder_traversal(SegmentTree* st, int node, int start, int end);
-void inorder_traversal(SegmentTree* st, int node, int start, int end);
-void postorder_traversal(SegmentTree* st, int node, int start, int end);
-void segment_tree_demo(void);
-
 // For Stack
 typedef struct stack
 {

--- a/src/data_structures/data_structures_demo.c
+++ b/src/data_structures/data_structures_demo.c
@@ -12,9 +12,8 @@ void data_structures_demo(void)
             safe_input_int(&data_structures_choice,
                            "\nenter 1 for standard linear data structures"
                            "\nenter 2 for circular variants of linear data structures"
-                           "\nenter 3 for segment tree demo"
                            "\nenter choice : ",
-                           1, 3);
+                           1, 2);
 
         if (data_structures_status == INPUT_EXIT_SIGNAL)
         {
@@ -122,11 +121,6 @@ void data_structures_demo(void)
                     }
                 }
 
-                break;
-
-            case 3:
-                display_header("Segment Tree");
-                segment_tree_demo();
                 break;
         }
 

--- a/src/trees/segment_tree.c
+++ b/src/trees/segment_tree.c
@@ -1,6 +1,6 @@
 // Trigger build test
-#include "data_structures.h"
 #include "safe_input.h"
+#include "trees.h"
 #include <stdio.h>
 #include <stdlib.h>
 

--- a/src/trees/trees.h
+++ b/src/trees/trees.h
@@ -137,4 +137,23 @@ void bplus_tree_range_query(BPlusTree* tree, int lower, int upper);
 void bplus_tree_print(BPlusTree* tree);
 void bplus_tree_demo(void);
 
+// For Segment Tree (Dynamic Implementation)
+typedef struct
+{
+    int* tree;
+    int size;
+    int original_array_size;
+} SegmentTree;
+
+SegmentTree* create_segment_tree(int arr[], int n);
+void destroy_segment_tree(SegmentTree* st);
+void build_tree(SegmentTree* st, int arr[], int node, int start, int end);
+void update_point(SegmentTree* st, int node, int start, int end, int idx, int val);
+int query_range(SegmentTree* st, int node, int start, int end, int l, int r);
+
+void preorder_traversal(SegmentTree* st, int node, int start, int end);
+void inorder_traversal(SegmentTree* st, int node, int start, int end);
+void postorder_traversal(SegmentTree* st, int node, int start, int end);
+void segment_tree_demo(void);
+
 #endif

--- a/src/trees/trees_demo.c
+++ b/src/trees/trees_demo.c
@@ -16,8 +16,9 @@ void trees_demo(void)
                                      "\nenter 4 for Trie demo"
                                      "\nenter 5 for B-Tree demo"
                                      "\nenter 6 for B+ Tree demo"
+                                     "\nenter 7 for Segment Tree demo"
                                      "\nenter choice : ",
-                                     1, 6);
+                                     1, 7);
 
         if (tree_status == INPUT_EXIT_SIGNAL)
         {
@@ -58,6 +59,11 @@ void trees_demo(void)
             case 6:
                 display_header("B+ Tree");
                 bplus_tree_demo();
+                break;
+
+            case 7:
+                display_header("Segment Tree");
+                segment_tree_demo();
                 break;
         }
     }

--- a/tests/trees/test_segment_tree.c
+++ b/tests/trees/test_segment_tree.c
@@ -1,4 +1,4 @@
-#include "data_structures.h"
+#include "trees.h"
 #include <assert.h>
 #include <stdio.h>
 


### PR DESCRIPTION
## Summary
This PR relocates the Segment Tree implementation from the general `data_structures` module to the dedicated `trees` module to adhere to project conventions. 

## Changes Made
- **File Relocation**: 
  - Relocated `src/data_structures/segment_tree.c` to [src/trees/segment_tree.c](file:///e:/C-DSA-interactive-suite/src/trees/segment_tree.c).
  - Relocated `tests/data_structures/test_segment_tree.c` to [tests/trees/test_segment_tree.c](file:///e:/C-DSA-interactive-suite/tests/trees/test_segment_tree.c).
- **Header Refactoring**:
  - Shipped the `SegmentTree` struct and its function declarations from [data_structures.h](file:///e:/C-DSA-interactive-suite/src/data_structures/data_structures.h) to [trees.h](file:///e:/C-DSA-interactive-suite/src/trees/trees.h).
  - Updated include statements in the relocated segment tree and test files to refer to `"trees.h"`.
- **Demo Menu Adjustments**:
  - Removed the Segment Tree choice from [data_structures_demo.c](file:///e:/C-DSA-interactive-suite/src/data_structures/data_structures_demo.c) and adjusted selection limits to `(1, 2)`.
  - Added option `7` for the Segment Tree demo to the Trees module menu in [trees_demo.c](file:///e:/C-DSA-interactive-suite/src/trees/trees_demo.c) and adjusted selection limits to `(1, 7)`.
- **Build Update**:
  - Updated the path dependencies for building the Segment Tree test executable inside the [Makefile](file:///e:/C-DSA-interactive-suite/Makefile) to align with the new folder structures.

## Verification
- Verified compilation and test validation locally using `make test_segment_tree` and the full test suite `make test`. All tests passed successfully.

closes #586 