### PR TITLE
feat(benchmark): standardize benchmarking with fixed seeds, multi-runs, and statistical reports

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -1,0 +1,33 @@
+# Benchmarking Methodology
+
+This directory contains the benchmarking and profiling suite for the C DSA Interactive Suite.
+
+## Overview
+The goal of this benchmarking suite is to provide a reliable, stable, and reproducible performance profiling tool for all data structures and algorithms across different platforms (Linux, macOS, Windows) and different commits.
+
+## Statistical Methodology
+To ensure that measurements are consistent, reliable, and directly comparable across commits, the following methodologies are implemented:
+
+1. **Fixed Random Seed (`BENCHMARK_SEED`)**
+   - We use a standardized fixed seed (`12345`) for all random input generation instead of non-deterministic methods (like using the system clock). This guarantees that the generated datasets are identical on every benchmark run of the same size $N$.
+
+2. **Multiple Iterations (`BENCHMARK_DEFAULT_ITERATIONS`)**
+   - Each algorithm is benchmarked over multiple iterations (defaulting to `5` iterations). This helps absorb transient spikes in CPU scheduling or background OS activities.
+
+3. **Mean and Standard Deviation Reporting**
+   - We measure and report both the **Mean** execution time and the **Standard Deviation** (representing timing variance) over the iterations.
+   - The reported standard deviation is calculated using standard formulas:
+     $$\mu = \frac{1}{N} \sum_{i=1}^{N} x_i$$
+     $$\sigma = \sqrt{\frac{1}{N-1} \sum_{i=1}^{N} (x_i - \mu)^2}$$
+   - To avoid cross-platform math library (`-lm`) linking issues, the square root ($\sqrt{\cdot}$) is computed dynamically using a highly precise Babylonian (Newton-Raphson) approximation.
+
+4. **Peak Memory Consumption Tracking**
+   - We track the peak resident set size (RSS) of the process during the runs on both POSIX systems and Windows (using Windows API `GetProcessMemoryInfo`).
+
+## Standardized CLI/TUI Layout
+The table outputs are standardized to:
+* **Category Name & Input Size $N$**
+* **Columns**: `Algorithm` (30 chars width), `Execution Time` (mean ± stddev), `Peak Memory` (KB), and `Status`.
+
+## CSV Exports
+Every run appends a data row containing the algorithm name, input size, mean execution time, peak memory consumption, and a human-readable timestamp to `benchmarks/<category>.csv` for post-run processing or profiling plots.

--- a/benchmark/benchmark.c
+++ b/benchmark/benchmark.c
@@ -136,3 +136,68 @@ int benchmark_export_csv(const char* category_name, const char* algo_name, int i
 
     return 0;
 }
+
+double benchmark_mean(const double* values, int count)
+{
+    if (count <= 0)
+        return 0.0;
+    double sum = 0.0;
+    for (int i = 0; i < count; i++)
+    {
+        sum += values[i];
+    }
+    return sum / count;
+}
+
+static double simple_sqrt(double x)
+{
+    if (x <= 0.0)
+        return 0.0;
+    double z = x;
+    for (int i = 0; i < 10; i++)
+    {
+        z = 0.5 * (z + x / z);
+    }
+    return z;
+}
+
+double benchmark_stddev(const double* values, int count, double mean)
+{
+    if (count <= 1)
+        return 0.0;
+    double variance_sum = 0.0;
+    for (int i = 0; i < count; i++)
+    {
+        double diff = values[i] - mean;
+        variance_sum += diff * diff;
+    }
+    return simple_sqrt(variance_sum / (count - 1));
+}
+
+void benchmark_report_result(const char* category, const char* name, int n, const double times[],
+                             size_t peak_mem)
+{
+    double mean = benchmark_mean(times, BENCHMARK_DEFAULT_ITERATIONS);
+    double stddev = benchmark_stddev(times, BENCHMARK_DEFAULT_ITERATIONS, mean);
+
+    char time_str[64];
+    if (mean < 0.001)
+    {
+        snprintf(time_str, sizeof(time_str), "%.3f ± %.3f ms", mean * 1000.0, stddev * 1000.0);
+    }
+    else if (mean < 1.0)
+    {
+        snprintf(time_str, sizeof(time_str), "%.2f ± %.2f ms", mean * 1000.0, stddev * 1000.0);
+    }
+    else
+    {
+        snprintf(time_str, sizeof(time_str), "%.3f ± %.3f s", mean, stddev);
+    }
+
+    char mem_str[32];
+    snprintf(mem_str, sizeof(mem_str), "%zu KB", peak_mem);
+
+    printf("%-30s %-25s %-15s %-10s\n", name, time_str, mem_str, "PASSED");
+
+    benchmark_export_csv(category, name, n, mean, peak_mem);
+}

