### PR TITLE
test(eca): add unit tests for Checksum algorithm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -120,6 +120,7 @@ TEST_BINS = test_circ_queue test_bst test_search test_hash_func \
             test_deque test_astar test_avl test_segment_tree \
             test_greedy_bfs test_sorting_n2 test_advanced_sorting \
             test_history_logger test_shell_sort test_trie test_btree test_bplus_tree test_parity_bit \
+            test_checksum \
             test_prim test_kruskal test_floyd_warshall test_mcm test_fibonacci test_knapsack test_lcs \
             test_string_algorithms test_expression_evaluation \
             test_fcfs test_sjf test_srtf test_round_robin test_priority_scheduling test_preemptive_priority \
@@ -547,7 +548,20 @@ test_parity_bit: $(TEST_DIR)/test_parity_bit$(EXE)
 
 $(TEST_DIR)/test_parity_bit$(EXE): $(OBJ_DIR)/src/error_correction_algorithms/parity_bit.o $(OBJ_DIR)/src/error_correction_algorithms/checksum.o $(OBJ_DIR)/src/utils/safe_input_int.o $(OBJ_DIR)/src/utils/history_logger.o tests/error_correction_algorithms/test_parity_bit.c
 	@$(call MKDIR_P,$(TEST_DIR))
-	$(CC) $(CFLAGS) $^ -o $@ $(LDFLAGS)                                                                                                                                                                                                                                                                                         
+	$(CC) $(CFLAGS) $^ -o $@ $(LDFLAGS)
+
+test_checksum: $(TEST_DIR)/test_checksum$(EXE)
+	$(TEST_DIR)/test_checksum$(EXE)
+
+$(TEST_DIR)/test_checksum$(EXE): \
+	$(OBJ_DIR)/src/error_correction_algorithms/checksum.o \
+	$(OBJ_DIR)/src/error_correction_algorithms/checksum_receiver.o \
+	$(OBJ_DIR)/src/utils/safe_input_int.o \
+	$(OBJ_DIR)/src/utils/history_logger.o \
+	tests/error_correction_algorithms/test_checksum.c
+	@$(call MKDIR_P,$(TEST_DIR))
+	$(CC) $(CFLAGS) $^ -o $@ $(LDFLAGS)
+
 
 test_expression_evaluation: $(TEST_DIR)/test_expression_evaluation$(EXE)
 	$(TEST_DIR)/test_expression_evaluation$(EXE)

--- a/src/error_correction_algorithms/checksum.c
+++ b/src/error_correction_algorithms/checksum.c
@@ -111,6 +111,17 @@ int checksum_block_sum(const char* data, int len, int k)
     return sum;
 }
 
+// converts a k-bit binary string into its integer value
+int checksum_bits_to_int(const char* bits, int k)
+{
+    int value = 0;
+    for (int i = 0; i < k; i++)
+    {
+        value = (value << 1) | (bits[i] - '0');
+    }
+    return value;
+}
+
 // checksum (sender side): the data is split into k-bit blocks and summed using
 // one's-complement (end-around carry) addition; the checksum is the one's complement
 // of that running sum. this is the value the sender appends to the data before

--- a/src/error_correction_algorithms/checksum_receiver.c
+++ b/src/error_correction_algorithms/checksum_receiver.c
@@ -5,16 +5,6 @@
 #include <string.h>
 #include <time.h>
 
-// converts a k-bit binary string into its integer value
-int checksum_bits_to_int(const char* bits, int k)
-{
-    int value = 0;
-    for (int i = 0; i < k; i++)
-    {
-        value = (value << 1) | (bits[i] - '0');
-    }
-    return value;
-}
 // checksum (receiver side): re-runs the one's-complement block sum over the received
 // data, then folds in the received checksum block. if the one's complement of the
 // total is all zeros the frame is accepted, otherwise an error is detected. this is

--- a/src/error_correction_algorithms/error_correction_algorithms.h
+++ b/src/error_correction_algorithms/error_correction_algorithms.h
@@ -44,7 +44,9 @@ void checksum_print_binary(int value, int bits);
 int safe_input_binary_string(char* buff, size_t size, const char* prompt);
 int checksum_add(int sum, int word, int k);
 int checksum_block_sum(const char* data, int len, int k);
+int checksum_bits_to_int(const char* bits, int k);
 
+/* CRC */
 void crc_xor_operation(char* dividend, const char* divisor, int pos);
 
 #endif /* ERROR_CORRECTION_ALGORITHMS_H */

