### PR TITLE
feat: add AddressSanitizer and UBSan build targets (closes #559)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,3 +28,16 @@ jobs:
 
       - name: Memory check with valgrind
         run: make valgrind
+
+  sanitizers:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install build tools
+        run: sudo apt update && sudo apt install -y build-essential libncurses-dev
+
+      - name: Build and test with AddressSanitizer + UBSan
+        run: make asan

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,14 @@ project(C_DSA_interactive_suite C)
 set(CMAKE_C_STANDARD 11)
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Werror")
 
+option(SANITIZE "Enable AddressSanitizer and UndefinedBehaviorSanitizer" OFF)
+
+if(SANITIZE)
+    message(STATUS "Sanitizers enabled: AddressSanitizer + UndefinedBehaviorSanitizer")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fsanitize=address,undefined -fno-sanitize-recover=all -fno-omit-frame-pointer -g")
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fsanitize=address,undefined")
+endif()
+
 # Source directories
 set(SRC_DIRS
     src/data_structures

--- a/Makefile
+++ b/Makefile
@@ -109,6 +109,20 @@ valgrind:
 		valgrind $(VGFLAGS) $(TEST_DIR)/$$t$(EXE) || exit 1; \
 	done
 
+SANITIZE_CFLAGS = -fsanitize=address,undefined -fno-sanitize-recover=all -fno-omit-frame-pointer -g
+
+asan: CFLAGS += $(SANITIZE_CFLAGS)
+asan: LDFLAGS += -fsanitize=address,undefined
+asan: clean test
+	@echo "AddressSanitizer + UBSan build passed."
+
+ubsan: CFLAGS += -fsanitize=undefined -fno-sanitize-recover=all -fno-omit-frame-pointer -g
+ubsan: LDFLAGS += -fsanitize=undefined
+ubsan: clean test
+	@echo "UndefinedBehaviorSanitizer build passed."
+
+sanitize: asan
+
 
 # =========================
 # Test Section
@@ -769,4 +783,4 @@ $(TEST_DIR)/test_%$(EXE): $(OBJS) tests/advanced_heaps/test_%.c
 
 .PRECIOUS: $(TEST_DIR)/test_%$(EXE)
 
-.PHONY: run fmt clean valgrind
+.PHONY: run fmt clean valgrind asan ubsan sanitize


### PR DESCRIPTION
## Summary
- Added `make asan`, `make ubsan`, and `make sanitize` targets to the Makefile
- Added `SANITIZE` CMake option that enables both AddressSanitizer and UndefinedBehaviorSanitizer
- Updated CI workflow with a separate `sanitizers` job

## Changes

### Makefile
- **`make asan`** — Builds and runs all tests with `-fsanitize=address,undefined -fno-sanitize-recover=all -fno-omit-frame-pointer`
- **`make ubsan`** — Builds and runs all tests with UBSan only
- **`make sanitize`** — Alias for `make asan`
- All sanitizer targets do a clean build to ensure object files are compiled with sanitizer flags

### CMakeLists.txt
- Added `option(SANITIZE "Enable AddressSanitizer and UndefinedBehaviorSanitizer" OFF)`
- When enabled (`cmake -DSANITIZE=ON`), adds `-fsanitize=address,undefined -fno-sanitize-recover=all -fno-omit-frame-pointer` to C flags and linker flags

### CI (.github/workflows/ci.yml)
- Added separate `sanitizers` job that runs `make asan` in parallel with the existing `build` job
- Sanitizer job installs minimal dependencies (no valgrind/clang-format needed)
- Does NOT slow down the existing valgrind job

## Usage
```bash
# Makefile
make asan      # AddressSanitizer + UBSan
make ubsan     # UBSan only
make sanitize  # Alias for asan

# CMake
cmake -DSANITIZE=ON -B build
cmake --build build
ctest --test-dir build
```

Closes #559
