### PR TITLE
test(eca): add unit tests for Checksum and VRC (Part 1)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -120,6 +120,7 @@ TEST_BINS = test_circ_queue test_bst test_search test_hash_func \
             test_deque test_astar test_avl test_segment_tree \
             test_greedy_bfs test_sorting_n2 test_advanced_sorting \
             test_history_logger test_shell_sort test_trie test_btree test_bplus_tree test_parity_bit \
+            test_checksum test_vrc \
             test_prim test_kruskal test_floyd_warshall test_mcm test_fibonacci test_knapsack test_lcs \
             test_string_algorithms test_expression_evaluation \
             test_fcfs test_sjf test_srtf test_round_robin test_priority_scheduling test_preemptive_priority \
@@ -547,7 +548,33 @@ test_parity_bit: $(TEST_DIR)/test_parity_bit$(EXE)
 
 $(TEST_DIR)/test_parity_bit$(EXE): $(OBJ_DIR)/src/error_correction_algorithms/parity_bit.o $(OBJ_DIR)/src/error_correction_algorithms/checksum.o $(OBJ_DIR)/src/utils/safe_input_int.o $(OBJ_DIR)/src/utils/history_logger.o tests/error_correction_algorithms/test_parity_bit.c
 	@$(call MKDIR_P,$(TEST_DIR))
-	$(CC) $(CFLAGS) $^ -o $@ $(LDFLAGS)                                                                                                                                                                                                                                                                                         
+	$(CC) $(CFLAGS) $^ -o $@ $(LDFLAGS)
+
+test_checksum: $(TEST_DIR)/test_checksum$(EXE)
+	$(TEST_DIR)/test_checksum$(EXE)
+
+$(TEST_DIR)/test_checksum$(EXE): \
+	$(OBJ_DIR)/src/error_correction_algorithms/checksum.o \
+	$(OBJ_DIR)/src/error_correction_algorithms/checksum_receiver.o \
+	$(OBJ_DIR)/src/utils/safe_input_int.o \
+	$(OBJ_DIR)/src/utils/history_logger.o \
+	tests/error_correction_algorithms/test_checksum.c
+	@$(call MKDIR_P,$(TEST_DIR))
+	$(CC) $(CFLAGS) $^ -o $@ $(LDFLAGS)
+
+test_vrc: $(TEST_DIR)/test_vrc$(EXE)
+	$(TEST_DIR)/test_vrc$(EXE)
+
+$(TEST_DIR)/test_vrc$(EXE): \
+	$(OBJ_DIR)/src/error_correction_algorithms/checksum.o \
+	$(OBJ_DIR)/src/error_correction_algorithms/vrc.o \
+	$(OBJ_DIR)/src/error_correction_algorithms/vrc_receiver.o \
+	$(OBJ_DIR)/src/utils/safe_input_int.o \
+	$(OBJ_DIR)/src/utils/history_logger.o \
+	tests/error_correction_algorithms/test_vrc.c
+	@$(call MKDIR_P,$(TEST_DIR))
+	$(CC) $(CFLAGS) $^ -o $@ $(LDFLAGS)
+                                                                                                                                                                                                                                                                                         
 
 test_expression_evaluation: $(TEST_DIR)/test_expression_evaluation$(EXE)
 	$(TEST_DIR)/test_expression_evaluation$(EXE)

--- a/src/error_correction_algorithms/checksum.c
+++ b/src/error_correction_algorithms/checksum.c
@@ -111,6 +111,17 @@ int checksum_block_sum(const char* data, int len, int k)
     return sum;
 }
 
+// converts a k-bit binary string into its integer value
+int checksum_bits_to_int(const char* bits, int k)
+{
+    int value = 0;
+    for (int i = 0; i < k; i++)
+    {
+        value = (value << 1) | (bits[i] - '0');
+    }
+    return value;
+}
+
 // checksum (sender side): the data is split into k-bit blocks and summed using
 // one's-complement (end-around carry) addition; the checksum is the one's complement
 // of that running sum. this is the value the sender appends to the data before

