### PR TITLE
test(eca): add unit tests for CRC algorithm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -120,7 +120,7 @@ TEST_BINS = test_circ_queue test_bst test_search test_hash_func \
             test_deque test_astar test_avl test_segment_tree \
             test_greedy_bfs test_sorting_n2 test_advanced_sorting \
             test_history_logger test_shell_sort test_trie test_btree test_bplus_tree test_parity_bit \
-            test_checksum \
+            test_checksum test_crc \
             test_prim test_kruskal test_floyd_warshall test_mcm test_fibonacci test_knapsack test_lcs \
             test_string_algorithms test_expression_evaluation \
             test_fcfs test_sjf test_srtf test_round_robin test_priority_scheduling test_preemptive_priority \
@@ -562,6 +562,19 @@ $(TEST_DIR)/test_checksum$(EXE): \
 	@$(call MKDIR_P,$(TEST_DIR))
 	$(CC) $(CFLAGS) $^ -o $@ $(LDFLAGS)
 
+
+test_crc: $(TEST_DIR)/test_crc$(EXE)
+	$(TEST_DIR)/test_crc$(EXE)
+
+$(TEST_DIR)/test_crc$(EXE): \
+	$(OBJ_DIR)/src/error_correction_algorithms/checksum.o \
+	$(OBJ_DIR)/src/error_correction_algorithms/crc.o \
+	$(OBJ_DIR)/src/error_correction_algorithms/crc_receiver.o \
+	$(OBJ_DIR)/src/utils/safe_input_int.o \
+	$(OBJ_DIR)/src/utils/history_logger.o \
+	tests/error_correction_algorithms/test_crc.c
+	@$(call MKDIR_P,$(TEST_DIR))
+	$(CC) $(CFLAGS) $^ -o $@ $(LDFLAGS)
 
 test_expression_evaluation: $(TEST_DIR)/test_expression_evaluation$(EXE)
 	$(TEST_DIR)/test_expression_evaluation$(EXE)

--- a/Makefile
+++ b/Makefile
@@ -120,6 +120,7 @@ TEST_BINS = test_circ_queue test_bst test_search test_hash_func \
             test_deque test_astar test_avl test_segment_tree \
             test_greedy_bfs test_sorting_n2 test_advanced_sorting \
             test_history_logger test_shell_sort test_trie test_btree test_bplus_tree test_parity_bit \
+            test_checksum \
             test_prim test_kruskal test_floyd_warshall test_mcm test_fibonacci test_knapsack test_lcs \
             test_string_algorithms test_expression_evaluation \
             test_fcfs test_sjf test_srtf test_round_robin test_priority_scheduling test_preemptive_priority \
@@ -547,7 +548,20 @@ test_parity_bit: $(TEST_DIR)/test_parity_bit$(EXE)
 
 $(TEST_DIR)/test_parity_bit$(EXE): $(OBJ_DIR)/src/error_correction_algorithms/parity_bit.o $(OBJ_DIR)/src/error_correction_algorithms/checksum.o $(OBJ_DIR)/src/utils/safe_input_int.o $(OBJ_DIR)/src/utils/history_logger.o tests/error_correction_algorithms/test_parity_bit.c
 	@$(call MKDIR_P,$(TEST_DIR))
-	$(CC) $(CFLAGS) $^ -o $@ $(LDFLAGS)                                                                                                                                                                                                                                                                                         
+	$(CC) $(CFLAGS) $^ -o $@ $(LDFLAGS)
+
+test_checksum: $(TEST_DIR)/test_checksum$(EXE)
+	$(TEST_DIR)/test_checksum$(EXE)
+
+$(TEST_DIR)/test_checksum$(EXE): \
+	$(OBJ_DIR)/src/error_correction_algorithms/checksum.o \
+	$(OBJ_DIR)/src/error_correction_algorithms/checksum_receiver.o \
+	$(OBJ_DIR)/src/utils/safe_input_int.o \
+	$(OBJ_DIR)/src/utils/history_logger.o \
+	tests/error_correction_algorithms/test_checksum.c
+	@$(call MKDIR_P,$(TEST_DIR))
+	$(CC) $(CFLAGS) $^ -o $@ $(LDFLAGS)
+
 
 test_expression_evaluation: $(TEST_DIR)/test_expression_evaluation$(EXE)
 	$(TEST_DIR)/test_expression_evaluation$(EXE)