--- a/tests/error_correction_algorithms/test_checksum.c
+++ b/tests/error_correction_algorithms/test_checksum.c
@@ -1,0 +1,96 @@
+#include "error_correction_algorithms.h"
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+
+void test_checksum_add(void)
+{
+    // Test 3-bit checksum addition (k=3)
+    // 111 + 001 = 1000 -> 000 + 1 = 001
+    assert(checksum_add(7, 1, 3) == 1);
+    assert(checksum_add(5, 3, 3) == 1);
+    assert(checksum_add(4, 4, 3) == 1);
+
+    // Test 8-bit checksum addition (k=8)
+    assert(checksum_add(255, 1, 8) == 1);
+    assert(checksum_add(100, 150, 8) == 250);
+
+    printf("test_checksum_add passed\n");
+}
+
+void test_checksum_bits_to_int(void)
+{
+    assert(checksum_bits_to_int("000", 3) == 0);
+    assert(checksum_bits_to_int("111", 3) == 7);
+    assert(checksum_bits_to_int("101", 3) == 5);
+    assert(checksum_bits_to_int("101010", 6) == 42);
+
+    printf("test_checksum_bits_to_int passed\n");
+}
+
+void test_checksum_block_sum(void)
+{
+    // Data: "10110011", len=8, k=4
+    // Blocks: "1011" (11) and "0011" (3)
+    // 11 + 3 = 14 ("1110")
+    int sum = checksum_block_sum("10110011", 8, 4);
+    assert(sum == 14);
+
+    // Data: "101", len=3, k=4 (padded with 0 to "1010" (10))
+    sum = checksum_block_sum("101", 3, 4);
+    assert(sum == 10);
+
+    printf("test_checksum_block_sum passed\n");
+}
+
+void test_checksum_transmission(void)
+{
+    // Simulate transmission
+    const char* data = "1011001110101111"; // 16 bits
+    int len = 16;
+    int k = 4;
+    int mask = (1 << k) - 1;
+
+    // Sender side
+    int sum = checksum_block_sum(data, len, k);
+    int checksum = (~sum) & mask;
+
+    // We convert checksum to binary string
+    char checksum_str[5];
+    for (int i = 0; i < k; i++)
+    {
+        checksum_str[i] = ((checksum >> (k - 1 - i)) & 1) ? '1' : '0';
+    }
+    checksum_str[k] = '\0';
+
+    // Receiver side: verification
+    int checkword = checksum_bits_to_int(checksum_str, k);
+    int rec_sum = checksum_block_sum(data, len, k);
+    rec_sum = checksum_add(rec_sum, checkword, k);
+
+    int complement = (~rec_sum) & mask;
+    assert(complement == 0); // No error detected
+
+    // Simulate error in data
+    char corrupt_data[17];
+    strcpy(corrupt_data, data);
+    corrupt_data[0] = (corrupt_data[0] == '1') ? '0' : '1'; // Flip first bit
+
+    int corrupt_rec_sum = checksum_block_sum(corrupt_data, len, k);
+    corrupt_rec_sum = checksum_add(corrupt_rec_sum, checkword, k);
+    int corrupt_complement = (~corrupt_rec_sum) & mask;
+    assert(corrupt_complement != 0); // Error detected!
+
+    printf("test_checksum_transmission passed\n");
+}
+
+int main(void)
+{
+    test_checksum_add();
+    test_checksum_bits_to_int();
+    test_checksum_block_sum();
+    test_checksum_transmission();
+
+    printf("All checksum tests passed successfully!\n");
+    return 0;
+}


### PR DESCRIPTION
Closes #435

## Summary
Extracts the `checksum_bits_to_int()` helper from `checksum_receiver.c` into the shared `checksum.c` so it can be reused without duplicate symbol errors, declares it in the header, and adds a comprehensive unit test suite.

## Changes
- **`checksum.c`** – implement `checksum_bits_to_int()` (binary string → integer)
- **`checksum_receiver.c`** – remove the now-duplicate local definition
- **`error_correction_algorithms.h`** – declare `checksum_bits_to_int()`
- **`tests/error_correction_algorithms/test_checksum.c`** – new test file
- **`Makefile`** – register `test_checksum` in `TEST_BINS` with build rule

## Tests Added
| Test | What it covers |
|------|----------------|
| `test_checksum_add` | One's-complement addition with end-around carry |
| `test_checksum_bits_to_int` | Binary string → integer conversion |
| `test_checksum_block_sum` | Multi-block folding with zero-padding |
| `test_checksum_transmission` | Full sender→receiver: clean frame accepted, corrupted frame rejected |