--- a/src/error_correction_algorithms/checksum_receiver.c
+++ b/src/error_correction_algorithms/checksum_receiver.c
@@ -5,16 +5,6 @@
 #include <string.h>
 #include <time.h>
 
-// converts a k-bit binary string into its integer value
-int checksum_bits_to_int(const char* bits, int k)
-{
-    int value = 0;
-    for (int i = 0; i < k; i++)
-    {
-        value = (value << 1) | (bits[i] - '0');
-    }
-    return value;
-}
 // checksum (receiver side): re-runs the one's-complement block sum over the received
 // data, then folds in the received checksum block. if the one's complement of the
 // total is all zeros the frame is accepted, otherwise an error is detected. this is

--- a/src/error_correction_algorithms/error_correction_algorithms.h
+++ b/src/error_correction_algorithms/error_correction_algorithms.h
@@ -44,6 +44,7 @@ void checksum_print_binary(int value, int bits);
 int safe_input_binary_string(char* buff, size_t size, const char* prompt);
 int checksum_add(int sum, int word, int k);
 int checksum_block_sum(const char* data, int len, int k);
+int checksum_bits_to_int(const char* bits, int k);
 
 void crc_xor_operation(char* dividend, const char* divisor, int pos);
 

--- a/src/trees/red_black_tree.c
+++ b/src/trees/red_black_tree.c
@@ -3,8 +3,9 @@
 #include <stdlib.h>
 
 // Core Initialization
