### PR TITLE
Feature/test eca part3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -120,7 +120,7 @@ TEST_BINS = test_circ_queue test_bst test_search test_hash_func \
             test_deque test_astar test_avl test_segment_tree \
             test_greedy_bfs test_sorting_n2 test_advanced_sorting \
             test_history_logger test_shell_sort test_trie test_btree test_bplus_tree test_parity_bit \
-            test_checksum test_vrc test_crc test_lrc \
+            test_checksum test_vrc test_crc test_lrc test_hamming \
             test_prim test_kruskal test_floyd_warshall test_mcm test_fibonacci test_knapsack test_lcs \
             test_string_algorithms test_expression_evaluation \
             test_fcfs test_sjf test_srtf test_round_robin test_priority_scheduling test_preemptive_priority \
@@ -600,6 +600,20 @@ $(TEST_DIR)/test_lrc$(EXE): \
 	tests/error_correction_algorithms/test_lrc.c
 	@$(call MKDIR_P,$(TEST_DIR))
 	$(CC) $(CFLAGS) $^ -o $@ $(LDFLAGS)
+
+test_hamming: $(TEST_DIR)/test_hamming$(EXE)
+	$(TEST_DIR)/test_hamming$(EXE)
+
+$(TEST_DIR)/test_hamming$(EXE): \
+	$(OBJ_DIR)/src/error_correction_algorithms/checksum.o \
+	$(OBJ_DIR)/src/error_correction_algorithms/hamming.o \
+	$(OBJ_DIR)/src/error_correction_algorithms/hamming_receiver.o \
+	$(OBJ_DIR)/src/utils/safe_input_int.o \
+	$(OBJ_DIR)/src/utils/history_logger.o \
+	tests/error_correction_algorithms/test_hamming.c
+	@$(call MKDIR_P,$(TEST_DIR))
+	$(CC) $(CFLAGS) $^ -o $@ $(LDFLAGS)
+
 
 test_expression_evaluation: $(TEST_DIR)/test_expression_evaluation$(EXE)
 	$(TEST_DIR)/test_expression_evaluation$(EXE)

--- a/Makefile
+++ b/Makefile
@@ -120,7 +120,7 @@ TEST_BINS = test_circ_queue test_bst test_search test_hash_func \
             test_deque test_astar test_avl test_segment_tree \
             test_greedy_bfs test_sorting_n2 test_advanced_sorting \
             test_history_logger test_shell_sort test_trie test_btree test_bplus_tree test_parity_bit \
-            test_checksum test_vrc \
+            test_checksum test_vrc test_crc test_lrc \
             test_prim test_kruskal test_floyd_warshall test_mcm test_fibonacci test_knapsack test_lcs \
             test_string_algorithms test_expression_evaluation \
             test_fcfs test_sjf test_srtf test_round_robin test_priority_scheduling test_preemptive_priority \
@@ -574,7 +574,32 @@ $(TEST_DIR)/test_vrc$(EXE): \
 	tests/error_correction_algorithms/test_vrc.c
 	@$(call MKDIR_P,$(TEST_DIR))
 	$(CC) $(CFLAGS) $^ -o $@ $(LDFLAGS)
-                                                                                                                                                                                                                                                                                         
+
+test_crc: $(TEST_DIR)/test_crc$(EXE)
+	$(TEST_DIR)/test_crc$(EXE)
+
+$(TEST_DIR)/test_crc$(EXE): \
+	$(OBJ_DIR)/src/error_correction_algorithms/checksum.o \
+	$(OBJ_DIR)/src/error_correction_algorithms/crc.o \
+	$(OBJ_DIR)/src/error_correction_algorithms/crc_receiver.o \
+	$(OBJ_DIR)/src/utils/safe_input_int.o \
+	$(OBJ_DIR)/src/utils/history_logger.o \
+	tests/error_correction_algorithms/test_crc.c
+	@$(call MKDIR_P,$(TEST_DIR))
+	$(CC) $(CFLAGS) $^ -o $@ $(LDFLAGS)
+
+test_lrc: $(TEST_DIR)/test_lrc$(EXE)
+	$(TEST_DIR)/test_lrc$(EXE)
+
+$(TEST_DIR)/test_lrc$(EXE): \
+	$(OBJ_DIR)/src/error_correction_algorithms/checksum.o \
+	$(OBJ_DIR)/src/error_correction_algorithms/lrc.o \
+	$(OBJ_DIR)/src/error_correction_algorithms/lrc_receiver.o \
+	$(OBJ_DIR)/src/utils/safe_input_int.o \
+	$(OBJ_DIR)/src/utils/history_logger.o \
+	tests/error_correction_algorithms/test_lrc.c
+	@$(call MKDIR_P,$(TEST_DIR))
+	$(CC) $(CFLAGS) $^ -o $@ $(LDFLAGS)
 
 test_expression_evaluation: $(TEST_DIR)/test_expression_evaluation$(EXE)
 	$(TEST_DIR)/test_expression_evaluation$(EXE)

--- a/Makefile
+++ b/Makefile
@@ -120,6 +120,7 @@ TEST_BINS = test_circ_queue test_bst test_search test_hash_func \
             test_deque test_astar test_avl test_segment_tree \
             test_greedy_bfs test_sorting_n2 test_advanced_sorting \
             test_history_logger test_shell_sort test_trie test_btree test_bplus_tree test_parity_bit \
+            test_checksum test_vrc \
             test_prim test_kruskal test_floyd_warshall test_mcm test_fibonacci test_knapsack test_lcs \
             test_string_algorithms test_expression_evaluation \
             test_fcfs test_sjf test_srtf test_round_robin test_priority_scheduling test_preemptive_priority \
@@ -547,7 +548,33 @@ test_parity_bit: $(TEST_DIR)/test_parity_bit$(EXE)
 
 $(TEST_DIR)/test_parity_bit$(EXE): $(OBJ_DIR)/src/error_correction_algorithms/parity_bit.o $(OBJ_DIR)/src/error_correction_algorithms/checksum.o $(OBJ_DIR)/src/utils/safe_input_int.o $(OBJ_DIR)/src/utils/history_logger.o tests/error_correction_algorithms/test_parity_bit.c
 	@$(call MKDIR_P,$(TEST_DIR))
-	$(CC) $(CFLAGS) $^ -o $@ $(LDFLAGS)                                                                                                                                                                                                                                                                                         
+	$(CC) $(CFLAGS) $^ -o $@ $(LDFLAGS)
+
+test_checksum: $(TEST_DIR)/test_checksum$(EXE)
+	$(TEST_DIR)/test_checksum$(EXE)
+
+$(TEST_DIR)/test_checksum$(EXE): \
+	$(OBJ_DIR)/src/error_correction_algorithms/checksum.o \
+	$(OBJ_DIR)/src/error_correction_algorithms/checksum_receiver.o \
+	$(OBJ_DIR)/src/utils/safe_input_int.o \
+	$(OBJ_DIR)/src/utils/history_logger.o \
+	tests/error_correction_algorithms/test_checksum.c
+	@$(call MKDIR_P,$(TEST_DIR))
+	$(CC) $(CFLAGS) $^ -o $@ $(LDFLAGS)
+
+test_vrc: $(TEST_DIR)/test_vrc$(EXE)
+	$(TEST_DIR)/test_vrc$(EXE)
+
+$(TEST_DIR)/test_vrc$(EXE): \
+	$(OBJ_DIR)/src/error_correction_algorithms/checksum.o \
+	$(OBJ_DIR)/src/error_correction_algorithms/vrc.o \
+	$(OBJ_DIR)/src/error_correction_algorithms/vrc_receiver.o \
+	$(OBJ_DIR)/src/utils/safe_input_int.o \
+	$(OBJ_DIR)/src/utils/history_logger.o \
+	tests/error_correction_algorithms/test_vrc.c
+	@$(call MKDIR_P,$(TEST_DIR))
+	$(CC) $(CFLAGS) $^ -o $@ $(LDFLAGS)
+                                                                                                                                                                                                                                                                                         
 
 test_expression_evaluation: $(TEST_DIR)/test_expression_evaluation$(EXE)
 	$(TEST_DIR)/test_expression_evaluation$(EXE)