--- a/benchmark/benchmark.h
+++ b/benchmark/benchmark.h
@@ -8,6 +8,29 @@
 int _fileno(FILE*);
 #endif
 
+#define BENCHMARK_SEED 12345
+#define BENCHMARK_DEFAULT_ITERATIONS 5
+
+#define RUN_BENCHMARK(times_arr, peak_mem_var, ...)                                                \
+    do                                                                                             \
+    {                                                                                              \
+        peak_mem_var = 0;                                                                          \
+        for (int iter = 0; iter < BENCHMARK_DEFAULT_ITERATIONS; iter++)                            \
+        {                                                                                          \
+            size_t mem_before = benchmark_get_peak_memory();                                       \
+            double start_time = benchmark_get_time();                                              \
+            __VA_ARGS__;                                                                           \
+            double end_time = benchmark_get_time();                                                \
+            times_arr[iter] = end_time - start_time;                                               \
+            size_t mem_after = benchmark_get_peak_memory();                                        \
+            size_t peak_mem = (mem_after > mem_before) ? (mem_after - mem_before) : 0;             \
+            if (peak_mem > peak_mem_var)                                                           \
+            {                                                                                      \
+                peak_mem_var = peak_mem;                                                           \
+            }                                                                                      \
+        }                                                                                          \
+    } while (0)
+
 /**
  * Returns a high-resolution monotonic timestamp in seconds.
  * Suitable for measuring code execution duration.
@@ -94,5 +117,10 @@ void run_flow_benchmark(int v);
  * Runs benchmarks for Advanced Heaps with input size N.
  */
 void run_heaps_benchmark(int n);
+
+double benchmark_mean(const double* values, int count);
+double benchmark_stddev(const double* values, int count, double mean);
+void benchmark_report_result(const char* category, const char* name, int n, const double times[],
+                             size_t peak_mem);
 
 #endif // BENCHMARK_H

--- a/benchmark/benchmark_graphs.c
+++ b/benchmark/benchmark_graphs.c
@@ -17,8 +17,8 @@
 
 void run_graphs_benchmark(int v)
 {
-    // Seed random generator
-    srand((unsigned int)time(NULL));
+    // Seed random generator with fixed seed
+    srand(BENCHMARK_SEED);
 
     // Safety Guard: bypass all graph benchmarks if V is too large to prevent freezes
     if (v > 2000)
@@ -73,7 +73,7 @@ void run_graphs_benchmark(int v)
     printf("\n========================================================================\n");
     printf("             BENCHMARK REPORT: GRAPH SHORTEST PATH (V = %d)\n", v);
     printf("========================================================================\n");
-    printf("%-30s %-20s %-12s %-10s\n", "Algorithm", "Execution Time", "Peak Memory", "Status");
+    printf("%-30s %-25s %-15s %-10s\n", "Algorithm", "Execution Time", "Peak Memory", "Status");
     printf("------------------------------------------------------------------------\n");
 
     const char* algos[] = {"Dijkstra", "Bellman-Ford", "A* Search", "Greedy Best-First Search"};
@@ -94,80 +94,59 @@ void run_graphs_benchmark(int v)
 
         if (skip)
         {
-            printf("%-30s %-20s %-12s %-10s\n", name, "Skipped (V > 500)", "N/A", "SKIPPED");
+            printf("%-30s %-25s %-15s %-10s\n", name, "Skipped (V > 500)", "N/A", "SKIPPED");
             continue;
         }
 
-        // Track memory before
-        size_t mem_before = benchmark_get_peak_memory();
-        double start_time = benchmark_get_time();
+        double times[BENCHMARK_DEFAULT_ITERATIONS];
+        size_t peak_mem = 0;
 
-        // Redirect stdout to suppress prints from algorithm steps
-        fflush(stdout);
-        int stdout_dup = dup(1);
+        RUN_BENCHMARK(times, peak_mem, {
+            // Redirect stdout to suppress prints from algorithm steps
+            fflush(stdout);
+            int stdout_dup = dup(1);
 #ifdef _WIN32
-        FILE* fnull = fopen("NUL", "w");
+            FILE* fnull = fopen("NUL", "w");
 #else
-        FILE* fnull = fopen("/dev/null", "w");
+            FILE* fnull = fopen("/dev/null", "w");
 #endif
-        if (fnull != NULL && stdout_dup >= 0)
-        {
-            dup2(fileno(fnull), 1);
-        }
+            if (fnull != NULL && stdout_dup >= 0)
+            {
+                dup2(fileno(fnull), 1);
+            }
 
-        // Run algorithm
-        switch (i)
-        {
-            case 0:
-                dijkstra(graph, start);
-                break;
-            case 1:
-                bellman_ford(graph, start);
-                break;
-            case 2:
-                astar(graph, start, dest, h);
-                break;
-            case 3:
-                greedy_best_first_search(graph, start, dest, h);
-                break;
-        }
+            // Run algorithm
+            switch (i)
+            {
+                case 0:
+                    dijkstra(graph, start);
+                    break;
+                case 1:
+                    bellman_ford(graph, start);
+                    break;
+                case 2:
+                    astar(graph, start, dest, h);
+                    break;
+                case 3:
+                    greedy_best_first_search(graph, start, dest, h);
+                    break;
+            }
 
-        // Restore stdout
-        fflush(stdout);
-        if (stdout_dup >= 0)
-        {
-            dup2(stdout_dup, 1);
-            close(stdout_dup);
-        }
-        if (fnull != NULL)
-        {
-            fclose(fnull);
-        }
+            // Restore stdout
+            fflush(stdout);
+            if (stdout_dup >= 0)
+            {
+                dup2(stdout_dup, 1);
+                close(stdout_dup);
+            }
+            if (fnull != NULL)
+            {
+                fclose(fnull);
+            }
+        });
 
-        double end_time = benchmark_get_time();
-        size_t mem_after = benchmark_get_peak_memory();
-
-        double elapsed = end_time - start_time;
-        size_t peak_mem = (mem_after > mem_before) ? mem_after : mem_before;
-
-        // Format row print details
-        char time_str[30];
-        if (elapsed < 0.001)
-        {
-            snprintf(time_str, sizeof(time_str), "%.6f ms", elapsed * 1000.0);
-        }
-        else
-        {
-            snprintf(time_str, sizeof(time_str), "%.2f ms", elapsed * 1000.0);
-        }
-
-        char mem_str[30];
-        snprintf(mem_str, sizeof(mem_str), "%zu KB", peak_mem);
-
-        printf("%-30s %-20s %-12s %-10s\n", name, time_str, mem_str, "PASSED");
-
-        // Export to CSV
-        benchmark_export_csv("graphs", name, v, elapsed, peak_mem);
+        // Print row and export
+        benchmark_report_result("graphs", name, v, times, peak_mem);
     }
 
     printf("========================================================================\n");