--- a/src/error_correction_algorithms/checksum.c
+++ b/src/error_correction_algorithms/checksum.c
@@ -111,6 +111,17 @@ int checksum_block_sum(const char* data, int len, int k)
     return sum;
 }
 
+// converts a k-bit binary string into its integer value
+int checksum_bits_to_int(const char* bits, int k)
+{
+    int value = 0;
+    for (int i = 0; i < k; i++)
+    {
+        value = (value << 1) | (bits[i] - '0');
+    }
+    return value;
+}
+
 // checksum (sender side): the data is split into k-bit blocks and summed using
 // one's-complement (end-around carry) addition; the checksum is the one's complement
 // of that running sum. this is the value the sender appends to the data before

--- a/src/error_correction_algorithms/checksum_receiver.c
+++ b/src/error_correction_algorithms/checksum_receiver.c
@@ -5,16 +5,6 @@
 #include <string.h>
 #include <time.h>
 
-// converts a k-bit binary string into its integer value
-int checksum_bits_to_int(const char* bits, int k)
-{
-    int value = 0;
-    for (int i = 0; i < k; i++)
-    {
-        value = (value << 1) | (bits[i] - '0');
-    }
-    return value;
-}
 // checksum (receiver side): re-runs the one's-complement block sum over the received
 // data, then folds in the received checksum block. if the one's complement of the
 // total is all zeros the frame is accepted, otherwise an error is detected. this is

--- a/src/error_correction_algorithms/crc.c
+++ b/src/error_correction_algorithms/crc.c
@@ -13,6 +13,87 @@ void crc_xor_operation(char* dividend, const char* divisor, int pos)
     }
 }
 
+// crc_generate: computes the CRC remainder for `data` using `generator` via
+// modulo-2 (XOR) division.  The remainder is written to `remainder_out` and,
+// if `codeword_out` is not NULL, the full transmitted codeword (data + CRC) is
+// written there too.
+void crc_generate(const char* data, const char* generator, char* remainder_out, char* codeword_out)
+{
+    int data_len = (int)strlen(data);
+    int generator_len = (int)strlen(generator);
+
+    // Append (generator_len - 1) zero bits to data to form the dividend
+    char dividend[(CHECKSUM_MAX_BITS * 2) + 1];
+    strcpy(dividend, data);
+    for (int i = 0; i < generator_len - 1; i++)
+    {
+        dividend[data_len + i] = '0';
+    }
+    int dividend_len = data_len + generator_len - 1;
+    dividend[dividend_len] = '\0';
+
+    // Modulo-2 division
+    for (int i = 0; i <= dividend_len - generator_len; i++)
+    {
+        if (dividend[i] == '1')
+        {
+            crc_xor_operation(dividend, generator, i);
+        }
+    }
+
+    // Extract the remainder (last generator_len-1 bits)
+    for (int i = 0; i < generator_len - 1; i++)
+    {
+        remainder_out[i] = dividend[dividend_len - (generator_len - 1) + i];
+    }
+    remainder_out[generator_len - 1] = '\0';
+
+    if (codeword_out != NULL)
+    {
+        strcpy(codeword_out, data);
+        strcat(codeword_out, remainder_out);
+    }
+}
+
+// crc_verify: re-divides a received `codeword` by `generator`.  If the
+// remainder is all zeros the frame is clean and 1 is returned; otherwise 0 is
+// returned (error detected).  The computed remainder is optionally written to
+// `remainder_out`.
+int crc_verify(const char* codeword, const char* generator, char* remainder_out)
+{
+    int generator_len = (int)strlen(generator);
+    int codeword_len = (int)strlen(codeword);
+
+    char dividend[(CHECKSUM_MAX_BITS * 2) + 1];
+    strcpy(dividend, codeword);
+
+    for (int i = 0; i <= codeword_len - generator_len; i++)
+    {
+        if (dividend[i] == '1')
+        {
+            crc_xor_operation(dividend, generator, i);
+        }
+    }
+
+    // The remainder is the last (generator_len-1) bits
+    char remainder[CHECKSUM_MAX_BITS + 1];
+    strcpy(remainder, &dividend[codeword_len - (generator_len - 1)]);
+
+    if (remainder_out != NULL)
+    {
+        strcpy(remainder_out, remainder);
+    }
+
+    for (int i = 0; remainder[i] != '\0'; i++)
+    {
+        if (remainder[i] == '1')
+        {
+            return 0; // Error detected
+        }
+    }
+    return 1; // No error
+}
+
 void crc_demo(void)
 {
     while (1)
@@ -47,7 +128,6 @@ void crc_demo(void)
             continue;
         }
 
