### PR TITLE
fix(backtracking): optimize test wrapper for Knight's Tour with Warnsdorff for N >= 6

### DIFF
--- a/src/backtracking/knights_tour.c
+++ b/src/backtracking/knights_tour.c
@@ -237,5 +237,12 @@ bool run_knights_tour_test(int n)
         for (int j = 0; j < n; j++)
             board[i][j] = -1;
     board[0][0] = 0;
-    return solve_standard(0, 0, 1, board, n) == 1;
+    if (n <= 5)
+    {
+        return solve_standard(0, 0, 1, board, n) == 1;
+    }
+    else
+    {
+        return solve_warnsdorff(0, 0, 1, board, n) == 1;
+    }
 }


### PR DESCRIPTION
## Summary
Fixes the performance of the Knight's Tour test/benchmark runner which took over 111 seconds to execute due to un-heuristic backtracking.

resolves #652 

## Details
- In `src/backtracking/knights_tour.c`, updated `run_knights_tour_test` to use the Warnsdorff Heuristic (`solve_warnsdorff`) for board sizes $N \geq 6$, matching the interactive demo runner logic.
- Previously, it unconditionally ran standard backtracking (`solve_standard`), resulting in millions of state checks and formatting loops for a 6x6 board.
- This optimization reduces the benchmark run-time for Knight's Tour from **~111 seconds** to **under 1 millisecond**.