### PR TITLE
fix(trees): add malloc and calloc NULL checks in Fenwick Tree and resolve duplicate trees_demo case

### DIFF
--- a/benchmark/benchmark_trees.c
+++ b/benchmark/benchmark_trees.c
@@ -199,37 +199,30 @@ void run_trees_benchmark(int n)
                     bplus_tree_destroy(tree);
                 }
             }
-        }
-        else if (i == 6) // Segment Tree Simulation
-        {
-            SegmentTree* st = create_segment_tree(keys, n);
-            for (int k = 0; k < n; k++)
+            else if (i == 6) // Segment Tree Simulation
             {
-                update_point(st, 1, 0, n - 1, k, keys[k] / 2);
+                SegmentTree* st = create_segment_tree(keys, n);
+                if (st != NULL)
+                {
+                    for (int k = 0; k < n; k++)
+                    {
+                        update_point(st, 1, 0, n - 1, k, keys[k] / 2);
+                    }
+                    destroy_segment_tree(st);
+                }
             }
-            destroy_segment_tree(st);
-        }
-        else if (i == 7) // Fenwick Tree Simulation
-        {
-            FenwickTree* ft = create_fenwick_tree(n);
-            for (int k = 0; k < n; k++)
+            else if (i == 7) // Fenwick Tree Simulation
             {
-                fenwick_range_update(ft, 1, k + 1, keys[k]);
+                FenwickTree* ft = create_fenwick_tree(n);
+                if (ft != NULL)
+                {
+                    for (int k = 0; k < n; k++)
+                    {
+                        fenwick_range_update(ft, 1, k + 1, keys[k]);
+                    }
+                    destroy_fenwick_tree(ft);
+                }
             }
-            destroy_fenwick_tree(ft);
-        }
-
-        // Restore stdout
-        fflush(stdout);
-        if (stdout_dup >= 0)
-        {
-            dup2(stdout_dup, 1);
-            close(stdout_dup);
-        }
-        if (fnull != NULL)
-        {
-            fclose(fnull);
-        }
 
             // Restore stdout
             fflush(stdout);

--- a/src/trees/fenwick_tree.c
+++ b/src/trees/fenwick_tree.c
@@ -5,11 +5,22 @@
 
 FenwickTree* create_fenwick_tree(int size)
 {
+    if (size <= 0)
+        return NULL;
     FenwickTree* ft = (FenwickTree*)malloc(sizeof(FenwickTree));
+    if (ft == NULL)
+        return NULL;
     ft->size = size;
     // 1-based indexing for BIT
     ft->BIT1 = (int*)calloc(size + 1, sizeof(int));
     ft->BIT2 = (int*)calloc(size + 1, sizeof(int));
+    if (ft->BIT1 == NULL || ft->BIT2 == NULL)
+    {
+        free(ft->BIT1);
+        free(ft->BIT2);
+        free(ft);
+        return NULL;
+    }
     return ft;
 }
 