-        int data_len = (int)strlen(data);
         int generator_len = (int)strlen(generator);
 
         if (generator_len < 2)
@@ -56,42 +136,14 @@ void crc_demo(void)
             continue;
         }
 
-        char dividend[(CHECKSUM_MAX_BITS * 2) + 1];
+        char remainder[CHECKSUM_MAX_BITS + 1];
+        char codeword[(CHECKSUM_MAX_BITS * 2) + 1];
 
-        strcpy(dividend, data);
-
-        for (int i = 0; i < generator_len - 1; i++)
-        {
-            dividend[data_len + i] = '0';
-        }
-
-        dividend[data_len + generator_len - 1] = '\0';
+        crc_generate(data, generator, remainder, codeword);
 
         printf("\nOriginal Data : %s", data);
         printf("\nGenerator     : %s", generator);
-        printf("\nDividend      : %s\n", dividend);
-
-        int dividend_len = (int)strlen(dividend);
-
-        printf("\nPerforming modulo-2 division...\n");
-
-        for (int i = 0; i <= dividend_len - generator_len; i++)
-        {
-            if (dividend[i] == '1')
-            {
-                crc_xor_operation(dividend, generator, i);
-            }
-        }
-
-        char remainder[CHECKSUM_MAX_BITS + 1];
-        for (int i = 0; i < generator_len - 1; i++)
-        {
-            remainder[i] = dividend[dividend_len - (generator_len - 1) + i];
-        }
-        remainder[generator_len - 1] = '\0';
-
         printf("\nCRC Remainder : %s", remainder);
-
-        printf("\nTransmitted Codeword : %s%s\n", data, remainder);
+        printf("\nTransmitted Codeword : %s\n", codeword);
     }
 }

--- a/src/error_correction_algorithms/crc_receiver.c
+++ b/src/error_correction_algorithms/crc_receiver.c
@@ -58,42 +58,12 @@ void crc_receiver_demo(void)
             continue;
         }
 
-        char dividend[(CHECKSUM_MAX_BITS * 2) + 1];
-        strcpy(dividend, received_codeword);
-
-        printf("\nReceived Codeword : %s", received_codeword);
-        printf("\nGenerator         : %s\n", generator);
-
-        printf("\nPerforming modulo-2 division...\n");
-
-        int dividend_len = (int)strlen(dividend);
-
-        for (int i = 0; i <= dividend_len - generator_len; i++)
-        {
-            if (dividend[i] == '1')
-            {
-                crc_xor_operation(dividend, generator, i);
-            }
-        }
-
         char remainder[CHECKSUM_MAX_BITS + 1];
-
-        strcpy(remainder, &dividend[dividend_len - (generator_len - 1)]);
+        int is_valid = crc_verify(received_codeword, generator, remainder);
 
         printf("\nComputed Remainder : %s\n", remainder);
 
-        int error_detected = 0;
-
-        for (int i = 0; remainder[i] != '\0'; i++)
-        {
-            if (remainder[i] == '1')
-            {
-                error_detected = 1;
-                break;
-            }
-        }
-
-        if (error_detected)
+        if (!is_valid)
         {
             printf("\n[ERROR] Transmission error detected.\n");
         }

--- a/src/error_correction_algorithms/error_correction_algorithms.h
+++ b/src/error_correction_algorithms/error_correction_algorithms.h
@@ -48,5 +48,7 @@ int checksum_bits_to_int(const char* bits, int k);
 
 /* CRC */
 void crc_xor_operation(char* dividend, const char* divisor, int pos);