--- a/src/error_correction_algorithms/checksum.c
+++ b/src/error_correction_algorithms/checksum.c
@@ -111,6 +111,17 @@ int checksum_block_sum(const char* data, int len, int k)
     return sum;
 }
 
+// converts a k-bit binary string into its integer value
+int checksum_bits_to_int(const char* bits, int k)
+{
+    int value = 0;
+    for (int i = 0; i < k; i++)
+    {
+        value = (value << 1) | (bits[i] - '0');
+    }
+    return value;
+}
+
 // checksum (sender side): the data is split into k-bit blocks and summed using
 // one's-complement (end-around carry) addition; the checksum is the one's complement
 // of that running sum. this is the value the sender appends to the data before

--- a/src/error_correction_algorithms/checksum_receiver.c
+++ b/src/error_correction_algorithms/checksum_receiver.c
@@ -5,16 +5,6 @@
 #include <string.h>
 #include <time.h>
 
-// converts a k-bit binary string into its integer value
-int checksum_bits_to_int(const char* bits, int k)
-{
-    int value = 0;
-    for (int i = 0; i < k; i++)
-    {
-        value = (value << 1) | (bits[i] - '0');
-    }
-    return value;
-}
 // checksum (receiver side): re-runs the one's-complement block sum over the received
 // data, then folds in the received checksum block. if the one's complement of the
 // total is all zeros the frame is accepted, otherwise an error is detected. this is

--- a/src/error_correction_algorithms/crc.c
+++ b/src/error_correction_algorithms/crc.c
@@ -13,6 +13,87 @@ void crc_xor_operation(char* dividend, const char* divisor, int pos)
     }
 }
 
+// crc_generate: computes the CRC remainder for `data` using `generator` via
+// modulo-2 (XOR) division.  The remainder is written to `remainder_out` and,
+// if `codeword_out` is not NULL, the full transmitted codeword (data + CRC) is
+// written there too.
+void crc_generate(const char* data, const char* generator, char* remainder_out, char* codeword_out)
+{
+    int data_len = (int)strlen(data);
+    int generator_len = (int)strlen(generator);
+
+    // Append (generator_len - 1) zero bits to data to form the dividend
+    char dividend[(CHECKSUM_MAX_BITS * 2) + 1];
+    strcpy(dividend, data);
+    for (int i = 0; i < generator_len - 1; i++)
+    {
+        dividend[data_len + i] = '0';
+    }
+    int dividend_len = data_len + generator_len - 1;
+    dividend[dividend_len] = '\0';
+
+    // Modulo-2 division
+    for (int i = 0; i <= dividend_len - generator_len; i++)
+    {
+        if (dividend[i] == '1')
+        {
+            crc_xor_operation(dividend, generator, i);
+        }
+    }
+
+    // Extract the remainder (last generator_len-1 bits)
+    for (int i = 0; i < generator_len - 1; i++)
+    {
+        remainder_out[i] = dividend[dividend_len - (generator_len - 1) + i];
+    }
+    remainder_out[generator_len - 1] = '\0';
+
+    if (codeword_out != NULL)
+    {
+        strcpy(codeword_out, data);
+        strcat(codeword_out, remainder_out);
+    }
+}
+
+// crc_verify: re-divides a received `codeword` by `generator`.  If the
+// remainder is all zeros the frame is clean and 1 is returned; otherwise 0 is
+// returned (error detected).  The computed remainder is optionally written to
+// `remainder_out`.
+int crc_verify(const char* codeword, const char* generator, char* remainder_out)
+{
+    int generator_len = (int)strlen(generator);
+    int codeword_len = (int)strlen(codeword);
+
+    char dividend[(CHECKSUM_MAX_BITS * 2) + 1];
+    strcpy(dividend, codeword);
+
+    for (int i = 0; i <= codeword_len - generator_len; i++)
+    {
+        if (dividend[i] == '1')
+        {
+            crc_xor_operation(dividend, generator, i);
+        }
+    }
+
+    // The remainder is the last (generator_len-1) bits
+    char remainder[CHECKSUM_MAX_BITS + 1];
+    strcpy(remainder, &dividend[codeword_len - (generator_len - 1)]);
+
+    if (remainder_out != NULL)
+    {
+        strcpy(remainder_out, remainder);
+    }
+
+    for (int i = 0; remainder[i] != '\0'; i++)
+    {
+        if (remainder[i] == '1')
+        {
+            return 0; // Error detected
+        }
+    }
+    return 1; // No error
+}
+
 void crc_demo(void)
 {
     while (1)
@@ -47,7 +128,6 @@ void crc_demo(void)
             continue;
         }
 
-        int data_len = (int)strlen(data);
         int generator_len = (int)strlen(generator);
 
         if (generator_len < 2)
@@ -56,42 +136,14 @@ void crc_demo(void)
             continue;
         }
 
-        char dividend[(CHECKSUM_MAX_BITS * 2) + 1];
+        char remainder[CHECKSUM_MAX_BITS + 1];
+        char codeword[(CHECKSUM_MAX_BITS * 2) + 1];
 
-        strcpy(dividend, data);
-
-        for (int i = 0; i < generator_len - 1; i++)
-        {
-            dividend[data_len + i] = '0';
-        }
-
-        dividend[data_len + generator_len - 1] = '\0';
+        crc_generate(data, generator, remainder, codeword);
 
         printf("\nOriginal Data : %s", data);
         printf("\nGenerator     : %s", generator);
-        printf("\nDividend      : %s\n", dividend);
-
-        int dividend_len = (int)strlen(dividend);
-
-        printf("\nPerforming modulo-2 division...\n");
-
-        for (int i = 0; i <= dividend_len - generator_len; i++)
-        {
-            if (dividend[i] == '1')
-            {
-                crc_xor_operation(dividend, generator, i);
-            }
-        }
-
-        char remainder[CHECKSUM_MAX_BITS + 1];
-        for (int i = 0; i < generator_len - 1; i++)
-        {
-            remainder[i] = dividend[dividend_len - (generator_len - 1) + i];
-        }
-        remainder[generator_len - 1] = '\0';
-
         printf("\nCRC Remainder : %s", remainder);
-
-        printf("\nTransmitted Codeword : %s%s\n", data, remainder);
+        printf("\nTransmitted Codeword : %s\n", codeword);
     }
 }

--- a/src/error_correction_algorithms/crc_receiver.c
+++ b/src/error_correction_algorithms/crc_receiver.c
@@ -58,42 +58,12 @@ void crc_receiver_demo(void)
             continue;
         }
 