@@ -26,6 +37,8 @@ void destroy_fenwick_tree(FenwickTree* ft)
 // Point update on a single BIT
 void fenwick_point_update(int* BIT, int n, int idx, int delta)
 {
+    if (BIT == NULL || idx <= 0)
+        return;
     for (; idx <= n; idx += idx & -idx)
     {
         BIT[idx] += delta;
@@ -35,6 +48,8 @@ void fenwick_point_update(int* BIT, int n, int idx, int delta)
 // Dual-BIT Range Update [l, r] by delta
 void fenwick_range_update(FenwickTree* ft, int l, int r, int delta)
 {
+    if (ft == NULL || ft->BIT1 == NULL || ft->BIT2 == NULL || l <= 0 || r < l || r > ft->size)
+        return;
     int n = ft->size;
     fenwick_point_update(ft->BIT1, n, l, delta);
     fenwick_point_update(ft->BIT1, n, r + 1, -delta);
@@ -46,6 +61,8 @@ void fenwick_range_update(FenwickTree* ft, int l, int r, int delta)
 // Point query on a single BIT
 int fenwick_point_query(int* BIT, int idx)
 {
+    if (BIT == NULL)
+        return 0;
     int sum = 0;
     for (; idx > 0; idx -= idx & -idx)
     {
@@ -57,12 +74,16 @@ int fenwick_point_query(int* BIT, int idx)
 // Query prefix sum from 1 to x
 static int fenwick_prefix_sum(FenwickTree* ft, int x)
 {
+    if (ft == NULL || ft->BIT1 == NULL || ft->BIT2 == NULL)
+        return 0;
     return fenwick_point_query(ft->BIT1, x) * x - fenwick_point_query(ft->BIT2, x);
 }
 
 // Range Query [l, r]
 int fenwick_range_query(FenwickTree* ft, int l, int r)
 {
+    if (ft == NULL || ft->BIT1 == NULL || ft->BIT2 == NULL || l <= 0 || r < l || r > ft->size)
+        return 0;
     return fenwick_prefix_sum(ft, r) - fenwick_prefix_sum(ft, l - 1);
 }
 
@@ -72,10 +93,15 @@ void fenwick_tree_demo(void)
     int n = 5;
     printf("Created Fenwick Tree of size %d initialized to 0.\n", n);
     FenwickTree* ft = create_fenwick_tree(n);
+    if (ft == NULL)
+    {
+        printf("Failed to create Fenwick Tree due to memory allocation failure.\n");
+        return;
+    }
 
     printf("Action: Adding 10 to range [1, 3]\n");
     fenwick_range_update(ft, 1, 3, 10);
-    
+
     printf("Action: Adding 5 to range [2, 4]\n");
     fenwick_range_update(ft, 2, 4, 5);
 

--- a/src/trees/splay_tree.c
+++ b/src/trees/splay_tree.c
@@ -2,21 +2,24 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-splayNode* splay_create_node(int key) {
+splayNode* splay_create_node(int key)
+{
     splayNode* node = (splayNode*)malloc(sizeof(splayNode));
     node->key = key;
     node->left = node->right = NULL;
     return node;
 }
 
-static splayNode* rightRotate(splayNode* x) {
+static splayNode* rightRotate(splayNode* x)
+{
     splayNode* y = x->left;
     x->left = y->right;
     y->right = x;
     return y;
 }
 
-static splayNode* leftRotate(splayNode* x) {
+static splayNode* leftRotate(splayNode* x)
+{
     splayNode* y = x->right;
     x->right = y->left;
     y->left = x;
@@ -24,36 +27,46 @@ static splayNode* leftRotate(splayNode* x) {
 }
 
 // Splay function: brings the key to root if present, else brings the last accessed node
-splayNode* splay_tree_splay(splayNode* root, int key) {
+splayNode* splay_tree_splay(splayNode* root, int key)
+{
     if (root == NULL || root->key == key)
         return root;
 
-    if (root->key > key) {
-        if (root->left == NULL) return root;
+    if (root->key > key)
+    {
+        if (root->left == NULL)
+            return root;
 
         // Zig-Zig (Left Left)
-        if (root->left->key > key) {
+        if (root->left->key > key)
+        {
             root->left->left = splay_tree_splay(root->left->left, key);
             root = rightRotate(root);
         }
         // Zig-Zag (Left Right)
-        else if (root->left->key < key) {
+        else if (root->left->key < key)
+        {
             root->left->right = splay_tree_splay(root->left->right, key);
             if (root->left->right != NULL)
                 root->left = leftRotate(root->left);
         }
         return (root->left == NULL) ? root : rightRotate(root);
-    } else {
-        if (root->right == NULL) return root;
+    }
+    else
+    {
+        if (root->right == NULL)
+            return root;
 
         // Zag-Zig (Right Left)
-        if (root->right->key > key) {
+        if (root->right->key > key)
+        {
             root->right->left = splay_tree_splay(root->right->left, key);
             if (root->right->left != NULL)
                 root->right = rightRotate(root->right);
         }
         // Zag-Zag (Right Right)
-        else if (root->right->key < key) {
+        else if (root->right->key < key)
+        {
             root->right->right = splay_tree_splay(root->right->right, key);
             root = leftRotate(root);
         }
@@ -62,18 +75,24 @@ splayNode* splay_tree_splay(splayNode* root, int key) {
 }
 
 // Insert, and splay the new node to root
-splayNode* splay_tree_insert(splayNode* root, int key) {
-    if (root == NULL) return splay_create_node(key);
+splayNode* splay_tree_insert(splayNode* root, int key)
+{
+    if (root == NULL)
+        return splay_create_node(key);
 
     root = splay_tree_splay(root, key);
-    if (root->key == key) return root; // Key already exists
+    if (root->key == key)
+        return root; // Key already exists
 
     splayNode* newnode = splay_create_node(key);
-    if (root->key > key) {
+    if (root->key > key)
+    {
         newnode->right = root;
         newnode->left = root->left;
         root->left = NULL;
-    } else {
+    }
+    else
+    {
         newnode->left = root;
         newnode->right = root->right;
         root->right = NULL;
@@ -82,17 +101,23 @@ splayNode* splay_tree_insert(splayNode* root, int key) {
 }
 
 // Delete, and splay the maximum node in the left subtree to root
-splayNode* splay_tree_delete(splayNode* root, int key) {
+splayNode* splay_tree_delete(splayNode* root, int key)
+{
     splayNode* temp;
-    if (!root) return NULL;
+    if (!root)
+        return NULL;
 
     root = splay_tree_splay(root, key);
-    if (root->key != key) return root; // Key not found
+    if (root->key != key)
+        return root; // Key not found
 
-    if (!root->left) {
+    if (!root->left)
+    {
         temp = root;
         root = root->right;
-    } else {
+    }
+    else
+    {
         temp = root;
         root = splay_tree_splay(root->left, key);
         root->right = temp->right;
@@ -101,20 +126,25 @@ splayNode* splay_tree_delete(splayNode* root, int key) {
     return root;
 }
 
-splayNode* splay_tree_search(splayNode* root, int key) {
+splayNode* splay_tree_search(splayNode* root, int key)
+{
     return splay_tree_splay(root, key);
 }
 
-void splay_tree_preorder(splayNode* root) {
-    if (root != NULL) {
+void splay_tree_preorder(splayNode* root)
+{
+    if (root != NULL)
+    {
         printf("%d ", root->key);
         splay_tree_preorder(root->left);
         splay_tree_preorder(root->right);
     }
 }
 
-void destroy_splay_tree(splayNode* root) {
-    if (root) {
+void destroy_splay_tree(splayNode* root)
+{
+    if (root)
+    {
         destroy_splay_tree(root->left);
         destroy_splay_tree(root->right);
         free(root);
@@ -122,7 +152,8 @@ void destroy_splay_tree(splayNode* root) {
 }
 
 // Visual Demo for TUI
-void splay_tree_demo(void) {
+void splay_tree_demo(void)
+{
     splayNode* root = NULL;
     printf("\n--- Splay Tree (Amortized O(log n)) Demo ---\n");
     printf("Action: Inserting 10, 20, 30, 40, 50, 25...\n");
@@ -135,17 +166,17 @@ void splay_tree_demo(void) {
 
     printf("Tree Preorder Traversal (Root is %d): ", root->key);
     splay_tree_preorder(root);
-    
+
     printf("\n\nAction: Searching for 20 (This will splay '20' to the root!)\n");
     root = splay_tree_search(root, 20);
     printf("Tree Preorder Traversal (New Root is %d): ", root->key);
     splay_tree_preorder(root);
-    
+
     printf("\n\nAction: Deleting 30\n");
     root = splay_tree_delete(root, 30);
     printf("Tree Preorder Traversal (Root after deletion is %d): ", root->key);
     splay_tree_preorder(root);
     printf("\n--------------------------------------------\n\n");
-    
+
     destroy_splay_tree(root);
 }

--- a/src/trees/trees_demo.c
+++ b/src/trees/trees_demo.c
@@ -61,7 +61,6 @@ void trees_demo(void)
                 bplus_tree_demo();
                 break;
 
-           case 7:
             case 7:
                 display_header("Segment Tree");
                 segment_tree_demo();

--- a/tests/benchmark/test_benchmark_trees.c
+++ b/tests/benchmark/test_benchmark_trees.c
@@ -33,8 +33,8 @@ void test_trees_benchmark_run(void)
     }
     fclose(file);
 
-    // There should be exactly 6 data rows
-    assert(row_count == 6);
+    // There should be exactly 8 data rows
+    assert(row_count == 8);
 
     // Clean up
     remove("benchmarks/trees.csv");

--- a/tests/graph_traversals/test_dijkstra.c
+++ b/tests/graph_traversals/test_dijkstra.c
@@ -8,9 +8,20 @@
 
 #include "mock_printf.h"
 
-// Redirect printf to our mock
+static int mock_safe_input_int(int* val, const char* prompt, int min, int max)
+{
+    (void)prompt;
+    (void)min;
+    (void)max;
+    *val = 1; // Default to standard Binary Heap
+    return 1;
+}
+
+// Redirect printf to our mock and mock safe_input_int
 #define printf mock_printf
+#define safe_input_int mock_safe_input_int
 #include "../../src/graph_traversals/dijkstra.c"
+#undef safe_input_int
 #undef printf
 
 void test_dijkstra_simple_path()


### PR DESCRIPTION
Closes #654

## Summary
Adds necessary memory allocation validation checks for the newly added Fenwick Tree structure and resolves syntax errors/scoping issues in trees demo & tree benchmarks.

## Details
1. **Fenwick Tree Safety (`src/trees/fenwick_tree.c`)**:
   - Added validation guards to verify that `malloc` and `calloc` allocations for `ft`, `ft->BIT1`, and `ft->BIT2` succeed.
   - Cleaned up partially allocated memory buffers on allocation failures to prevent memory leaks.
   - Implemented safety bounds and NULL check guards in `fenwick_point_update`, `fenwick_range_update`, `fenwick_point_query`, and `fenwick_range_query`.
2. **Compiler Fixes (`src/trees/trees_demo.c`)**:
   - Resolved a duplicate `case 7:` compiler error introduced in the recent merge.
3. **Benchmark Corrections (`benchmark/benchmark_trees.c`)**:
   - Re-scoped the Segment Tree and Fenwick Tree benchmark cases correctly inside the `RUN_BENCHMARK` macro block to fix compiler errors relating to undeclared variables (`stdout_dup`, `fnull`).