+void crc_generate(const char* data, const char* generator, char* remainder_out, char* codeword_out);
+int crc_verify(const char* codeword, const char* generator, char* remainder_out);
 
 #endif /* ERROR_CORRECTION_ALGORITHMS_H */

--- a/src/error_correction_algorithms/error_correction_algorithms.h
+++ b/src/error_correction_algorithms/error_correction_algorithms.h
@@ -44,7 +44,9 @@ void checksum_print_binary(int value, int bits);
 int safe_input_binary_string(char* buff, size_t size, const char* prompt);
 int checksum_add(int sum, int word, int k);
 int checksum_block_sum(const char* data, int len, int k);
+int checksum_bits_to_int(const char* bits, int k);
 
+/* CRC */
 void crc_xor_operation(char* dividend, const char* divisor, int pos);
 
 #endif /* ERROR_CORRECTION_ALGORITHMS_H */

--- a/tests/error_correction_algorithms/test_checksum.c
+++ b/tests/error_correction_algorithms/test_checksum.c
@@ -1,0 +1,96 @@
+#include "error_correction_algorithms.h"
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+
+void test_checksum_add(void)
+{
+    // Test 3-bit checksum addition (k=3)
+    // 111 + 001 = 1000 -> 000 + 1 = 001
+    assert(checksum_add(7, 1, 3) == 1);
+    assert(checksum_add(5, 3, 3) == 1);
+    assert(checksum_add(4, 4, 3) == 1);
+
+    // Test 8-bit checksum addition (k=8)
+    assert(checksum_add(255, 1, 8) == 1);
+    assert(checksum_add(100, 150, 8) == 250);
+
+    printf("test_checksum_add passed\n");
+}
+
+void test_checksum_bits_to_int(void)
+{
+    assert(checksum_bits_to_int("000", 3) == 0);
+    assert(checksum_bits_to_int("111", 3) == 7);
+    assert(checksum_bits_to_int("101", 3) == 5);
+    assert(checksum_bits_to_int("101010", 6) == 42);
+
+    printf("test_checksum_bits_to_int passed\n");
+}
+
+void test_checksum_block_sum(void)
+{
+    // Data: "10110011", len=8, k=4
+    // Blocks: "1011" (11) and "0011" (3)
+    // 11 + 3 = 14 ("1110")
+    int sum = checksum_block_sum("10110011", 8, 4);
+    assert(sum == 14);
+
+    // Data: "101", len=3, k=4 (padded with 0 to "1010" (10))
+    sum = checksum_block_sum("101", 3, 4);
+    assert(sum == 10);
+
+    printf("test_checksum_block_sum passed\n");
+}
+
+void test_checksum_transmission(void)
+{
+    // Simulate transmission
+    const char* data = "1011001110101111"; // 16 bits
+    int len = 16;
+    int k = 4;
+    int mask = (1 << k) - 1;
+
+    // Sender side
+    int sum = checksum_block_sum(data, len, k);
+    int checksum = (~sum) & mask;
+
+    // We convert checksum to binary string
+    char checksum_str[5];
+    for (int i = 0; i < k; i++)
+    {
+        checksum_str[i] = ((checksum >> (k - 1 - i)) & 1) ? '1' : '0';
+    }
+    checksum_str[k] = '\0';
+
+    // Receiver side: verification
+    int checkword = checksum_bits_to_int(checksum_str, k);
+    int rec_sum = checksum_block_sum(data, len, k);
+    rec_sum = checksum_add(rec_sum, checkword, k);
+
+    int complement = (~rec_sum) & mask;
+    assert(complement == 0); // No error detected
+
+    // Simulate error in data
+    char corrupt_data[17];
+    strcpy(corrupt_data, data);
+    corrupt_data[0] = (corrupt_data[0] == '1') ? '0' : '1'; // Flip first bit
+
+    int corrupt_rec_sum = checksum_block_sum(corrupt_data, len, k);
+    corrupt_rec_sum = checksum_add(corrupt_rec_sum, checkword, k);
+    int corrupt_complement = (~corrupt_rec_sum) & mask;
+    assert(corrupt_complement != 0); // Error detected!
+
+    printf("test_checksum_transmission passed\n");
+}
+
+int main(void)
+{
+    test_checksum_add();
+    test_checksum_bits_to_int();
+    test_checksum_block_sum();
+    test_checksum_transmission();
+
+    printf("All checksum tests passed successfully!\n");
+    return 0;
+}