-        char dividend[(CHECKSUM_MAX_BITS * 2) + 1];
-        strcpy(dividend, received_codeword);
-
-        printf("\nReceived Codeword : %s", received_codeword);
-        printf("\nGenerator         : %s\n", generator);
-
-        printf("\nPerforming modulo-2 division...\n");
-
-        int dividend_len = (int)strlen(dividend);
-
-        for (int i = 0; i <= dividend_len - generator_len; i++)
-        {
-            if (dividend[i] == '1')
-            {
-                crc_xor_operation(dividend, generator, i);
-            }
-        }
-
         char remainder[CHECKSUM_MAX_BITS + 1];
-
-        strcpy(remainder, &dividend[dividend_len - (generator_len - 1)]);
+        int is_valid = crc_verify(received_codeword, generator, remainder);
 
         printf("\nComputed Remainder : %s\n", remainder);
 
-        int error_detected = 0;
-
-        for (int i = 0; remainder[i] != '\0'; i++)
-        {
-            if (remainder[i] == '1')
-            {
-                error_detected = 1;
-                break;
-            }
-        }
-
-        if (error_detected)
+        if (!is_valid)
         {
             printf("\n[ERROR] Transmission error detected.\n");
         }

--- a/src/error_correction_algorithms/error_correction_algorithms.h
+++ b/src/error_correction_algorithms/error_correction_algorithms.h
@@ -54,4 +54,8 @@ int crc_verify(const char* codeword, const char* generator, char* remainder_out)
 void lrc_calculate(const char* const* words, int num_words, int word_len, char* lrc_out);
 int lrc_verify(const char* const* words, int num_words, int word_len, const char* received_lrc);
 
+/* Hamming Logic */
+void hamming_generate(const char* data, char* codeword_out);
+int hamming_verify(const char* received_codeword, char* corrected_codeword_out, char* data_out);
+
 #endif /* ERROR_CORRECTION_ALGORITHMS_H */

--- a/src/error_correction_algorithms/error_correction_algorithms.h
+++ b/src/error_correction_algorithms/error_correction_algorithms.h
@@ -47,5 +47,11 @@ int checksum_block_sum(const char* data, int len, int k);
 int checksum_bits_to_int(const char* bits, int k);
 
 void crc_xor_operation(char* dividend, const char* divisor, int pos);
+void crc_generate(const char* data, const char* generator, char* remainder_out, char* codeword_out);
+int crc_verify(const char* codeword, const char* generator, char* remainder_out);
+
+/* LRC Logic */
+void lrc_calculate(const char* const* words, int num_words, int word_len, char* lrc_out);
+int lrc_verify(const char* const* words, int num_words, int word_len, const char* received_lrc);
 
 #endif /* ERROR_CORRECTION_ALGORITHMS_H */

--- a/src/error_correction_algorithms/error_correction_algorithms.h
+++ b/src/error_correction_algorithms/error_correction_algorithms.h
@@ -44,6 +44,7 @@ void checksum_print_binary(int value, int bits);
 int safe_input_binary_string(char* buff, size_t size, const char* prompt);
 int checksum_add(int sum, int word, int k);
 int checksum_block_sum(const char* data, int len, int k);
+int checksum_bits_to_int(const char* bits, int k);
 
 void crc_xor_operation(char* dividend, const char* divisor, int pos);
 

--- a/src/error_correction_algorithms/hamming.c
+++ b/src/error_correction_algorithms/hamming.c
@@ -3,9 +3,133 @@
 #include <stdio.h>
 #include <string.h>
 
-// hamming code generation (sender side). the user supplies the binary data bits and
-// we build the (n, k) codeword by inserting r even-parity bits at the power-of-2
-// positions (1, 2, 4, 8, ...). a 1-based layout keeps the parity maths readable.
+// hamming_generate: builds the (n,k) Hamming codeword for `data` by inserting
+// r even-parity bits at the power-of-2 positions (1, 2, 4, 8, …).
+// The codeword is written to `codeword_out` (caller must supply a buffer of at
+// least k + ceil(log2(k+r+1)) + 1 bytes; CHECKSUM_MAX_BITS + 16 is safe).
+void hamming_generate(const char* data, char* codeword_out)
+{
+    int k = (int)strlen(data);
+
+    // Smallest r such that 2^r >= k + r + 1
+    int r = 0;
+    while ((1 << r) < (k + r + 1))
+    {
+        r++;
+    }
+    int n = k + r;
+
+    // ham[1..n]: power-of-2 positions are parity placeholders, all others hold data
+    int ham[CHECKSUM_MAX_BITS + 16];
+    int data_index = 0;
+    for (int pos = 1; pos <= n; pos++)
+    {
+        if ((pos & (pos - 1)) == 0) // power of two -> parity position
+        {
+            ham[pos] = 0;
+        }
+        else
+        {
+            ham[pos] = data[data_index] - '0';
+            data_index++;
+        }
+    }
+
+    // Compute each parity bit (even parity) over every position it covers
+    for (int i = 0; i < r; i++)
+    {
+        int parity_pos = (1 << i);
+        int parity = 0;
+        for (int pos = 1; pos <= n; pos++)
+        {
+            if ((pos & parity_pos) && pos != parity_pos)
+            {
+                parity ^= ham[pos];
+            }
+        }
+        ham[parity_pos] = parity;
+    }
+
+    for (int pos = 1; pos <= n; pos++)
+    {
+        codeword_out[pos - 1] = ham[pos] + '0';
+    }
+    codeword_out[n] = '\0';
+}
+
+// hamming_verify: recomputes the syndrome from a received codeword and returns
+// the 1-based position of a single-bit error (0 = no error, >n = uncorrectable
+// multi-bit error).  If the error position is within range it is corrected
+// in-place.  The corrected codeword and recovered data bits are written to
+// `corrected_codeword_out` and `data_out` respectively (both may be NULL).
+int hamming_verify(const char* received_codeword, char* corrected_codeword_out, char* data_out)
+{
+    int n = (int)strlen(received_codeword);
+
+    int ham[CHECKSUM_MAX_BITS + 16];
+    for (int pos = 1; pos <= n; pos++)
+    {
+        ham[pos] = received_codeword[pos - 1] - '0';
+    }
+
+    int r = 0;
+    while ((1 << r) <= n)
+    {
+        r++;
+    }
+
+    // Build syndrome
+    int syndrome = 0;
+    for (int i = 0; i < r; i++)
+    {
+        int parity_pos = (1 << i);
+        int parity = 0;
+        for (int pos = 1; pos <= n; pos++)
+        {
+            if (pos & parity_pos)
+            {
+                parity ^= ham[pos];
+            }
+        }
+        if (parity)
+        {
+            syndrome += parity_pos;
+        }
+    }
+
+    // Correct single-bit error if within range
+    if (syndrome > 0 && syndrome <= n)
+    {
+        ham[syndrome] ^= 1;
+    }
+
+    if (corrected_codeword_out != NULL)
+    {
+        for (int pos = 1; pos <= n; pos++)
+        {
+            corrected_codeword_out[pos - 1] = ham[pos] + '0';
+        }
+        corrected_codeword_out[n] = '\0';
+    }
+
+    if (data_out != NULL)
+    {
+        int data_idx = 0;
+        for (int pos = 1; pos <= n; pos++)
+        {
+            if ((pos & (pos - 1)) != 0) // not a power of two -> data bit
+            {
+                data_out[data_idx] = ham[pos] + '0';
+                data_idx++;
+            }
+        }
+        data_out[data_idx] = '\0';
+    }
+
+    return syndrome;
+}
+
+// hamming code generation demo (sender side).
 void hamming_demo(void)
 {
     while (1)
@@ -27,84 +151,30 @@ void hamming_demo(void)
             continue;
         }
 
