### PR TITLE
Call display_header() at the right location

### DIFF
--- a/benchmark/benchmark_demo.c
+++ b/benchmark/benchmark_demo.c
@@ -1,3 +1,4 @@
+#include "display_header.h"
 #include "benchmark.h"
 #include "safe_input.h"
 #include <stdio.h>
@@ -6,6 +7,8 @@ void benchmark_menu_demo(void)
 {
     while (1)
     {
+        display_header("Algorithm Benchmarking & Profiling");
+
         int choice;
         int status = safe_input_int(&choice,
                                     "\n--- Algorithm Benchmarking & Profiling Menu ---\n"

--- a/src/advanced_sorting_algorithms/advanced_sorting_demo.c
+++ b/src/advanced_sorting_algorithms/advanced_sorting_demo.c
@@ -10,6 +10,8 @@ void advanced_sorting_demo(void)
     while (1)
     {
 
+        display_header("Advanced Sorting Algorithms");
+
         printf("\nAdvanced sorting algorithms demo\n");
 
         sorting_algo_status =

--- a/src/backtracking/backtracking_demo.c
+++ b/src/backtracking/backtracking_demo.c
@@ -8,6 +8,8 @@ void backtracking_demo(void)
     int bt_status, bt_choice;
     while (1)
     {
+        display_header("Backtracking Algorithms");
+
         bt_status = safe_input_int(&bt_choice,
                                    "\n--- Backtracking Algorithms ---"
                                    "\nenter 1 for N-Queens problem"

--- a/src/data_structures/data_structures_demo.c
+++ b/src/data_structures/data_structures_demo.c
@@ -7,6 +7,8 @@ void data_structures_demo(void)
 {
     while (1)
     {
+        display_header("Data Structures");
+
         int data_structures_choice;
         int data_structures_status =
             safe_input_int(&data_structures_choice,

--- a/src/dynamic_programming/dynamic_programming_demo.c
+++ b/src/dynamic_programming/dynamic_programming_demo.c
@@ -8,6 +8,8 @@ void dynamic_programming_demo(void)
     int dp_status, dp_choice;
     while (1)
     {
+        display_header("Dynamic Programming Algorithms");
+
         dp_status = safe_input_int(&dp_choice,
                                    "\nenter 1 for 0/1 Knapsack demo"
                                    "\nenter 2 for Longest Common Subsequence (LCS) demo"

--- a/src/error_correction_algorithms/error_correction_algorithms_demo.c
+++ b/src/error_correction_algorithms/error_correction_algorithms_demo.c
@@ -9,6 +9,8 @@ void error_correction_algorithms_demo(void)
 {
     while (1)
     {
+        display_header("Error Correction Algorithms");
+
         int ECA_choice;
 
         /* Change the prompt and the range accordingly when new functions get added */

--- a/src/expression_evaluation/expression_evaluation_demo.c
+++ b/src/expression_evaluation/expression_evaluation_demo.c
@@ -9,6 +9,8 @@ void expression_evaluation_demo(void)
     int expr_eval_status;
     while (1)
     {
+        display_header("Expression Evaluation");
+
         expr_eval_status = safe_input_int(&expr_eval_choice,
                                           "\nenter 1 for infix to postfix conversion"
                                           "\nenter 2 for postfix evaluation"

--- a/src/graph_traversals/graph_traversals_demo.c
+++ b/src/graph_traversals/graph_traversals_demo.c
@@ -9,6 +9,8 @@ void graph_traversals_demo(void)
 {
     while (1)
     {
+        display_header("Graph Traversals");
+
         int graph_traversal_choice;
         int graph_traversal_status = safe_input_int(&graph_traversal_choice,
                                                     "\nGraph Algorithms Demo\n"

--- a/src/hashing/hashing_algorithms_demo.c
+++ b/src/hashing/hashing_algorithms_demo.c
@@ -7,6 +7,8 @@ void hashing_algorithms_demo(void)
 {
     while (1)
     {
+        display_header("Hashing Algorithms");
+
         int hash_algo_choice;
         int hash_algo_status = safe_input_int(&hash_algo_choice,
                                               "\n\nenter 1 for linear probing, 2 for separate "

--- a/src/job_scheduling/job_scheduling_demo.c
+++ b/src/job_scheduling/job_scheduling_demo.c
@@ -172,6 +172,8 @@ void job_scheduling_demo(void)
 {
     while (1)
     {
+        display_header("Job Scheduling");
+
         int sched_choice;
         int sched_status =
             safe_input_int(&sched_choice,

--- a/src/main.c
+++ b/src/main.c
@@ -69,59 +69,45 @@ void run_legacy_menu()
         switch (choice)
         {
             case 1:
-                display_header("Data Structures");
                 data_structures_demo();
                 break;
             case 2:
-                display_header("Expression Evaluation");
                 expression_evaluation_demo();
                 break;
             case 3:
-                display_header("Sorting Algorithms (n^2)");
                 sorting_algorithms_n2_demo();
                 break;
             case 4:
-                display_header("Advanced Sorting Algorithms");
                 advanced_sorting_demo();
                 break;
             case 5:
-                display_header("Searching Algorithms");
                 searching_algorithms_demo();
                 break;
             case 6:
-                display_header("Graph Traversals");
                 graph_traversals_demo();
                 break;
             case 7:
-                display_header("Hashing Algorithms");
                 hashing_algorithms_demo();
                 break;
             case 8:
-                display_header("Trees");
                 trees_demo();
                 break;
             case 9:
-                display_header("Error Correction Algorithms");
                 error_correction_algorithms_demo();
                 break;
             case 10:
-                display_header("Job Scheduling");
                 job_scheduling_demo();
                 break;
             case 11:
-                display_header("Backtracking Algorithms");
                 backtracking_demo();
                 break;
             case 12:
-                display_header("Dynamic Programming Algorithms");
                 dynamic_programming_demo();
                 break;
             case 13:
-                display_header("String Algorithms");
                 string_algorithms_demo();
                 break;
             case 14:
-                display_header("Process Synchronization");
                 process_synchronization_demo();
                 break;
             case 15:

--- a/src/process_synchronization/process_synchronization_demo.c
+++ b/src/process_synchronization/process_synchronization_demo.c
@@ -6,6 +6,8 @@ void process_synchronization_demo(void)
 {
     while (1)
     {
+        display_header("Process Synchronization");
+
         int choice;
         int status = safe_input_int(&choice,
                                     "\n\n--- Process Synchronization Demos ---\n"

--- a/src/searching_algorithms/searching_algorithms_demo.c
+++ b/src/searching_algorithms/searching_algorithms_demo.c
@@ -8,6 +8,8 @@ void searching_algorithms_demo(void)
     int searching_algo_status, searching_algo_choice;
     while (1)
     {
+        display_header("Searching Algorithms");
+
         searching_algo_status = safe_input_int(&searching_algo_choice,
                                                "\nenter 1 for linear search demo"
                                                "\nenter 2 for binary search"

--- a/src/sorting_algorithms_n2/sorting_algorithms_n2_demo.c
+++ b/src/sorting_algorithms_n2/sorting_algorithms_n2_demo.c
@@ -8,6 +8,8 @@ void sorting_algorithms_n2_demo(void)
     int sorting_algo_status, sorting_algo_choice;
     while (1)
     {
+        display_header("Sorting Algorithms (n^2)");
+
         sorting_algo_status = safe_input_int(&sorting_algo_choice,
                                              "\nenter 1 for bubble sort"
                                              "\nenter 2 for insertion sort"

--- a/src/string_algorithms/string_algorithms_demo.c
+++ b/src/string_algorithms/string_algorithms_demo.c
@@ -8,6 +8,8 @@ void string_algorithms_demo(void)
     int status, choice;
     while (1)
     {
+        display_header("String Algorithms");
+
         status = safe_input_int(&choice,
                                 "\nenter 1 for Naive String Matching demo"
                                 "\nenter 2 for Knuth-Morris-Pratt (KMP) demo"

--- a/src/trees/trees_demo.c
+++ b/src/trees/trees_demo.c
@@ -9,6 +9,8 @@ void trees_demo(void)
 
     while (1)
     {
+        display_header("Trees");
+
         tree_status = safe_input_int(&tree_choice,
                                      "\nenter 1 for Binary Search Tree demo"
                                      "\nenter 2 for AVL Tree demo"


### PR DESCRIPTION
## Summary
This PR fixes the placement of `display_header()` by moving its invocation to the beginning of each module demo loop.

## Changes
- Added `display_header()` at the start of each module demo loop.
- Ensures the header is displayed every time the user returns to the module menu.
- Improves the user experience by keeping the interface consistent across modules.

## Testing
- Verified that the header appears when entering a module.
- Verified that after exiting a demo with `-1`, the header is displayed again when returning to the module menu.

Closes #587