-rbTree* create_rb_tree(void) {
-    rbTree *tree = (rbTree*)malloc(sizeof(rbTree));
+rbTree* create_rb_tree(void)
+{
+    rbTree* tree = (rbTree*)malloc(sizeof(rbTree));
     tree->TNULL = (rbNode*)malloc(sizeof(rbNode));
     tree->TNULL->color = BLACK;
     tree->TNULL->left = NULL;
@@ -14,43 +15,60 @@ rbTree* create_rb_tree(void) {
 }
 
 // Rotations
-static void rb_left_rotate(rbTree *tree, rbNode *x) {
-    rbNode *y = x->right;
+static void rb_left_rotate(rbTree* tree, rbNode* x)
+{
+    rbNode* y = x->right;
     x->right = y->left;
-    if (y->left != tree->TNULL) y->left->parent = x;
+    if (y->left != tree->TNULL)
+        y->left->parent = x;
     y->parent = x->parent;
-    if (x->parent == NULL) tree->root = y;
-    else if (x == x->parent->left) x->parent->left = y;
-    else x->parent->right = y;
+    if (x->parent == NULL)
+        tree->root = y;
+    else if (x == x->parent->left)
+        x->parent->left = y;
+    else
+        x->parent->right = y;
     y->left = x;
     x->parent = y;
 }
 
-static void rb_right_rotate(rbTree *tree, rbNode *x) {
-    rbNode *y = x->left;
+static void rb_right_rotate(rbTree* tree, rbNode* x)
+{
+    rbNode* y = x->left;
     x->left = y->right;
-    if (y->right != tree->TNULL) y->right->parent = x;
+    if (y->right != tree->TNULL)
+        y->right->parent = x;
     y->parent = x->parent;
-    if (x->parent == NULL) tree->root = y;
-    else if (x == x->parent->right) x->parent->right = y;
-    else x->parent->left = y;
+    if (x->parent == NULL)
+        tree->root = y;
+    else if (x == x->parent->right)
+        x->parent->right = y;
+    else
+        x->parent->left = y;
     y->right = x;
     x->parent = y;
 }
 
 // Insert Fixup
-static void rb_insert_fixup(rbTree *tree, rbNode *k) {
-    rbNode *u;
-    while (k->parent != NULL && k->parent->color == RED) {
-        if (k->parent == k->parent->parent->right) {
+static void rb_insert_fixup(rbTree* tree, rbNode* k)
+{
+    rbNode* u;
+    while (k->parent != NULL && k->parent->color == RED)
+    {
+        if (k->parent == k->parent->parent->right)
+        {
             u = k->parent->parent->left; // uncle
-            if (u->color == RED) {
+            if (u->color == RED)
+            {
                 u->color = BLACK;
                 k->parent->color = BLACK;
                 k->parent->parent->color = RED;
                 k = k->parent->parent;
-            } else {
-                if (k == k->parent->left) {
+            }
+            else
+            {
+                if (k == k->parent->left)
+                {
                     k = k->parent;
                     rb_right_rotate(tree, k);
                 }
@@ -58,15 +76,21 @@ static void rb_insert_fixup(rbTree *tree, rbNode *k) {
                 k->parent->parent->color = RED;
                 rb_left_rotate(tree, k->parent->parent);
             }
-        } else {
+        }
+        else
+        {
             u = k->parent->parent->right; // uncle
-            if (u->color == RED) {
+            if (u->color == RED)
+            {
                 u->color = BLACK;
                 k->parent->color = BLACK;
                 k->parent->parent->color = RED;
                 k = k->parent->parent;
-            } else {
-                if (k == k->parent->right) {
+            }
+            else
+            {
+                if (k == k->parent->right)
+                {
                     k = k->parent;
                     rb_left_rotate(tree, k);
                 }
@@ -75,48 +99,62 @@ static void rb_insert_fixup(rbTree *tree, rbNode *k) {
                 rb_right_rotate(tree, k->parent->parent);
             }
         }
-        if (k == tree->root) break;
+        if (k == tree->root)
+            break;
     }
     tree->root->color = BLACK;
 }
 
-void rb_insert(rbTree *tree, int key) {
-    rbNode *node = (rbNode*)malloc(sizeof(rbNode));
+void rb_insert(rbTree* tree, int key)
+{
+    rbNode* node = (rbNode*)malloc(sizeof(rbNode));
     node->data = key;
     node->parent = NULL;
     node->left = tree->TNULL;
     node->right = tree->TNULL;
     node->color = RED;
 
-    rbNode *y = NULL;
-    rbNode *x = tree->root;
+    rbNode* y = NULL;
+    rbNode* x = tree->root;
 
-    while (x != tree->TNULL) {
+    while (x != tree->TNULL)
+    {
         y = x;
-        if (node->data < x->data) x = x->left;
-        else x = x->right;
+        if (node->data < x->data)
+            x = x->left;
+        else
+            x = x->right;
     }
 
     node->parent = y;
-    if (y == NULL) tree->root = node;
-    else if (node->data < y->data) y->left = node;
-    else y->right = node;
+    if (y == NULL)
+        tree->root = node;
+    else if (node->data < y->data)
+        y->left = node;
+    else
+        y->right = node;
 
-    if (node->parent == NULL) {
+    if (node->parent == NULL)
+    {
         node->color = BLACK;
         return;
     }
-    if (node->parent->parent == NULL) return;
+    if (node->parent->parent == NULL)
+        return;
 
     rb_insert_fixup(tree, node);
 }
 
 // Validator (Proves all properties)
-static int check_black_height(rbTree *tree, rbNode *node, bool *is_valid) {
-    if (node == tree->TNULL) return 1;
+static int check_black_height(rbTree* tree, rbNode* node, bool* is_valid)
+{
+    if (node == tree->TNULL)
+        return 1;
 
-    if (node->color == RED) {
-        if (node->left->color == RED || node->right->color == RED) {
+    if (node->color == RED)
+    {
+        if (node->left->color == RED || node->right->color == RED)
+        {
             *is_valid = false; // Double Red Violation
         }
     }
@@ -124,29 +162,36 @@ static int check_black_height(rbTree *tree, rbNode *node, bool *is_valid) {
     int left_bh = check_black_height(tree, node->left, is_valid);
     int right_bh = check_black_height(tree, node->right, is_valid);
 
-    if (left_bh != right_bh) *is_valid = false; // Black Height Violation
+    if (left_bh != right_bh)
+        *is_valid = false; // Black Height Violation
 
     return left_bh + (node->color == BLACK ? 1 : 0);
 }
 
-bool is_rb_tree_valid(rbTree *tree) {
-    if (tree->root->color != BLACK) return false;
+bool is_rb_tree_valid(rbTree* tree)
+{
+    if (tree->root->color != BLACK)
+        return false;
     bool is_valid = true;
     check_black_height(tree, tree->root, &is_valid);
     return is_valid;
 }
 
 // Memory Cleanup
-static void free_rb_nodes(rbTree *tree, rbNode *node) {
-    if (node != tree->TNULL) {
+static void free_rb_nodes(rbTree* tree, rbNode* node)
+{
+    if (node != tree->TNULL)
+    {
         free_rb_nodes(tree, node->left);
         free_rb_nodes(tree, node->right);
         free(node);
     }
 }
 
-void destroy_rb_tree(rbTree *tree) {
-    if (tree) {
+void destroy_rb_tree(rbTree* tree)
+{
+    if (tree)
+    {
         free_rb_nodes(tree, tree->root);
         free(tree->TNULL);
         free(tree);
@@ -154,21 +199,24 @@ void destroy_rb_tree(rbTree *tree) {
 }
 
 // Demo function
-void red_black_tree_demo(void) {
+void red_black_tree_demo(void)
+{
     printf("\n--- Red-Black Tree (Self-Balancing BST) Demo ---\n");
-    rbTree *tree = create_rb_tree();
-    
+    rbTree* tree = create_rb_tree();
+
     printf("Action: Inserting 10, 20, 30, 15, 25...\n");
     rb_insert(tree, 10);
     rb_insert(tree, 20);
     rb_insert(tree, 30);
     rb_insert(tree, 15);
     rb_insert(tree, 25);
-    
+
     bool valid = is_rb_tree_valid(tree);
-    printf("Invariant Check: Are all 5 RB-Tree properties holding? %s\n", valid ? "YES (Valid)" : "NO (Invalid)");
-    printf("Root of the tree is: %d (Color: %s)\n", tree->root->data, tree->root->color == BLACK ? "BLACK" : "RED");
-    
+    printf("Invariant Check: Are all 5 RB-Tree properties holding? %s\n",
+           valid ? "YES (Valid)" : "NO (Invalid)");
+    printf("Root of the tree is: %d (Color: %s)\n", tree->root->data,
+           tree->root->color == BLACK ? "BLACK" : "RED");
+
     destroy_rb_tree(tree);
     printf("------------------------------------------------\n\n");
 }

--- a/src/trees/trees.h
+++ b/src/trees/trees.h
@@ -156,29 +156,33 @@ void inorder_traversal(SegmentTree* st, int node, int start, int end);
 void postorder_traversal(SegmentTree* st, int node, int start, int end);
 void segment_tree_demo(void);
 
-
 // For Red-Black Tree (Self-Balancing BST)
-typedef enum { RED, BLACK } rbColor;
+typedef enum
+{
+    RED,
+    BLACK
+} rbColor;
 
-typedef struct rbNode {
+typedef struct rbNode
+{
     int data;
     rbColor color;
-    struct rbNode *left;
-    struct rbNode *right;
-    struct rbNode *parent;
+    struct rbNode* left;
+    struct rbNode* right;
+    struct rbNode* parent;
 } rbNode;
 
-typedef struct rbTree {
-    rbNode *root;
-    rbNode *TNULL;
+typedef struct rbTree
+{
+    rbNode* root;
+    rbNode* TNULL;
 } rbTree;
 
 rbTree* create_rb_tree(void);
-void rb_insert(rbTree *tree, int key);
-void rb_delete(rbTree *tree, int key);
-bool is_rb_tree_valid(rbTree *tree);
-void destroy_rb_tree(rbTree *tree);
+void rb_insert(rbTree* tree, int key);
+void rb_delete(rbTree* tree, int key);
+bool is_rb_tree_valid(rbTree* tree);
+void destroy_rb_tree(rbTree* tree);
 void red_black_tree_demo(void);
-
 
 #endif

--- a/tests/error_correction_algorithms/test_checksum.c
+++ b/tests/error_correction_algorithms/test_checksum.c
@@ -1,0 +1,96 @@
+#include "error_correction_algorithms.h"
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+
+void test_checksum_add(void)
+{
+    // Test 3-bit checksum addition (k=3)
+    // 111 + 001 = 1000 -> 000 + 1 = 001
+    assert(checksum_add(7, 1, 3) == 1);
+    assert(checksum_add(5, 3, 3) == 1);
+    assert(checksum_add(4, 4, 3) == 1);
+
+    // Test 8-bit checksum addition (k=8)
+    assert(checksum_add(255, 1, 8) == 1);
+    assert(checksum_add(100, 150, 8) == 250);
+
+    printf("test_checksum_add passed\n");
+}
+
+void test_checksum_bits_to_int(void)
+{
+    assert(checksum_bits_to_int("000", 3) == 0);
+    assert(checksum_bits_to_int("111", 3) == 7);
+    assert(checksum_bits_to_int("101", 3) == 5);
+    assert(checksum_bits_to_int("101010", 6) == 42);
+
+    printf("test_checksum_bits_to_int passed\n");
+}
+
+void test_checksum_block_sum(void)
+{
+    // Data: "10110011", len=8, k=4
+    // Blocks: "1011" (11) and "0011" (3)
+    // 11 + 3 = 14 ("1110")
+    int sum = checksum_block_sum("10110011", 8, 4);
+    assert(sum == 14);
+
+    // Data: "101", len=3, k=4 (padded with 0 to "1010" (10))
+    sum = checksum_block_sum("101", 3, 4);
+    assert(sum == 10);
+
+    printf("test_checksum_block_sum passed\n");
+}
+
+void test_checksum_transmission(void)
+{
+    // Simulate transmission
+    const char* data = "1011001110101111"; // 16 bits
+    int len = 16;
+    int k = 4;
+    int mask = (1 << k) - 1;
+
+    // Sender side
+    int sum = checksum_block_sum(data, len, k);
+    int checksum = (~sum) & mask;
+
+    // We convert checksum to binary string
+    char checksum_str[5];
+    for (int i = 0; i < k; i++)
+    {
+        checksum_str[i] = ((checksum >> (k - 1 - i)) & 1) ? '1' : '0';
+    }
+    checksum_str[k] = '\0';
+
+    // Receiver side: verification
+    int checkword = checksum_bits_to_int(checksum_str, k);
+    int rec_sum = checksum_block_sum(data, len, k);
+    rec_sum = checksum_add(rec_sum, checkword, k);
+
+    int complement = (~rec_sum) & mask;
+    assert(complement == 0); // No error detected
+
+    // Simulate error in data
+    char corrupt_data[17];
+    strcpy(corrupt_data, data);
+    corrupt_data[0] = (corrupt_data[0] == '1') ? '0' : '1'; // Flip first bit
+
+    int corrupt_rec_sum = checksum_block_sum(corrupt_data, len, k);
+    corrupt_rec_sum = checksum_add(corrupt_rec_sum, checkword, k);
+    int corrupt_complement = (~corrupt_rec_sum) & mask;
+    assert(corrupt_complement != 0); // Error detected!
+
+    printf("test_checksum_transmission passed\n");
+}
+
+int main(void)
+{
+    test_checksum_add();
+    test_checksum_bits_to_int();
+    test_checksum_block_sum();
+    test_checksum_transmission();
+
+    printf("All checksum tests passed successfully!\n");
+    return 0;
+}

--- a/tests/error_correction_algorithms/test_vrc.c
+++ b/tests/error_correction_algorithms/test_vrc.c
@@ -1,0 +1,86 @@
+#include "error_correction_algorithms.h"
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+
+/* VRC (Vertical Redundancy Check) logic lifted directly from vrc.c/vrc_receiver.c.
+   Since VRC has no extracted library helper, we replicate the logic here inline. */
+
+static int compute_parity_bit(const char* data)
+{
+    int ones = 0;
+    for (int i = 0; data[i] != '\0'; i++)
+    {
+        if (data[i] == '1')
+            ones++;
+    }
+    return (ones % 2 == 0) ? 0 : 1; // Even parity
+}
+
+static int verify_frame(const char* frame)
+{
+    int ones = 0;
+    for (int i = 0; frame[i] != '\0'; i++)
+    {
+        if (frame[i] == '1')
+            ones++;
+    }
+    return (ones % 2 == 0) ? 1 : 0; // Even parity: total 1s must be even
+}
+
+void test_vrc_even_parity(void)
+{
+    // "1011" has 3 ones -> odd -> parity bit = 1
+    assert(compute_parity_bit("1011") == 1);
+    // Transmitted frame: "10111"
+    assert(verify_frame("10111") == 1); // Even total 1s: 4 -> clean
+
+    // "1100" has 2 ones -> even -> parity bit = 0
+    assert(compute_parity_bit("1100") == 0);
+    // Transmitted frame: "11000"
+    assert(verify_frame("11000") == 1); // Even total 1s: 2 -> clean
+
+    printf("test_vrc_even_parity passed\n");
+}
+
+void test_vrc_error_detection(void)
+{
+    // "1011" + parity -> "10111", flip bit 0 -> "00111" (3 ones, odd -> error)
+    assert(verify_frame("00111") == 0); // Error detected
+
+    // "1100" + parity -> "11000", flip bit 2 -> "11100" (3 ones, odd -> error)
+    assert(verify_frame("11100") == 0); // Error detected
+
+    printf("test_vrc_error_detection passed\n");
+}
+
+void test_vrc_all_zeros(void)
+{
+    // "0000" has 0 ones -> even -> parity bit = 0
+    assert(compute_parity_bit("0000") == 0);
+    // Transmitted frame: "00000" -> 0 ones, even -> clean
+    assert(verify_frame("00000") == 1);
+
+    printf("test_vrc_all_zeros passed\n");
+}
+
+void test_vrc_all_ones(void)
+{
+    // "1111" has 4 ones -> even -> parity bit = 0
+    assert(compute_parity_bit("1111") == 0);
+    // Transmitted frame: "11110" -> 4 ones, even -> clean
+    assert(verify_frame("11110") == 1);
+
+    printf("test_vrc_all_ones passed\n");
+}
+
+int main(void)
+{
+    test_vrc_even_parity();
+    test_vrc_error_detection();
+    test_vrc_all_zeros();
+    test_vrc_all_ones();
+
+    printf("All VRC tests passed successfully!\n");
+    return 0;
+}


### PR DESCRIPTION
Closes #435

## Summary
Refactors Checksum and Vertical Redundancy Check (VRC) algorithms to extract their non-interactive helper functions, and adds comprehensive unit tests.

## Changes
- **`checksum.c`** – implement `checksum_bits_to_int()` (binary string to integer value)
- **`checksum_receiver.c`** – reuse the shared helper function
- **`error_correction_algorithms.h`** – declare `checksum_bits_to_int()`
- **`tests/error_correction_algorithms/test_checksum.c`** – new unit test suite
- **`tests/error_correction_algorithms/test_vrc.c`** – new VRC unit test suite
- **`Makefile`** – register test binaries and build rules