+        char codeword[CHECKSUM_MAX_BITS + 16];
+        hamming_generate(data, codeword);
+
         int k = (int)strlen(data);
-
-        // number of parity bits r: the smallest r with 2^r >= k + r + 1, so that every
-        // codeword position (data + parity) can be addressed by the r parity checks.
-        int r = 0;
-        while ((1 << r) < (k + r + 1))
-        {
-            r++;
-        }
-
-        int n = k + r;
-
-        // ham[1..n] is the codeword in transmission order (position 1 is the MSB end).
-        int ham[CHECKSUM_MAX_BITS + 16];
-
-        // lay out the frame: power-of-2 positions are parity placeholders (filled below),
-        // every other position takes the next data bit in order.
-        int data_index = 0;
-        for (int pos = 1; pos <= n; pos++)
-        {
-            if ((pos & (pos - 1)) == 0) // pos is a power of two -> parity position
-            {
-                ham[pos] = 0;
-            }
-            else
-            {
-                ham[pos] = data[data_index] - '0';
-                data_index++;
-            }
-        }
-
-        // compute each parity bit (even parity) over the positions it covers: parity bit
-        // at position p = 2^i covers every position whose index has bit i set.
-        for (int i = 0; i < r; i++)
-        {
-            int parity_pos = (1 << i);
-            int parity = 0;
-
-            for (int pos = 1; pos <= n; pos++)
-            {
-                if ((pos & parity_pos) && pos != parity_pos)
-                {
-                    parity ^= ham[pos];
-                }
-            }
-
-            ham[parity_pos] = parity;
-        }
+        int n = (int)strlen(codeword);
+        int r = n - k;
 
         printf("\nData bits (k)        : %d", k);
         printf("\nParity bits (r)      : %d", r);
         printf("\nCodeword length (n)  : %d", n);
-
-        printf("\nParity bit values    :");
-        for (int i = 0; i < r; i++)
-        {
-            int parity_pos = (1 << i);
-            printf(" P%d=%d", parity_pos, ham[parity_pos]);
-        }
 
         printf("\nHamming Code (P=parity, transmitted left to right):\n");
         for (int pos = 1; pos <= n; pos++)
         {
             if ((pos & (pos - 1)) == 0)
             {
-                printf("P%d=%d ", pos, ham[pos]);
+                printf("P%d=%c ", pos, codeword[pos - 1]);
             }
             else
             {
-                printf("D%d=%d ", pos, ham[pos]);
+                printf("D%d=%c ", pos, codeword[pos - 1]);
             }
         }
 
-        printf("\nGenerated Hamming Code (%d,%d): ", n, k);
-        for (int pos = 1; pos <= n; pos++)
-        {
-            printf("%d", ham[pos]);
-        }
-        printf("\n");
+        printf("\nGenerated Hamming Code (%d,%d): %s\n", n, k, codeword);
     }
 }

--- a/src/error_correction_algorithms/hamming_receiver.c
+++ b/src/error_correction_algorithms/hamming_receiver.c
@@ -3,9 +3,7 @@
 #include <stdio.h>
 #include <string.h>
 
-// hamming code receiver (decoder). given a received codeword we recompute the parity
-// checks to form the syndrome: read as a binary number it is the 1-based position of a
-// single-bit error (0 means no error). flipping that bit corrects the codeword.
+// hamming code receiver (decoder) demo.
 void hamming_receiver_demo(void)
 {
     while (1)
@@ -29,42 +27,16 @@ void hamming_receiver_demo(void)
         }
 
         int n = (int)strlen(frame);
-
-        // ham[1..n] is the received codeword in transmission order (1-based, MSB end).
-        int ham[CHECKSUM_MAX_BITS + 16];
-        for (int pos = 1; pos <= n; pos++)
-        {
-            ham[pos] = frame[pos - 1] - '0';
-        }
-
-        // number of parity bits r = count of power-of-2 positions that fit in n.
         int r = 0;
         while ((1 << r) <= n)
         {
             r++;
         }
 
-        // build the syndrome: bit i is the even-parity check over every position whose
-        // index has bit i set (the parity bit itself is included in its own check).
-        int syndrome = 0;
-        for (int i = 0; i < r; i++)
-        {
-            int parity_pos = (1 << i);
-            int parity = 0;
+        char corrected_frame[CHECKSUM_MAX_BITS + 16];
+        char data_out[CHECKSUM_MAX_BITS + 16];
 
-            for (int pos = 1; pos <= n; pos++)
-            {
-                if (pos & parity_pos)
-                {
-                    parity ^= ham[pos];
-                }
-            }
-
-            if (parity)
-            {
-                syndrome += parity_pos;
-            }
-        }
+        int syndrome = hamming_verify(frame, corrected_frame, data_out);
 
         printf("\nReceived codeword    : %s", frame);
         printf("\nCodeword length (n)  : %d", n);
@@ -77,8 +49,7 @@ void hamming_receiver_demo(void)
         }
         else if (syndrome > n)
         {
-            // the syndrome points past the frame: more than a single-bit error, which a
-            // basic Hamming code cannot reliably locate.
+            // syndrome points outside frame: multi-bit error, cannot correct
             printf("\nResult               : syndrome %d is out of range -- "
                    "multiple-bit error, cannot correct",
                    syndrome);
@@ -87,24 +58,9 @@ void hamming_receiver_demo(void)
         {
             printf("\nResult               : error detected at position %d -- correcting",
                    syndrome);
-            ham[syndrome] ^= 1;
-
-            printf("\nCorrected codeword   : ");
-            for (int pos = 1; pos <= n; pos++)
-            {
-                printf("%d", ham[pos]);
-            }
+            printf("\nCorrected codeword   : %s", corrected_frame);
         }
 
-        // recover the data bits (every position that is not a power of two).
-        printf("\nRecovered data bits  : ");
-        for (int pos = 1; pos <= n; pos++)
-        {
-            if ((pos & (pos - 1)) != 0)
-            {
-                printf("%d", ham[pos]);
-            }
-        }
-        printf("\n");
+        printf("\nRecovered data bits  : %s\n", data_out);
     }
 }

--- a/src/error_correction_algorithms/lrc.c
+++ b/src/error_correction_algorithms/lrc.c
@@ -14,12 +14,38 @@
 #define LRC_MAX_ROWS 20
 #define LRC_MAX_COLS 64
 