--- a/benchmark/benchmark_heaps.c
+++ b/benchmark/benchmark_heaps.c
@@ -9,13 +9,20 @@ void run_heaps_benchmark(int n)
     printf("\n========================================================================\n");
     printf("             BENCHMARK REPORT: ADVANCED HEAPS (N = %d)\n", n);
     printf("========================================================================\n");
-    printf("%-30s %-20s %-12s %-9s\n", "Heap Type", "Execution Time", "Peak Memory", "Status");
+    printf("%-30s %-25s %-15s %-10s\n", "Heap Type", "Execution Time", "Peak Memory", "Status");
     printf("------------------------------------------------------------------------\n");
 
-    // Initialize random number generator
-    srand(42);
+    // Initialize random number generator with fixed seed
+    srand(BENCHMARK_SEED);
     int* random_keys = (int*)malloc(n * sizeof(int));
     int* random_vals = (int*)malloc(n * sizeof(int));
+    if (random_keys == NULL || random_vals == NULL)
+    {
+        fprintf(stderr, "Error: Memory allocation failed for benchmark keys/values\n");
+        free(random_keys);
+        free(random_vals);
+        return;
+    }
     for (int i = 0; i < n; i++)
     {
         random_keys[i] = rand() % 1000000;
@@ -24,80 +31,82 @@ void run_heaps_benchmark(int n)
 
     // 1. Binomial Heap Benchmark
     {
-        double start_time = benchmark_get_time();
-        BinomialNode* heap = NULL;
+        double times[BENCHMARK_DEFAULT_ITERATIONS];
+        size_t peak_mem = 0;
 
-        // Perform inserts
-        for (int i = 0; i < n; i++)
-        {
-            heap = binomial_heap_insert(heap, random_keys[i], random_vals[i]);
-        }
+        RUN_BENCHMARK(times, peak_mem, {
+            BinomialNode* heap = NULL;
 
-        // Perform extracts
-        for (int i = 0; i < n; i++)
-        {
-            int k, v;
-            heap = binomial_heap_extract_min(heap, &k, &v);
-        }
-        destroy_binomial_heap(heap);
+            // Perform inserts
+            for (int i = 0; i < n; i++)
+            {
+                heap = binomial_heap_insert(heap, random_keys[i], random_vals[i]);
+            }
 
-        double elapsed_time = benchmark_get_time() - start_time;
-        size_t memory = benchmark_get_peak_memory();
+            // Perform extracts
+            for (int i = 0; i < n; i++)
+            {
+                int k, v;
+                heap = binomial_heap_extract_min(heap, &k, &v);
+            }
+            destroy_binomial_heap(heap);
+        });
 
-        printf("%-30s %-20f %-12zu %-9s\n", "Binomial Heap", elapsed_time, memory, "PASSED");
-        benchmark_export_csv("heaps", "Binomial Heap", n, elapsed_time, memory);
+        benchmark_report_result("heaps", "Binomial Heap", n, times, peak_mem);
     }
 
     // 2. Fibonacci Heap Benchmark
     {
-        double start_time = benchmark_get_time();
-        FibonacciNode* heap = NULL;
+        double times[BENCHMARK_DEFAULT_ITERATIONS];
+        size_t peak_mem = 0;
 
-        // Perform inserts
-        for (int i = 0; i < n; i++)
-        {
-            heap = fib_heap_insert(heap, random_keys[i], random_vals[i]);
-        }
+        RUN_BENCHMARK(times, peak_mem, {
+            FibonacciNode* heap = NULL;
 
-        // Perform extracts
-        for (int i = 0; i < n; i++)
-        {
-            int k, v;
-            heap = fib_heap_extract_min(heap, &k, &v);
-        }
-        destroy_fibonacci_heap(heap);
+            // Perform inserts
+            for (int i = 0; i < n; i++)
+            {
+                heap = fib_heap_insert(heap, random_keys[i], random_vals[i]);
+            }
 
-        double elapsed_time = benchmark_get_time() - start_time;
-        size_t memory = benchmark_get_peak_memory();
+            // Perform extracts
+            for (int i = 0; i < n; i++)
+            {
+                int k, v;
+                heap = fib_heap_extract_min(heap, &k, &v);
+            }
+            destroy_fibonacci_heap(heap);
+        });
 
-        printf("%-30s %-20f %-12zu %-9s\n", "Fibonacci Heap", elapsed_time, memory, "PASSED");
-        benchmark_export_csv("heaps", "Fibonacci Heap", n, elapsed_time, memory);
+        benchmark_report_result("heaps", "Fibonacci Heap", n, times, peak_mem);
     }
 
     // 3. Min-Max Heap Benchmark
     {
-        double start_time = benchmark_get_time();
-        MinMaxHeap* heap = create_min_max_heap(n);
+        double times[BENCHMARK_DEFAULT_ITERATIONS];
+        size_t peak_mem = 0;
 
-        // Perform inserts
-        for (int i = 0; i < n; i++)
-        {
-            min_max_heap_insert(heap, random_keys[i], random_vals[i]);
-        }
+        RUN_BENCHMARK(times, peak_mem, {
+            MinMaxHeap* heap = create_min_max_heap(n);
+            if (heap != NULL)
+            {
+                // Perform inserts
+                for (int i = 0; i < n; i++)
+                {
+                    min_max_heap_insert(heap, random_keys[i], random_vals[i]);
+                }
 
-        // Perform extracts
-        for (int i = 0; i < n; i++)
-        {
-            int k, v;
-            min_max_heap_extract_min(heap, &k, &v);
-        }
-        destroy_min_max_heap(heap);
+                // Perform extracts
+                for (int i = 0; i < n; i++)
+                {
+                    int k, v;
+                    min_max_heap_extract_min(heap, &k, &v);
+                }
+                destroy_min_max_heap(heap);
+            }
+        });
 
-        double elapsed_time = benchmark_get_time() - start_time;
-        size_t memory = benchmark_get_peak_memory();
-
-        printf("%-30s %-20f %-12zu %-9s\n", "Min-Max Heap", elapsed_time, memory, "PASSED");
-        benchmark_export_csv("heaps", "Min-Max Heap", n, elapsed_time, memory);
+        benchmark_report_result("heaps", "Min-Max Heap", n, times, peak_mem);
     }
 
     free(random_keys);

--- a/benchmark/benchmark_searching.c
+++ b/benchmark/benchmark_searching.c
@@ -7,8 +7,8 @@
 
 void run_searching_benchmark(int n)
 {
-    // Seed random generator
-    srand((unsigned int)time(NULL));
+    // Seed random generator with fixed seed
+    srand(BENCHMARK_SEED);
 
     // Allocate sorted array
     int* arr = malloc(n * sizeof(int));
@@ -44,7 +44,7 @@ void run_searching_benchmark(int n)
     printf("             BENCHMARK REPORT: SEARCHING ALGORITHMS (N = %d, Loops = %d)\n", n,
            num_queries);
     printf("========================================================================\n");
-    printf("%-30s %-20s %-12s %-10s\n", "Algorithm", "Execution Time", "Peak Memory", "Status");
+    printf("%-30s %-25s %-15s %-10s\n", "Algorithm", "Execution Time", "Peak Memory", "Status");
     printf("------------------------------------------------------------------------\n");
 
     const char* algos[] = {"Linear Search", "Binary Search (Iterative)",
@@ -63,64 +63,44 @@ void run_searching_benchmark(int n)
 
         if (skip)
         {
-            printf("%-30s %-20s %-12s %-10s\n", name, "Skipped (N > 10000)", "N/A", "SKIPPED");
+            printf("%-30s %-25s %-15s %-10s\n", name, "Skipped (N > 10000)", "N/A", "SKIPPED");
             continue;
         }
 
-        // Track memory before
-        size_t mem_before = benchmark_get_peak_memory();
-        double start_time = benchmark_get_time();
+        double times[BENCHMARK_DEFAULT_ITERATIONS];
+        size_t peak_mem = 0;
 
-        volatile int dummy = 0;
-        for (int q = 0; q < num_queries; q++)
-        {
-            int target = queries[q];
-            int res = -1;
-            switch (i)
+        RUN_BENCHMARK(times, peak_mem, {
+            volatile int dummy = 0;
+            for (int q = 0; q < num_queries; q++)
             {
-                case 0:
-                    res = linear_search(arr, target, n);
-                    break;
-                case 1:
-                    res = binary_search(arr, target, n);
-                    break;
-                case 2:
-                    res = binary_search_recursive(arr, target, 0, n - 1);
-                    break;
-                case 3:
-                    res = jump_search(arr, target, n);
-                    break;
-                case 4:
-                    res = interpolation_search(arr, target, n);
-                    break;
+                int target = queries[q];
+                int res = -1;
+                switch (i)
+                {
+                    case 0:
+                        res = linear_search(arr, target, n);
+                        break;
+                    case 1:
+                        res = binary_search(arr, target, n);
+                        break;
+                    case 2:
+                        res = binary_search_recursive(arr, target, 0, n - 1);
+                        break;
+                    case 3:
+                        res = jump_search(arr, target, n);
+                        break;
+                    case 4:
+                        res = interpolation_search(arr, target, n);
+                        break;
+                }
+                dummy += res;
             }
-            dummy += res;
-        }
+            (void)dummy;
+        });
 
-        double end_time = benchmark_get_time();
-        size_t mem_after = benchmark_get_peak_memory();
-
-        double elapsed = end_time - start_time;
-        size_t peak_mem = (mem_after > mem_before) ? mem_after : mem_before;
-
-        // Print row
-        char time_str[30];
-        if (elapsed < 0.001)
-        {
-            snprintf(time_str, sizeof(time_str), "%.6f ms", elapsed * 1000.0);
-        }
-        else
-        {
-            snprintf(time_str, sizeof(time_str), "%.2f ms", elapsed * 1000.0);
-        }
-
-        char mem_str[30];
-        snprintf(mem_str, sizeof(mem_str), "%zu KB", peak_mem);
-
-        printf("%-30s %-20s %-12s %-10s\n", name, time_str, mem_str, "PASSED");
-
-        // Export to CSV
-        benchmark_export_csv("searching", name, n, elapsed, peak_mem);
+        // Print row and export
+        benchmark_report_result("searching", name, n, times, peak_mem);
     }
 
     printf("========================================================================\n");

--- a/benchmark/benchmark_sorting.c
+++ b/benchmark/benchmark_sorting.c
@@ -8,8 +8,8 @@
 
 void run_sorting_benchmark(int n)
 {
-    // Seed random generator
-    srand((unsigned int)time(NULL));
+    // Seed random generator with fixed seed
+    srand(BENCHMARK_SEED);
 
     // Allocate master array
     int* master = malloc(n * sizeof(int));
@@ -29,7 +29,7 @@ void run_sorting_benchmark(int n)
     printf("\n========================================================================\n");
     printf("             BENCHMARK REPORT: SORTING ALGORITHMS (N = %d)\n", n);
     printf("========================================================================\n");
-    printf("%-20s %-25s %-15s %-10s\n", "Algorithm", "Execution Time", "Peak Memory", "Status");
+    printf("%-30s %-25s %-15s %-10s\n", "Algorithm", "Execution Time", "Peak Memory", "Status");
     printf("------------------------------------------------------------------------\n");
 
     const char* algos[] = {"Bubble Sort", "Selection Sort", "Insertion Sort",
@@ -49,7 +49,7 @@ void run_sorting_benchmark(int n)
 
         if (skip)
         {
-            printf("%-20s %-25s %-15s %-10s\n", name, "Skipped (N > 10000)", "N/A", "SKIPPED");
+            printf("%-30s %-25s %-15s %-10s\n", name, "Skipped (N > 10000)", "N/A", "SKIPPED");
             continue;
         }
 
@@ -57,71 +57,49 @@ void run_sorting_benchmark(int n)
         int* clone = malloc(n * sizeof(int));
         if (clone == NULL)
         {
-            printf("%-20s %-25s %-15s %-10s\n", name, "Alloc Failure", "N/A", "FAILED");
+            printf("%-30s %-25s %-15s %-10s\n", name, "Alloc Failure", "N/A", "FAILED");
             continue;
         }
-        memcpy(clone, master, n * sizeof(int));
 
-        // Track memory before
-        size_t mem_before = benchmark_get_peak_memory();
-        double start_time = benchmark_get_time();
+        double times[BENCHMARK_DEFAULT_ITERATIONS];
+        size_t peak_mem = 0;
 
-        // Run algorithm
-        switch (i)
-        {
-            case 0:
-                bubble_sort_optimized(clone, n);
-                break;
-            case 1:
-                selection_sort(clone, n);
-                break;
-            case 2:
-                insertion_sort(clone, n);
-                break;
-            case 3:
-                shell_sort(clone, n);
-                break;
-            case 4:
-                merge_sort(clone, n);
-                break;
-            case 5:
-                quicksort(clone, 0, n - 1);
-                break;
-            case 6:
-                heap_sort(clone, n);
-                break;
-            case 7:
-                radix_sort(clone, n);
-                break;
-            case 8:
-                bucket_sort(clone, n);
-                break;
-        }
+        RUN_BENCHMARK(times, peak_mem, {
+            memcpy(clone, master, n * sizeof(int));
+            switch (i)
+            {
+                case 0:
+                    bubble_sort_optimized(clone, n);
+                    break;
+                case 1:
+                    selection_sort(clone, n);
+                    break;
+                case 2:
+                    insertion_sort(clone, n);
+                    break;
+                case 3:
+                    shell_sort(clone, n);
+                    break;
+                case 4:
+                    merge_sort(clone, n);
+                    break;
+                case 5:
+                    quicksort(clone, 0, n - 1);
+                    break;
+                case 6:
+                    heap_sort(clone, n);
+                    break;
+                case 7:
+                    radix_sort(clone, n);
+                    break;
+                case 8:
+                    bucket_sort(clone, n);
+                    break;
+            }
+        });
 
-        double end_time = benchmark_get_time();
-        size_t mem_after = benchmark_get_peak_memory();
-
-        double elapsed = end_time - start_time;
-        size_t peak_mem = (mem_after > mem_before) ? mem_after : mem_before;
-
-        // Print row
-        char time_str[30];
-        if (elapsed < 0.001)
-        {
-            snprintf(time_str, sizeof(time_str), "%.6f ms", elapsed * 1000.0);
-        }
-        else
-        {
-            snprintf(time_str, sizeof(time_str), "%.2f ms", elapsed * 1000.0);
-        }
-
-        char mem_str[30];
-        snprintf(mem_str, sizeof(mem_str), "%zu KB", peak_mem);
-
-        printf("%-20s %-25s %-15s %-10s\n", name, time_str, mem_str, "PASSED");
-
-        // Export to CSV
-        benchmark_export_csv("sorting", name, n, elapsed, peak_mem);
+        // Print row and export
+        benchmark_report_result("sorting", name, n, times, peak_mem);
 
         free(clone);
     }

--- a/benchmark/benchmark_trees.c
+++ b/benchmark/benchmark_trees.c
@@ -33,7 +33,8 @@ static void generate_unique_keys(int* keys, int n)
 
 void run_trees_benchmark(int n)
 {
-    srand((unsigned int)time(NULL));
+    // Seed random generator with fixed seed
+    srand(BENCHMARK_SEED);
 
     if (n > 5000)
     {
@@ -49,7 +50,7 @@ void run_trees_benchmark(int n)
     printf("\n========================================================================\n");
     printf("             BENCHMARK REPORT: TREES LOOKUP & INSERTION (N = %d)\n", n);
     printf("========================================================================\n");
-    printf("%-30s %-20s %-12s %-10s\n", "Structure", "Execution Time", "Peak Memory", "Status");
+    printf("%-30s %-25s %-15s %-10s\n", "Structure", "Execution Time", "Peak Memory", "Status");
     printf("------------------------------------------------------------------------\n");
 
     const char* algos[] = {"Binary Search Tree (BST)", "Threaded Binary Tree (TBT)",
@@ -58,161 +59,156 @@ void run_trees_benchmark(int n)
 
     for (int i = 0; i < 6; i++)
     {
-        size_t mem_before = benchmark_get_peak_memory();
-        double start_time = benchmark_get_time();
+        double times[BENCHMARK_DEFAULT_ITERATIONS];
+        size_t peak_mem = 0;
 
-        // Redirect stdout
-        fflush(stdout);
-        int stdout_dup = dup(1);
+        RUN_BENCHMARK(times, peak_mem, {
+            // Redirect stdout
+            fflush(stdout);
+            int stdout_dup = dup(1);
 #ifdef _WIN32
-        FILE* fnull = fopen("NUL", "w");
+            FILE* fnull = fopen("NUL", "w");
 #else
-        FILE* fnull = fopen("/dev/null", "w");
+            FILE* fnull = fopen("/dev/null", "w");
 #endif
-        if (fnull != NULL && stdout_dup >= 0)
-        {
-            dup2(fileno(fnull), 1);
-        }
+            if (fnull != NULL && stdout_dup >= 0)
+            {
+                dup2(fileno(fnull), 1);
+            }
 
-        if (i == 0) // BST
-        {
-            bstNode* root = NULL;
-            for (int k = 0; k < n; k++)
+            if (i == 0) // BST
             {
-                bst_insert(&root, keys[k]);
-            }
-            for (int k = 0; k < n; k++)
-            {
-                bstNode* curr = root;
-                int key = keys[k];
-                while (curr)
-                {
-                    if (curr->data == key)
-                        break;
-                    curr = (key < curr->data) ? curr->left : curr->right;
-                }
-            }
-            destroy_bst(root);
-        }
-        else if (i == 1) // TBT
-        {
-            TBTnode* root = NULL;
-            for (int k = 0; k < n; k++)
-            {
-                insert_node_tbt(&root, keys[k]);
-            }
-            for (int k = 0; k < n; k++)
-            {
-                TBTnode* curr = root;
-                int key = keys[k];
-                while (curr)
-                {
-                    if (curr->data == key)
-                        break;
-                    if (key < curr->data)
-                    {
-                        if (curr->lthread)
-                            break;
-                        curr = curr->left;
-                    }
-                    else
-                    {
-                        if (curr->rthread)
-                            break;
-                        curr = curr->right;
-                    }
-                }
-            }
-            destroy_tbt(root);
-        }
-        else if (i == 2) // AVL
-        {
-            avlNode* root = NULL;
-            for (int k = 0; k < n; k++)
-            {
-                avl_insert(&root, keys[k]);
-            }
-            for (int k = 0; k < n; k++)
-            {
-                avlNode* curr = root;
-                int key = keys[k];
-                while (curr)
-                {
-                    if (curr->data == key)
-                        break;
-                    curr = (key < curr->data) ? curr->left : curr->right;
-                }
-            }
-            destroy_avl(root);
-        }
-        else if (i == 3) // Trie
-        {
-            TrieNode* root = trie_create_node();
-            char buf[32];
-            for (int k = 0; k < n; k++)
-            {
-                sprintf(buf, "%d", keys[k]);
-                trie_insert(root, buf);
-            }
-            for (int k = 0; k < n; k++)
-            {
-                sprintf(buf, "%d", keys[k]);
-                trie_search(root, buf);
-            }
-            trie_free(root);
-        }
-        else if (i == 4) // B-Tree
-        {
-            btreeNode* root = NULL;
-            int t = 3;
-            for (int k = 0; k < n; k++)
-            {
-                btree_insert(&root, keys[k], t);
-            }
-            for (int k = 0; k < n; k++)
-            {
-                btree_search(root, keys[k]);
-            }
-            btree_destroy(root);
-        }
-        else if (i == 5) // B+ Tree
-        {
-            BPlusTree* tree = bplus_tree_create(4);
-            if (tree)
-            {
+                bstNode* root = NULL;
                 for (int k = 0; k < n; k++)
                 {
-                    bplus_tree_insert(tree, keys[k], keys[k]);
+                    bst_insert(&root, keys[k]);
                 }
-                int val_out;
                 for (int k = 0; k < n; k++)
                 {
-                    bplus_tree_search(tree, keys[k], &val_out);
+                    bstNode* curr = root;
+                    int key = keys[k];
+                    while (curr)
+                    {
+                        if (curr->data == key)
+                            break;
+                        curr = (key < curr->data) ? curr->left : curr->right;
+                    }
                 }
-                bplus_tree_destroy(tree);
+                destroy_bst(root);
             }
-        }
+            else if (i == 1) // TBT
+            {
+                TBTnode* root = NULL;
+                for (int k = 0; k < n; k++)
+                {
+                    insert_node_tbt(&root, keys[k]);
+                }
+                for (int k = 0; k < n; k++)
+                {
+                    TBTnode* curr = root;
+                    int key = keys[k];
+                    while (curr)
+                    {
+                        if (curr->data == key)
+                            break;
+                        if (key < curr->data)
+                        {
+                            if (curr->lthread)
+                                break;
+                            curr = curr->left;
+                        }
+                        else
+                        {
+                            if (curr->rthread)
+                                break;
+                            curr = curr->right;
+                        }
+                    }
+                }
+                destroy_tbt(root);
+            }
+            else if (i == 2) // AVL
+            {
+                avlNode* root = NULL;
+                for (int k = 0; k < n; k++)
+                {
+                    avl_insert(&root, keys[k]);
+                }
+                for (int k = 0; k < n; k++)
+                {
+                    avlNode* curr = root;
+                    int key = keys[k];
+                    while (curr)
+                    {
+                        if (curr->data == key)
+                            break;
+                        curr = (key < curr->data) ? curr->left : curr->right;
+                    }
+                }
+                destroy_avl(root);
+            }
+            else if (i == 3) // Trie
+            {
+                TrieNode* root = trie_create_node();
+                char buf[32];
+                for (int k = 0; k < n; k++)
+                {
+                    sprintf(buf, "%d", keys[k]);
+                    trie_insert(root, buf);
+                }
+                for (int k = 0; k < n; k++)
+                {
+                    sprintf(buf, "%d", keys[k]);
+                    trie_search(root, buf);
+                }
+                trie_free(root);
+            }
+            else if (i == 4) // B-Tree
+            {
+                btreeNode* root = NULL;
+                int t = 3;
+                for (int k = 0; k < n; k++)
+                {
+                    btree_insert(&root, keys[k], t);
+                }
+                for (int k = 0; k < n; k++)
+                {
+                    btree_search(root, keys[k]);
+                }
+                btree_destroy(root);
+            }
+            else if (i == 5) // B+ Tree
+            {
+                BPlusTree* tree = bplus_tree_create(4);
+                if (tree)
+                {
+                    for (int k = 0; k < n; k++)
+                    {
+                        bplus_tree_insert(tree, keys[k], keys[k]);
+                    }
+                    int val_out;
+                    for (int k = 0; k < n; k++)
+                    {
+                        bplus_tree_search(tree, keys[k], &val_out);
+                    }
+                    bplus_tree_destroy(tree);
+                }
+            }
 
-        // Restore stdout
-        fflush(stdout);
-        if (stdout_dup >= 0)
-        {
-            dup2(stdout_dup, 1);
-            close(stdout_dup);
-        }
-        if (fnull != NULL)
-        {
-            fclose(fnull);
-        }
+            // Restore stdout
+            fflush(stdout);
+            if (stdout_dup >= 0)
+            {
+                dup2(stdout_dup, 1);
+                close(stdout_dup);
+            }
+            if (fnull != NULL)
+            {
+                fclose(fnull);
+            }
+        });
 
-        double duration = benchmark_get_time() - start_time;
-        size_t mem_after = benchmark_get_peak_memory();
-        size_t mem_used = (mem_after > mem_before) ? (mem_after - mem_before) : 0;
-        if (mem_used == 0)
-            mem_used = mem_after;
-
-        printf("%-30s %-20.6f %-12zu %-10s\n", algos[i], duration * 1000.0, mem_used, "PASSED");
-        benchmark_export_csv("trees", algos[i], n, duration, mem_used);
+        benchmark_report_result("trees", algos[i], n, times, peak_mem);
     }
     printf("========================================================================\n");
     printf("Exported results to 'benchmarks/trees.csv'.\n");


### PR DESCRIPTION
Closes #561 
## Summary
Implements standardization rules for all benchmarks to ensure performance timing and peak memory metrics are reliable, reproducible, and directly comparable across commits.

## Details
1. **Benchmark Configuration (`benchmark/benchmark.h`)**:
   - Replaced dynamic clock/time seeding with a fixed random seed `BENCHMARK_SEED = 12345` for deterministic, uniform dataset generation.
   - Introduced a `RUN_BENCHMARK()` variadic macro that executes each test iteration `BENCHMARK_DEFAULT_ITERATIONS = 5` times.
2. **Statistical Timing Calculations (`benchmark/benchmark.c`)**:
   - Implemented standard `mean` and `stddev` calculations over the 5 iterations.
   - Created a standalone Newton-Raphson approximation for `simple_sqrt` to avoid platform-specific linkage requirements of the math library (`-lm`).
   - Implemented a standardized formatting and printing helper (`benchmark_report_result`) that auto-scales small execution times to milliseconds (`ms`) or seconds (`s`) and exports the average time to CSVs.
3. **Runner Integration**:
   - Upgraded Sorting, Searching, Heaps, Trees, and Graph shortest path runners to use fixed seed, variadic loop execution, and standardized printing.
4. **Documentation**:
   - Created `benchmark/README.md` containing the statistical equations, layout definitions, and benchmarking methodology.