### PR TITLE
fix(heaps): check if heap is empty before extracting min in demo loops

### DIFF
--- a/src/advanced_heaps/binomial_heap.c
+++ b/src/advanced_heaps/binomial_heap.c
@@ -336,14 +336,14 @@ void run_binomial_demo(void)
         }
         else if (choice == 2)
         {
-            int key, val;
-            heap = binomial_heap_extract_min(heap, &key, &val);
-            if (key == -1 && val == -1 && heap == NULL)
+            if (heap == NULL)
             {
                 printf("\nHeap is already empty!\n");
             }
             else
             {
+                int key, val;
+                heap = binomial_heap_extract_min(heap, &key, &val);
                 printf("\nExtracted Min Node -> Key: %d, Value: %d\n", key, val);
             }
             printf("\nPress Enter to continue...");

--- a/src/advanced_heaps/fibonacci_heap.c
+++ b/src/advanced_heaps/fibonacci_heap.c
@@ -519,14 +519,14 @@ void run_fibonacci_demo(void)
         }
         else if (choice == 2)
         {
-            int key, val;
-            heap = fib_heap_extract_min(heap, &key, &val);
-            if (key == -1 && val == -1 && heap == NULL)
+            if (heap == NULL)
             {
                 printf("\nHeap is empty!\n");
             }
             else
             {
+                int key, val;
+                heap = fib_heap_extract_min(heap, &key, &val);
                 printf("\nExtracted Min Node -> Key: %d, Value: %d\n", key, val);
             }
             printf("\nPress Enter to continue...");

--- a/src/advanced_heaps/leftist_skew_heap.c
+++ b/src/advanced_heaps/leftist_skew_heap.c
@@ -268,14 +268,14 @@ void run_leftist_demo(void)
         }
         else if (choice == 2)
         {
-            int key, val;
-            heap = leftist_heap_extract_min(heap, &key, &val);
-            if (key == -1 && val == -1 && heap == NULL)
+            if (heap == NULL)
             {
                 printf("\nHeap is empty!\n");
             }
             else
             {
+                int key, val;
+                heap = leftist_heap_extract_min(heap, &key, &val);
                 printf("\nExtracted Min Node -> Key: %d, Value: %d\n", key, val);
             }
             printf("\nPress Enter to continue...");
@@ -321,14 +321,14 @@ void run_skew_demo(void)
         }
         else if (choice == 2)
         {
-            int key, val;
-            heap = skew_heap_extract_min(heap, &key, &val);
-            if (key == -1 && val == -1 && heap == NULL)
+            if (heap == NULL)
             {
                 printf("\nHeap is empty!\n");
             }
             else
             {
+                int key, val;
+                heap = skew_heap_extract_min(heap, &key, &val);
                 printf("\nExtracted Min Node -> Key: %d, Value: %d\n", key, val);
             }
             printf("\nPress Enter to continue...");


### PR DESCRIPTION
Closes #641

## Summary
Fixes a bug where extracting from an empty heap in interactive demos printed uninitialized stack memory garbage instead of the "Heap is empty!" message.

## Cause of the Bug
In `run_leftist_demo()`, `run_skew_demo()`, `run_binomial_demo()`, and `run_fibonacci_demo()`, selecting Option 2 ("Extract min node") declared `int key, val;` on the stack without initializing them. 
It then called the extraction helper with these addresses. If the heap was empty, the helper returned early without writing to `key` and `val`. The check `if (key == -1 && val == -1 && heap == NULL)` subsequently failed since `key` and `val` contained random stack garbage, leading the code to skip the empty check and print garbage.

## Solution
Modified the extraction code block in:
- `src/advanced_heaps/leftist_skew_heap.c` (Leftist & Skew demos)
- `src/advanced_heaps/binomial_heap.c` (Binomial demo)
- `src/advanced_heaps/fibonacci_heap.c` (Fibonacci demo)

To check if `heap == NULL` first, and if so, output the empty message directly without running the extraction helper.