+// lrc_calculate: computes the LRC by XOR-ing each column across all `words`.
+// Writes a null-terminated binary string of length `word_len` to `lrc_out`.
+void lrc_calculate(const char* const* words, int num_words, int word_len, char* lrc_out)
+{
+    for (int j = 0; j < word_len; j++)
+    {
+        int ones = 0;
+        for (int i = 0; i < num_words; i++)
+        {
+            if (words[i][j] == '1')
+            {
+                ones++;
+            }
+        }
+        lrc_out[j] = (ones % 2 == 0) ? '0' : '1';
+    }
+    lrc_out[word_len] = '\0';
+}
+
+// lrc_verify: returns 1 if the computed LRC matches `received_lrc`, 0 otherwise.
+int lrc_verify(const char* const* words, int num_words, int word_len, const char* received_lrc)
+{
+    char computed_lrc[LRC_MAX_COLS + 1];
+    lrc_calculate(words, num_words, word_len, computed_lrc);
+    return (strcmp(computed_lrc, received_lrc) == 0) ? 1 : 0;
+}
+
 void lrc_demo(void)
 {
     int rows;
     printf("\n=== LRC (Longitudinal Redundancy Check) ===\n");
 
-    // Fix 1: Use safe_input_int() instead of scanf()
     int result = safe_input_int(&rows, "Enter number of data words (1-20): ", 1, LRC_MAX_ROWS);
     if (result == -111)
     {
@@ -38,7 +64,6 @@ void lrc_demo(void)
     printf("Enter binary data words (same length, e.g. 10110011):\n");
     for (int i = 0; i < rows; i++)
     {
-        // Fix 2: Use fgets() instead of scanf() for strings
         printf("  Word %d: ", i + 1);
         if (fgets(data[i], sizeof(data[i]), stdin) == NULL)
         {
@@ -46,7 +71,6 @@ void lrc_demo(void)
             return;
         }
 
-        // Remove trailing newline; if absent, input exceeded buffer — flush stdin
         int len = strlen(data[i]);
         if (len > 0 && data[i][len - 1] == '\n')
         {
@@ -60,7 +84,6 @@ void lrc_demo(void)
                 ;
         }
 
-        /* validate: only '0' and '1' allowed */
         if (len == 0)
         {
             printf("Error: word cannot be empty.\n");
@@ -76,7 +99,6 @@ void lrc_demo(void)
             }
         }
 
-        /* all words must have the same length */
         if (cols == -1)
         {
             cols = len;
@@ -88,21 +110,15 @@ void lrc_demo(void)
         }
     }
 
-    /* compute LRC: XOR each column across all rows */
-    char lrc[LRC_MAX_COLS + 1];
-    for (int j = 0; j < cols; j++)
+    const char* words[LRC_MAX_ROWS];
+    for (int i = 0; i < rows; i++)
     {
-        int ones = 0;
-        for (int i = 0; i < rows; i++)
-        {
-            if (data[i][j] == '1')
-                ones++;
-        }
-        lrc[j] = (ones % 2 == 0) ? '0' : '1';
+        words[i] = data[i];
     }
-    lrc[cols] = '\0';
 
-    /* display results */
+    char lrc[LRC_MAX_COLS + 1];
+    lrc_calculate(words, rows, cols, lrc);
+
     printf("\nTransmitted Block:\n");
     printf("------------------\n");
     for (int i = 0; i < rows; i++)

--- a/src/error_correction_algorithms/lrc_receiver.c
+++ b/src/error_correction_algorithms/lrc_receiver.c
@@ -82,6 +82,12 @@ void lrc_receiver_demo(void)
         }
     }
 
+    const char* words[LRC_MAX_ROWS];
+    for (int i = 0; i < rows; i++)
+    {
+        words[i] = data[i];
+    }
+
     char received_lrc[LRC_MAX_COLS + 1];
 
     printf("Enter received LRC: ");
@@ -113,29 +119,12 @@ void lrc_receiver_demo(void)
     }
 
     char computed_lrc[LRC_MAX_COLS + 1];
-
-    for (int j = 0; j < cols; j++)
-    {
-        int ones = 0;
-
-        for (int i = 0; i < rows; i++)
-        {
-            if (data[i][j] == '1')
-            {
-                ones++;
-            }
-        }
-
-        computed_lrc[j] = (ones % 2 == 0) ? '0' : '1';
-    }
-
-    computed_lrc[cols] = '\0';
+    lrc_calculate(words, rows, cols, computed_lrc);
 
     printf("\nReceived LRC : %s\n", received_lrc);
-
     printf("Computed LRC : %s\n", computed_lrc);
 
-    if (strcmp(received_lrc, computed_lrc) == 0)
+    if (lrc_verify(words, rows, cols, received_lrc))
     {
         printf("\n[SUCCESS] No error detected. Data accepted.\n");
     }

--- a/src/trees/red_black_tree.c
+++ b/src/trees/red_black_tree.c
@@ -3,8 +3,9 @@
 #include <stdlib.h>
 
 // Core Initialization
