### PR TITLE
feat(heap): implement Binomial Heap and unit tests (PR 1)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,7 @@ set(SRC_DIRS
     src/searching_algorithms
     src/graph_traversals
     src/advanced_graph_algorithms
+    src/advanced_heaps
     src/hashing
     src/utils
     src/trees

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ CFLAGS = -Wall -Wextra -Werror -std=c11 -g \
 	-Isrc/searching_algorithms \
 	-Isrc/graph_traversals \
 	-Isrc/advanced_graph_algorithms \
+	-Isrc/advanced_heaps \
 	-Isrc/hashing \
 	-Isrc/utils \
 	-Isrc/trees \
@@ -35,6 +36,7 @@ SRC_DIRS = \
 	src/searching_algorithms \
 	src/graph_traversals \
 	src/advanced_graph_algorithms \
+	src/advanced_heaps \
 	src/hashing \
 	src/utils \
 	src/trees \
@@ -122,7 +124,7 @@ TEST_BINS = test_circ_queue test_bst test_search test_hash_func \
             test_string_algorithms test_expression_evaluation \
             test_fcfs test_sjf test_srtf test_round_robin test_priority_scheduling test_preemptive_priority \
             test_dining_philosophers test_petersons test_producer_consumer \
-            test_dijkstra test_bellman_ford test_bfs test_dfs test_topological_sort test_benchmark test_scc test_ford_fulkerson test_edmonds_karp test_dinic test_bipartite_matching test_hopcroft_karp test_eulerian_path
+            test_dijkstra test_bellman_ford test_bfs test_dfs test_topological_sort test_benchmark test_scc test_ford_fulkerson test_edmonds_karp test_dinic test_bipartite_matching test_hopcroft_karp test_eulerian_path test_binomial_heap
 
 ifneq ($(wildcard tests/benchmark/test_benchmark_sorting.c),)
 TEST_BINS += test_benchmark_sorting
@@ -662,6 +664,12 @@ $(TEST_DIR)/test_hopcroft_karp$(EXE): $(filter-out $(OBJ_DIR)/src/advanced_graph
 test_eulerian_path: $(TEST_DIR)/test_eulerian_path$(EXE)
 	$(TEST_DIR)/test_eulerian_path$(EXE)
 $(TEST_DIR)/test_eulerian_path$(EXE): $(filter-out $(OBJ_DIR)/src/advanced_graph_algorithms/eulerian_path.o,$(OBJS)) tests/advanced_graph_algorithms/test_eulerian_path.c
+	@$(call MKDIR_P,$(TEST_DIR))
+	$(CC) $(CFLAGS) $^ -o $@ $(LDFLAGS)
+
+test_binomial_heap: $(TEST_DIR)/test_binomial_heap$(EXE)
+	$(TEST_DIR)/test_binomial_heap$(EXE)
+$(TEST_DIR)/test_binomial_heap$(EXE): $(OBJS) tests/advanced_heaps/test_binomial_heap.c
 	@$(call MKDIR_P,$(TEST_DIR))
 	$(CC) $(CFLAGS) $^ -o $@ $(LDFLAGS)
 

--- a/src/advanced_heaps/advanced_heaps.h
+++ b/src/advanced_heaps/advanced_heaps.h
@@ -1,0 +1,35 @@
+#ifndef ADVANCED_HEAPS_H
+#define ADVANCED_HEAPS_H
+
+#include <stdbool.h>
+
+/*
+ * =========================================================================
+ *                              Binomial Heap
+ * =========================================================================
+ */
+
+typedef struct BinomialNode
+{
+    int key;
+    int value;
+    int degree;
+    struct BinomialNode* parent;
+    struct BinomialNode* child;
+    struct BinomialNode* sibling;
+} BinomialNode;
+
+/* Constructor & Destructor */
+BinomialNode* create_binomial_node(int key, int value);
+void destroy_binomial_heap(BinomialNode* head);
+
+/* Core Heap Operations */
+BinomialNode* binomial_heap_insert(BinomialNode* head, int key, int value);
+BinomialNode* binomial_heap_merge(BinomialNode* head1, BinomialNode* head2);
+BinomialNode* binomial_heap_extract_min(BinomialNode* head, int* min_key, int* min_val);
+BinomialNode* binomial_heap_decrease_key(BinomialNode* head, BinomialNode* target, int new_key);
+
+/* Search / Utility Helpers */
+BinomialNode* binomial_heap_find_node(BinomialNode* head, int key);
+
+#endif /* ADVANCED_HEAPS_H */

--- a/src/advanced_heaps/binomial_heap.c
+++ b/src/advanced_heaps/binomial_heap.c
@@ -1,0 +1,268 @@
+#include "advanced_heaps.h"
+#include <stdio.h>
+#include <stdlib.h>
+
+/* Creates a single binomial node with the given key and value */
+BinomialNode* create_binomial_node(int key, int value)
+{
+    BinomialNode* node = (BinomialNode*)malloc(sizeof(BinomialNode));
+    if (node == NULL)
+    {
+        return NULL;
+    }
+    node->key = key;
+    node->value = value;
+    node->degree = 0;
+    node->parent = NULL;
+    node->child = NULL;
+    node->sibling = NULL;
+    return node;
+}
+
+/* Frees all memory allocated for the binomial heap */
+void destroy_binomial_heap(BinomialNode* head)
+{
+    if (head == NULL)
+    {
+        return;
+    }
+    destroy_binomial_heap(head->sibling);
+    destroy_binomial_heap(head->child);
+    free(head);
+}
+
+/* Links tree y as a child of tree z (y gets degree z incremented) */
+static void binomial_link(BinomialNode* y, BinomialNode* z)
+{
+    y->parent = z;
+    y->sibling = z->child;
+    z->child = y;
+    z->degree++;
+}
+
+/* Merges two binomial heaps root lists sorted by degree ascending */
+static BinomialNode* binomial_heap_merge_lists(BinomialNode* head1, BinomialNode* head2)
+{
+    if (head1 == NULL)
+        return head2;
+    if (head2 == NULL)
+        return head1;
+
+    BinomialNode* head = NULL;
+    BinomialNode** tail_ref = &head;
+
+    while (head1 != NULL && head2 != NULL)
+    {
+        if (head1->degree <= head2->degree)
+        {
+            *tail_ref = head1;
+            head1 = head1->sibling;
+        }
+        else
+        {
+            *tail_ref = head2;
+            head2 = head2->sibling;
+        }
+        tail_ref = &((*tail_ref)->sibling);
+    }
+
+    if (head1 != NULL)
+    {
+        *tail_ref = head1;
+    }
+    else
+    {
+        *tail_ref = head2;
+    }
+
+    return head;
+}
+
+/* Combines two binomial heaps and combines trees of equal degree */
+BinomialNode* binomial_heap_merge(BinomialNode* head1, BinomialNode* head2)
+{
+    BinomialNode* head = binomial_heap_merge_lists(head1, head2);
+    if (head == NULL)
+    {
+        return NULL;
+    }
+
+    BinomialNode* prev = NULL;
+    BinomialNode* curr = head;
+    BinomialNode* next = curr->sibling;
+
+    while (next != NULL)
+    {
+        /* Case 1: current and next have different degrees, or there is a third
+         * tree of the same degree */
+        if ((curr->degree != next->degree) ||
+            (next->sibling != NULL && next->sibling->degree == curr->degree))
+        {
+            prev = curr;
+            curr = next;
+        }
+        /* Case 2: current has smaller key, so link next under current */
+        else if (curr->key <= next->key)
+        {
+            curr->sibling = next->sibling;
+            binomial_link(next, curr);
+        }
+        /* Case 3: next has smaller key, so link current under next */
+        else
+        {
+            if (prev == NULL)
+            {
+                head = next;
+            }
+            else
+            {
+                prev->sibling = next;
+            }
+            binomial_link(curr, next);
+            curr = next;
+        }
+        next = curr->sibling;
+    }
+
+    return head;
+}
+
+/* Inserts a key-value pair into the binomial heap */
+BinomialNode* binomial_heap_insert(BinomialNode* head, int key, int value)
+{
+    BinomialNode* new_node = create_binomial_node(key, value);
+    if (new_node == NULL)
+    {
+        return head;
+    }
+    return binomial_heap_merge(head, new_node);
+}
+
+/* Reverses a linked list of binomial nodes */
+static BinomialNode* reverse_list(BinomialNode* head)
+{
+    BinomialNode* prev = NULL;
+    BinomialNode* curr = head;
+    BinomialNode* next = NULL;
+
+    while (curr != NULL)
+    {
+        next = curr->sibling;
+        curr->sibling = prev;
+        prev = curr;
+        curr = next;
+    }
+    return prev;
+}
+
+/* Extracts the minimum element from the binomial heap */
+BinomialNode* binomial_heap_extract_min(BinomialNode* head, int* min_key, int* min_val)
+{
+    if (head == NULL)
+    {
+        return NULL;
+    }
+
+    /* Find the node with the minimum key in the root list */
+    BinomialNode* min_node = head;
+    BinomialNode* min_prev = NULL;
+    BinomialNode* curr = head;
+    BinomialNode* prev = NULL;
+
+    while (curr != NULL)
+    {
+        if (curr->key < min_node->key)
+        {
+            min_node = curr;
+            min_prev = prev;
+        }
+        prev = curr;
+        curr = curr->sibling;
+    }
+
+    /* Unlink the minimum node from the root list */
+    if (min_prev == NULL)
+    {
+        head = min_node->sibling;
+    }
+    else
+    {
+        min_prev->sibling = min_node->sibling;
+    }
+
+    if (min_key)
+        *min_key = min_node->key;
+    if (min_val)
+        *min_val = min_node->value;
+
+    /* Reverse the children of the extracted min node */
+    BinomialNode* child_head = min_node->child;
+    /* Clear parent pointers of children */
+    curr = child_head;
+    while (curr != NULL)
+    {
+        curr->parent = NULL;
+        curr = curr->sibling;
+    }
+
+    BinomialNode* reversed_children = reverse_list(child_head);
+
+    free(min_node);
+
+    /* Merge the remaining root list with the reversed children */
+    return binomial_heap_merge(head, reversed_children);
+}
+
+/* Decreases the key of a given target node in the binomial heap */
+BinomialNode* binomial_heap_decrease_key(BinomialNode* head, BinomialNode* target, int new_key)
+{
+    if (target == NULL || new_key > target->key)
+    {
+        return head; /* Cannot increase key */
+    }
+
+    target->key = new_key;
+    BinomialNode* curr = target;
+    BinomialNode* parent_node = curr->parent;
+
+    /* Bubble up to restore heap order */
+    while (parent_node != NULL && curr->key < parent_node->key)
+    {
+        /* Swap keys and values */
+        int temp_key = curr->key;
+        int temp_val = curr->value;
+        curr->key = parent_node->key;
+        curr->value = parent_node->value;
+        parent_node->key = temp_key;
+        parent_node->value = temp_val;
+
+        curr = parent_node;
+        parent_node = curr->parent;
+    }
+
+    return head;
+}
+
+/* Recursively searches the heap for a node with the given key */
+BinomialNode* binomial_heap_find_node(BinomialNode* head, int key)
+{
+    if (head == NULL)
+    {
+        return NULL;
+    }
+
+    if (head->key == key)
+    {
+        return head;
+    }
+
+    /* Search the child subtree */
+    BinomialNode* res = binomial_heap_find_node(head->child, key);
+    if (res != NULL)
+    {
+        return res;
+    }
+
+    /* Search the sibling list */
+    return binomial_heap_find_node(head->sibling, key);
+}

--- a/tests/advanced_heaps/test_binomial_heap.c
+++ b/tests/advanced_heaps/test_binomial_heap.c
@@ -1,0 +1,92 @@
+#include "advanced_heaps.h"
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+void test_binomial_insert_and_extract()
+{
+    BinomialNode* heap = NULL;
+
+    heap = binomial_heap_insert(heap, 10, 100);
+    heap = binomial_heap_insert(heap, 5, 50);
+    heap = binomial_heap_insert(heap, 15, 150);
+    heap = binomial_heap_insert(heap, 2, 20);
+
+    int min_key, min_val;
+
+    heap = binomial_heap_extract_min(heap, &min_key, &min_val);
+    assert(min_key == 2);
+    assert(min_val == 20);
+
+    heap = binomial_heap_extract_min(heap, &min_key, &min_val);
+    assert(min_key == 5);
+    assert(min_val == 50);
+
+    heap = binomial_heap_extract_min(heap, &min_key, &min_val);
+    assert(min_key == 10);
+    assert(min_val == 100);
+
+    heap = binomial_heap_extract_min(heap, &min_key, &min_val);
+    assert(min_key == 15);
+    assert(min_val == 150);
+
+    assert(heap == NULL);
+
+    destroy_binomial_heap(heap);
+    printf("Binomial Heap insert and extract test passed\n");
+}
+
+void test_binomial_decrease_key()
+{
+    BinomialNode* heap = NULL;
+
+    heap = binomial_heap_insert(heap, 10, 100);
+    heap = binomial_heap_insert(heap, 20, 200);
+    heap = binomial_heap_insert(heap, 30, 300);
+
+    BinomialNode* target = binomial_heap_find_node(heap, 20);
+    assert(target != NULL);
+
+    heap = binomial_heap_decrease_key(heap, target, 5);
+
+    int min_key, min_val;
+    heap = binomial_heap_extract_min(heap, &min_key, &min_val);
+    assert(min_key == 5);
+    assert(min_val == 200); /* Value stays tied to decreased key */
+
+    destroy_binomial_heap(heap);
+    printf("Binomial Heap decrease key test passed\n");
+}
+
+void test_binomial_merge()
+{
+    BinomialNode* heap1 = NULL;
+    heap1 = binomial_heap_insert(heap1, 10, 100);
+    heap1 = binomial_heap_insert(heap1, 30, 300);
+
+    BinomialNode* heap2 = NULL;
+    heap2 = binomial_heap_insert(heap2, 5, 50);
+    heap2 = binomial_heap_insert(heap2, 20, 200);
+
+    BinomialNode* merged = binomial_heap_merge(heap1, heap2);
+
+    int min_key, min_val;
+    merged = binomial_heap_extract_min(merged, &min_key, &min_val);
+    assert(min_key == 5);
+
+    merged = binomial_heap_extract_min(merged, &min_key, &min_val);
+    assert(min_key == 10);
+
+    destroy_binomial_heap(merged);
+    printf("Binomial Heap merge test passed\n");
+}
+
+int main()
+{
+    test_binomial_insert_and_extract();
+    test_binomial_decrease_key();
+    test_binomial_merge();
+
+    printf("All Binomial Heap tests passed\n");
+    return 0;
+}


### PR DESCRIPTION
This PR implements the Binomial Heap data structure under the new `src/advanced_heaps/` module.

Key changes:
- Added binomial node allocation, sibling/child tracking, and degree tracking.
- Implemented merging/linking root lists of binomial trees.
- Implemented operations: insertions, extract-minimum, decrease-key, search, and destruction.
- Added comprehensive unit tests in `tests/advanced_heaps/test_binomial_heap.c` verifying heap properties under multiple insertions and extractions.
- Added Makefile rules to support compilation and formatting of the test binary.

Resolves #603