--- a/tests/error_correction_algorithms/test_crc.c
+++ b/tests/error_correction_algorithms/test_crc.c
@@ -1,0 +1,65 @@
+#include "error_correction_algorithms.h"
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+
+void test_crc_generate_and_verify(void)
+{
+    // Test data and generator
+    const char* data = "1101011011";
+    const char* generator = "10011"; // CRC-4
+    char remainder[CHECKSUM_MAX_BITS + 1];
+    char codeword[CHECKSUM_MAX_BITS * 2 + 1];
+
+    crc_generate(data, generator, remainder, codeword);
+
+    // Verify remainder size: length of generator - 1
+    assert(strlen(remainder) == strlen(generator) - 1);
+    assert(strcmp(remainder, "1110") == 0); // Modulo-2 remainder for this input
+
+    // Codeword should be data + remainder
+    char expected_codeword[128];
+    snprintf(expected_codeword, sizeof(expected_codeword), "%s%s", data, remainder);
+    assert(strcmp(codeword, expected_codeword) == 0);
+
+    // Verify the clean codeword
+    int check_valid = crc_verify(codeword, generator, NULL);
+    assert(check_valid == 1); // Should be clean
+
+    // Simulate bit flip error in data
+    char corrupt_codeword[128];
+    strcpy(corrupt_codeword, codeword);
+    corrupt_codeword[0] = (corrupt_codeword[0] == '1') ? '0' : '1';
+
+    int check_corrupt = crc_verify(corrupt_codeword, generator, NULL);
+    assert(check_corrupt == 0); // Should detect error
+
+    // Simulate bit flip in parity remainder
+    strcpy(corrupt_codeword, codeword);
+    int last_idx = (int)strlen(corrupt_codeword) - 1;
+    corrupt_codeword[last_idx] = (corrupt_codeword[last_idx] == '1') ? '0' : '1';
+
+    check_corrupt = crc_verify(corrupt_codeword, generator, NULL);
+    assert(check_corrupt == 0); // Should detect error
+
+    printf("test_crc_generate_and_verify passed\n");
+}
+
+void test_crc_xor_operation(void)
+{
+    char div[32];
+    strcpy(div, "110100");
+    crc_xor_operation(div, "1011", 0);
+    assert(strncmp(div, "0110", 4) == 0); // 1101 XOR 1011 = 0110
+
+    printf("test_crc_xor_operation passed\n");
+}
+
+int main(void)
+{
+    test_crc_xor_operation();
+    test_crc_generate_and_verify();
+
+    printf("All CRC tests passed successfully!\n");
+    return 0;
+}


### PR DESCRIPTION
Part of #435 — depends on PR 1

## Summary
Extracts the CRC computation into reusable `crc_generate()` and `crc_verify()` library functions, refactors the demos to use them, and adds unit tests.

## Changes
- **`crc.c`** – implement `crc_generate()` (modulo-2 XOR division, builds remainder + codeword) and `crc_verify()` (re-divides received codeword, returns 1=clean / 0=error)
- **`crc_receiver.c`** – refactor `crc_receiver_demo()` to delegate to `crc_verify()`
- **`error_correction_algorithms.h`** – declare `crc_generate()` and `crc_verify()`
- **`tests/error_correction_algorithms/test_crc.c`** – new test file
- **`Makefile`** – register `test_crc` in `TEST_BINS` with build rule

## Tests Added
| Test | What it covers |
|------|----------------|
| `test_crc_xor_operation` | Single XOR step correctness |
| `test_crc_generate_and_verify` | Remainder size, value, codeword assembly; clean codeword accepted; bit-flip in data rejected; bit-flip in CRC rejected |