-rbTree* create_rb_tree(void) {
-    rbTree *tree = (rbTree*)malloc(sizeof(rbTree));
+rbTree* create_rb_tree(void)
+{
+    rbTree* tree = (rbTree*)malloc(sizeof(rbTree));
     tree->TNULL = (rbNode*)malloc(sizeof(rbNode));
     tree->TNULL->color = BLACK;
     tree->TNULL->left = NULL;
@@ -14,43 +15,60 @@ rbTree* create_rb_tree(void) {
 }
 
 // Rotations
-static void rb_left_rotate(rbTree *tree, rbNode *x) {
-    rbNode *y = x->right;
+static void rb_left_rotate(rbTree* tree, rbNode* x)
+{
+    rbNode* y = x->right;
     x->right = y->left;
-    if (y->left != tree->TNULL) y->left->parent = x;
+    if (y->left != tree->TNULL)
+        y->left->parent = x;
     y->parent = x->parent;
-    if (x->parent == NULL) tree->root = y;
-    else if (x == x->parent->left) x->parent->left = y;
-    else x->parent->right = y;
+    if (x->parent == NULL)
+        tree->root = y;
+    else if (x == x->parent->left)
+        x->parent->left = y;
+    else
+        x->parent->right = y;
     y->left = x;
     x->parent = y;
 }
 
-static void rb_right_rotate(rbTree *tree, rbNode *x) {
-    rbNode *y = x->left;
+static void rb_right_rotate(rbTree* tree, rbNode* x)
+{
+    rbNode* y = x->left;
     x->left = y->right;
-    if (y->right != tree->TNULL) y->right->parent = x;
+    if (y->right != tree->TNULL)
+        y->right->parent = x;
     y->parent = x->parent;
-    if (x->parent == NULL) tree->root = y;
-    else if (x == x->parent->right) x->parent->right = y;
-    else x->parent->left = y;
+    if (x->parent == NULL)
+        tree->root = y;
+    else if (x == x->parent->right)
+        x->parent->right = y;
+    else
+        x->parent->left = y;
     y->right = x;
     x->parent = y;
 }
 
 // Insert Fixup
-static void rb_insert_fixup(rbTree *tree, rbNode *k) {
-    rbNode *u;
-    while (k->parent != NULL && k->parent->color == RED) {
-        if (k->parent == k->parent->parent->right) {
+static void rb_insert_fixup(rbTree* tree, rbNode* k)
+{
+    rbNode* u;
+    while (k->parent != NULL && k->parent->color == RED)
+    {
+        if (k->parent == k->parent->parent->right)
+        {
             u = k->parent->parent->left; // uncle
-            if (u->color == RED) {
+            if (u->color == RED)
+            {
                 u->color = BLACK;
                 k->parent->color = BLACK;
                 k->parent->parent->color = RED;
                 k = k->parent->parent;
-            } else {
-                if (k == k->parent->left) {
+            }
+            else
+            {
+                if (k == k->parent->left)
+                {
                     k = k->parent;
                     rb_right_rotate(tree, k);
                 }
@@ -58,15 +76,21 @@ static void rb_insert_fixup(rbTree *tree, rbNode *k) {
                 k->parent->parent->color = RED;
                 rb_left_rotate(tree, k->parent->parent);
             }
-        } else {
+        }
+        else
+        {
             u = k->parent->parent->right; // uncle
-            if (u->color == RED) {
+            if (u->color == RED)
+            {
                 u->color = BLACK;
                 k->parent->color = BLACK;
                 k->parent->parent->color = RED;
                 k = k->parent->parent;
-            } else {
-                if (k == k->parent->right) {
+            }
+            else
+            {
+                if (k == k->parent->right)
+                {
                     k = k->parent;
                     rb_left_rotate(tree, k);
                 }
@@ -75,48 +99,62 @@ static void rb_insert_fixup(rbTree *tree, rbNode *k) {
                 rb_right_rotate(tree, k->parent->parent);
             }
         }
-        if (k == tree->root) break;
+        if (k == tree->root)
+            break;
     }
     tree->root->color = BLACK;
 }
 
-void rb_insert(rbTree *tree, int key) {
-    rbNode *node = (rbNode*)malloc(sizeof(rbNode));
+void rb_insert(rbTree* tree, int key)
+{
+    rbNode* node = (rbNode*)malloc(sizeof(rbNode));
     node->data = key;
     node->parent = NULL;
     node->left = tree->TNULL;
     node->right = tree->TNULL;
     node->color = RED;
 
-    rbNode *y = NULL;
-    rbNode *x = tree->root;
+    rbNode* y = NULL;
+    rbNode* x = tree->root;
 
-    while (x != tree->TNULL) {
+    while (x != tree->TNULL)
+    {
         y = x;
-        if (node->data < x->data) x = x->left;
-        else x = x->right;
+        if (node->data < x->data)
+            x = x->left;
+        else
+            x = x->right;
     }
 
     node->parent = y;
-    if (y == NULL) tree->root = node;
-    else if (node->data < y->data) y->left = node;
-    else y->right = node;
+    if (y == NULL)
+        tree->root = node;
+    else if (node->data < y->data)
+        y->left = node;
+    else
+        y->right = node;
 
-    if (node->parent == NULL) {
+    if (node->parent == NULL)
+    {
         node->color = BLACK;
         return;
     }
-    if (node->parent->parent == NULL) return;
+    if (node->parent->parent == NULL)
+        return;
 
     rb_insert_fixup(tree, node);
 }
 
 // Validator (Proves all properties)
-static int check_black_height(rbTree *tree, rbNode *node, bool *is_valid) {
-    if (node == tree->TNULL) return 1;
+static int check_black_height(rbTree* tree, rbNode* node, bool* is_valid)
+{
+    if (node == tree->TNULL)
+        return 1;
 
-    if (node->color == RED) {
-        if (node->left->color == RED || node->right->color == RED) {
+    if (node->color == RED)
+    {
+        if (node->left->color == RED || node->right->color == RED)
+        {
             *is_valid = false; // Double Red Violation
         }
     }
@@ -124,29 +162,36 @@ static int check_black_height(rbTree *tree, rbNode *node, bool *is_valid) {
     int left_bh = check_black_height(tree, node->left, is_valid);
     int right_bh = check_black_height(tree, node->right, is_valid);
 
-    if (left_bh != right_bh) *is_valid = false; // Black Height Violation
+    if (left_bh != right_bh)
+        *is_valid = false; // Black Height Violation
 
     return left_bh + (node->color == BLACK ? 1 : 0);
 }
 
-bool is_rb_tree_valid(rbTree *tree) {
-    if (tree->root->color != BLACK) return false;
+bool is_rb_tree_valid(rbTree* tree)
+{
+    if (tree->root->color != BLACK)
+        return false;
     bool is_valid = true;
     check_black_height(tree, tree->root, &is_valid);
     return is_valid;
 }
 
 // Memory Cleanup
-static void free_rb_nodes(rbTree *tree, rbNode *node) {
-    if (node != tree->TNULL) {
+static void free_rb_nodes(rbTree* tree, rbNode* node)
+{
+    if (node != tree->TNULL)
+    {
         free_rb_nodes(tree, node->left);
         free_rb_nodes(tree, node->right);
         free(node);
     }
 }
 
-void destroy_rb_tree(rbTree *tree) {
-    if (tree) {
+void destroy_rb_tree(rbTree* tree)
+{
+    if (tree)
+    {
         free_rb_nodes(tree, tree->root);
         free(tree->TNULL);
         free(tree);
@@ -154,21 +199,24 @@ void destroy_rb_tree(rbTree *tree) {
 }
 
 // Demo function
-void red_black_tree_demo(void) {
+void red_black_tree_demo(void)
+{
     printf("\n--- Red-Black Tree (Self-Balancing BST) Demo ---\n");
-    rbTree *tree = create_rb_tree();
-    
+    rbTree* tree = create_rb_tree();
+
     printf("Action: Inserting 10, 20, 30, 15, 25...\n");
     rb_insert(tree, 10);
     rb_insert(tree, 20);
     rb_insert(tree, 30);
     rb_insert(tree, 15);
     rb_insert(tree, 25);
-    
+
     bool valid = is_rb_tree_valid(tree);
-    printf("Invariant Check: Are all 5 RB-Tree properties holding? %s\n", valid ? "YES (Valid)" : "NO (Invalid)");
-    printf("Root of the tree is: %d (Color: %s)\n", tree->root->data, tree->root->color == BLACK ? "BLACK" : "RED");
-    
+    printf("Invariant Check: Are all 5 RB-Tree properties holding? %s\n",
+           valid ? "YES (Valid)" : "NO (Invalid)");
+    printf("Root of the tree is: %d (Color: %s)\n", tree->root->data,
+           tree->root->color == BLACK ? "BLACK" : "RED");
+
     destroy_rb_tree(tree);
     printf("------------------------------------------------\n\n");
 }

--- a/src/trees/trees.h
+++ b/src/trees/trees.h
@@ -156,29 +156,33 @@ void inorder_traversal(SegmentTree* st, int node, int start, int end);
 void postorder_traversal(SegmentTree* st, int node, int start, int end);
 void segment_tree_demo(void);
 
-
 // For Red-Black Tree (Self-Balancing BST)
-typedef enum { RED, BLACK } rbColor;
+typedef enum
+{
+    RED,
+    BLACK
+} rbColor;
 
-typedef struct rbNode {
+typedef struct rbNode
+{
     int data;
     rbColor color;
-    struct rbNode *left;
-    struct rbNode *right;
-    struct rbNode *parent;
+    struct rbNode* left;
+    struct rbNode* right;
+    struct rbNode* parent;
 } rbNode;
 
-typedef struct rbTree {
-    rbNode *root;
-    rbNode *TNULL;
+typedef struct rbTree
+{
+    rbNode* root;
+    rbNode* TNULL;
 } rbTree;
 
 rbTree* create_rb_tree(void);
-void rb_insert(rbTree *tree, int key);
-void rb_delete(rbTree *tree, int key);
-bool is_rb_tree_valid(rbTree *tree);
-void destroy_rb_tree(rbTree *tree);
+void rb_insert(rbTree* tree, int key);
+void rb_delete(rbTree* tree, int key);
+bool is_rb_tree_valid(rbTree* tree);
+void destroy_rb_tree(rbTree* tree);
 void red_black_tree_demo(void);
-
 
 #endif

--- a/tests/error_correction_algorithms/test_checksum.c
+++ b/tests/error_correction_algorithms/test_checksum.c
@@ -1,0 +1,96 @@
+#include "error_correction_algorithms.h"
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+
+void test_checksum_add(void)
+{
+    // Test 3-bit checksum addition (k=3)
+    // 111 + 001 = 1000 -> 000 + 1 = 001
+    assert(checksum_add(7, 1, 3) == 1);
+    assert(checksum_add(5, 3, 3) == 1);
+    assert(checksum_add(4, 4, 3) == 1);
+
+    // Test 8-bit checksum addition (k=8)
+    assert(checksum_add(255, 1, 8) == 1);
+    assert(checksum_add(100, 150, 8) == 250);
+
+    printf("test_checksum_add passed\n");
+}
+
+void test_checksum_bits_to_int(void)
+{
+    assert(checksum_bits_to_int("000", 3) == 0);
+    assert(checksum_bits_to_int("111", 3) == 7);
+    assert(checksum_bits_to_int("101", 3) == 5);
+    assert(checksum_bits_to_int("101010", 6) == 42);
+
+    printf("test_checksum_bits_to_int passed\n");
+}
+
+void test_checksum_block_sum(void)
+{
+    // Data: "10110011", len=8, k=4
+    // Blocks: "1011" (11) and "0011" (3)
+    // 11 + 3 = 14 ("1110")
+    int sum = checksum_block_sum("10110011", 8, 4);
+    assert(sum == 14);
+
+    // Data: "101", len=3, k=4 (padded with 0 to "1010" (10))
+    sum = checksum_block_sum("101", 3, 4);
+    assert(sum == 10);
+
+    printf("test_checksum_block_sum passed\n");
+}
+
+void test_checksum_transmission(void)
+{
+    // Simulate transmission
+    const char* data = "1011001110101111"; // 16 bits
+    int len = 16;
+    int k = 4;
+    int mask = (1 << k) - 1;
+
+    // Sender side
+    int sum = checksum_block_sum(data, len, k);
+    int checksum = (~sum) & mask;
+
+    // We convert checksum to binary string
+    char checksum_str[5];
+    for (int i = 0; i < k; i++)
+    {
+        checksum_str[i] = ((checksum >> (k - 1 - i)) & 1) ? '1' : '0';
+    }
+    checksum_str[k] = '\0';
+
+    // Receiver side: verification
+    int checkword = checksum_bits_to_int(checksum_str, k);
+    int rec_sum = checksum_block_sum(data, len, k);
+    rec_sum = checksum_add(rec_sum, checkword, k);
+
+    int complement = (~rec_sum) & mask;
+    assert(complement == 0); // No error detected
+
+    // Simulate error in data
+    char corrupt_data[17];
+    strcpy(corrupt_data, data);
+    corrupt_data[0] = (corrupt_data[0] == '1') ? '0' : '1'; // Flip first bit
+
+    int corrupt_rec_sum = checksum_block_sum(corrupt_data, len, k);
+    corrupt_rec_sum = checksum_add(corrupt_rec_sum, checkword, k);
+    int corrupt_complement = (~corrupt_rec_sum) & mask;
+    assert(corrupt_complement != 0); // Error detected!
+
+    printf("test_checksum_transmission passed\n");
+}
+
+int main(void)
+{
+    test_checksum_add();
+    test_checksum_bits_to_int();
+    test_checksum_block_sum();
+    test_checksum_transmission();
+
+    printf("All checksum tests passed successfully!\n");
+    return 0;
+}

--- a/tests/error_correction_algorithms/test_crc.c
+++ b/tests/error_correction_algorithms/test_crc.c
@@ -1,0 +1,65 @@
+#include "error_correction_algorithms.h"
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+
+void test_crc_generate_and_verify(void)
+{
+    // Test data and generator
+    const char* data = "1101011011";
+    const char* generator = "10011"; // CRC-4
+    char remainder[CHECKSUM_MAX_BITS + 1];
+    char codeword[CHECKSUM_MAX_BITS * 2 + 1];
+
+    crc_generate(data, generator, remainder, codeword);
+
+    // Verify remainder size: length of generator - 1
+    assert(strlen(remainder) == strlen(generator) - 1);
+    assert(strcmp(remainder, "1110") == 0); // Modulo-2 remainder for this input
+
+    // Codeword should be data + remainder
+    char expected_codeword[CHECKSUM_MAX_BITS * 2 + 1];
+    snprintf(expected_codeword, sizeof(expected_codeword), "%s%s", data, remainder);
+    assert(strcmp(codeword, expected_codeword) == 0);
+
+    // Verify the clean codeword
+    int check_valid = crc_verify(codeword, generator, NULL);
+    assert(check_valid == 1); // Should be clean
+
+    // Simulate bit flip error in data
+    char corrupt_codeword[CHECKSUM_MAX_BITS * 2 + 1];
+    strcpy(corrupt_codeword, codeword);
+    corrupt_codeword[0] = (corrupt_codeword[0] == '1') ? '0' : '1';
+
+    int check_corrupt = crc_verify(corrupt_codeword, generator, NULL);
+    assert(check_corrupt == 0); // Should detect error
+
+    // Simulate bit flip in parity remainder
+    strcpy(corrupt_codeword, codeword);
+    int last_idx = (int)strlen(corrupt_codeword) - 1;
+    corrupt_codeword[last_idx] = (corrupt_codeword[last_idx] == '1') ? '0' : '1';
+
+    check_corrupt = crc_verify(corrupt_codeword, generator, NULL);
+    assert(check_corrupt == 0); // Should detect error
+
+    printf("test_crc_generate_and_verify passed\n");
+}
+
+void test_crc_xor_operation(void)
+{
+    char div[32];
+    strcpy(div, "110100");
+    crc_xor_operation(div, "1011", 0);
+    assert(strncmp(div, "0110", 4) == 0); // 1101 XOR 1011 = 0110
+
+    printf("test_crc_xor_operation passed\n");
+}
+
+int main(void)
+{
+    test_crc_xor_operation();
+    test_crc_generate_and_verify();
+
+    printf("All CRC tests passed successfully!\n");
+    return 0;
+}

--- a/tests/error_correction_algorithms/test_hamming.c
+++ b/tests/error_correction_algorithms/test_hamming.c
@@ -1,0 +1,54 @@
+#include "error_correction_algorithms.h"
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+
+void test_hamming_generate_and_verify(void)
+{
+    // Test data: "1001101" (7 data bits)
+    // Parity bits needed: r=4 since 2^4 >= 7+4+1 (16 >= 12)
+    // Codeword length: n = 11
+    const char* data = "1001101";
+    char codeword[128];
+
+    hamming_generate(data, codeword);
+    assert(strlen(codeword) == 11);
+
+    // Verify error-free reception
+    char corrected[128];
+    char data_recovered[128];
+    int syndrome = hamming_verify(codeword, corrected, data_recovered);
+    assert(syndrome == 0); // No error
+    assert(strcmp(corrected, codeword) == 0);
+    assert(strcmp(data_recovered, data) == 0);
+
+    // Simulate single-bit error at position 5
+    // 1-based index 5 corresponds to 0-based index 4 in C string
+    char corrupt_codeword[128];
+    strcpy(corrupt_codeword, codeword);
+    corrupt_codeword[4] = (corrupt_codeword[4] == '1') ? '0' : '1';
+
+    int error_pos = hamming_verify(corrupt_codeword, corrected, data_recovered);
+    assert(error_pos == 5);                    // Error detected at position 5
+    assert(strcmp(corrected, codeword) == 0);  // Should be corrected back to original codeword
+    assert(strcmp(data_recovered, data) == 0); // Data should be recovered successfully
+
+    // Simulate error in parity bit at position 1 (0-based index 0)
+    strcpy(corrupt_codeword, codeword);
+    corrupt_codeword[0] = (corrupt_codeword[0] == '1') ? '0' : '1';
+
+    error_pos = hamming_verify(corrupt_codeword, corrected, data_recovered);
+    assert(error_pos == 1); // Error detected at parity bit position 1
+    assert(strcmp(corrected, codeword) == 0);
+    assert(strcmp(data_recovered, data) == 0);
+
+    printf("test_hamming_generate_and_verify passed\n");
+}
+
+int main(void)
+{
+    test_hamming_generate_and_verify();
+
+    printf("All Hamming tests passed successfully!\n");
+    return 0;
+}

--- a/tests/error_correction_algorithms/test_lrc.c
+++ b/tests/error_correction_algorithms/test_lrc.c
@@ -1,0 +1,64 @@
+#include "error_correction_algorithms.h"
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+
+void test_lrc_calculate(void)
+{
+    // 3 data words, each 4 bits wide
+    // "1100"
+    // "1010"
+    // "0110"
+    // Column XOR: col0=1^1^0=0, col1=1^0^1=0, col2=0^1^1=0, col3=0^0^0=0
+    const char* words[] = {"1100", "1010", "0110"};
+    char lrc[5];
+    lrc_calculate(words, 3, 4, lrc);
+    assert(strcmp(lrc, "0000") == 0);
+
+    // Another test: "1011", "0110" → XOR col-by-col: 1,1,0,1
+    const char* words2[] = {"1011", "0110"};
+    lrc_calculate(words2, 2, 4, lrc);
+    assert(strcmp(lrc, "1101") == 0);
+
+    printf("test_lrc_calculate passed\n");
+}
+
+void test_lrc_verify_clean(void)
+{
+    const char* words[] = {"10110011", "11001100", "01100110"};
+    char lrc[9];
+    lrc_calculate(words, 3, 8, lrc);
+
+    // Verify the computed LRC passes
+    int result = lrc_verify(words, 3, 8, lrc);
+    assert(result == 1);
+
+    printf("test_lrc_verify_clean passed\n");
+}
+
+void test_lrc_verify_corrupted(void)
+{
+    const char* words[] = {"10110011", "11001100", "01100110"};
+    char lrc[9];
+    lrc_calculate(words, 3, 8, lrc);
+
+    // Flip one bit in the LRC to simulate corruption
+    char corrupted_lrc[9];
+    strcpy(corrupted_lrc, lrc);
+    corrupted_lrc[0] = (corrupted_lrc[0] == '1') ? '0' : '1';
+
+    int result = lrc_verify(words, 3, 8, corrupted_lrc);
+    assert(result == 0); // Should detect error
+
+    printf("test_lrc_verify_corrupted passed\n");
+}
+
+int main(void)
+{
+    test_lrc_calculate();
+    test_lrc_verify_clean();
+    test_lrc_verify_corrupted();
+
+    printf("All LRC tests passed successfully!\n");
+    return 0;
+}

--- a/tests/error_correction_algorithms/test_vrc.c
+++ b/tests/error_correction_algorithms/test_vrc.c
@@ -1,0 +1,86 @@
+#include "error_correction_algorithms.h"
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+
+/* VRC (Vertical Redundancy Check) logic lifted directly from vrc.c/vrc_receiver.c.
+   Since VRC has no extracted library helper, we replicate the logic here inline. */
+
+static int compute_parity_bit(const char* data)
+{
+    int ones = 0;
+    for (int i = 0; data[i] != '\0'; i++)
+    {
+        if (data[i] == '1')
+            ones++;
+    }
+    return (ones % 2 == 0) ? 0 : 1; // Even parity
+}
+
+static int verify_frame(const char* frame)
+{
+    int ones = 0;
+    for (int i = 0; frame[i] != '\0'; i++)
+    {
+        if (frame[i] == '1')
+            ones++;
+    }
+    return (ones % 2 == 0) ? 1 : 0; // Even parity: total 1s must be even
+}
+
+void test_vrc_even_parity(void)
+{
+    // "1011" has 3 ones -> odd -> parity bit = 1
+    assert(compute_parity_bit("1011") == 1);
+    // Transmitted frame: "10111"
+    assert(verify_frame("10111") == 1); // Even total 1s: 4 -> clean
+
+    // "1100" has 2 ones -> even -> parity bit = 0
+    assert(compute_parity_bit("1100") == 0);
+    // Transmitted frame: "11000"
+    assert(verify_frame("11000") == 1); // Even total 1s: 2 -> clean
+
+    printf("test_vrc_even_parity passed\n");
+}
+
+void test_vrc_error_detection(void)
+{
+    // "1011" + parity -> "10111", flip bit 0 -> "00111" (3 ones, odd -> error)
+    assert(verify_frame("00111") == 0); // Error detected
+
+    // "1100" + parity -> "11000", flip bit 2 -> "11100" (3 ones, odd -> error)
+    assert(verify_frame("11100") == 0); // Error detected
+
+    printf("test_vrc_error_detection passed\n");
+}
+
+void test_vrc_all_zeros(void)
+{
+    // "0000" has 0 ones -> even -> parity bit = 0
+    assert(compute_parity_bit("0000") == 0);
+    // Transmitted frame: "00000" -> 0 ones, even -> clean
+    assert(verify_frame("00000") == 1);
+
+    printf("test_vrc_all_zeros passed\n");
+}
+
+void test_vrc_all_ones(void)
+{
+    // "1111" has 4 ones -> even -> parity bit = 0
+    assert(compute_parity_bit("1111") == 0);
+    // Transmitted frame: "11110" -> 4 ones, even -> clean
+    assert(verify_frame("11110") == 1);
+
+    printf("test_vrc_all_ones passed\n");
+}
+
+int main(void)
+{
+    test_vrc_even_parity();
+    test_vrc_error_detection();
+    test_vrc_all_zeros();
+    test_vrc_all_ones();
+
+    printf("All VRC tests passed successfully!\n");
+    return 0;
+}


### PR DESCRIPTION
Part of #435 — depends on PR 2

## Summary
Extracts Hamming encoding and decoding into reusable library functions, refactors the receiver demos, and adds unit tests covering syndrome error correction.

## Changes
- **`hamming.c`** – implement `hamming_generate()`
- **`hamming_receiver.c`** – implement `hamming_verify()` and refactor the receiver demo
- **`error_correction_algorithms.h`** – declare Hamming helpers
- **`tests/error_correction_algorithms/test_hamming.c`** – new Hamming unit test suite
- **`Makefile`** – register test binary and build rule