### PR TITLE
fix(trees): check malloc return in splay_create_node to avoid segfaults

### DIFF
--- a/src/trees/splay_tree.c
+++ b/src/trees/splay_tree.c
@@ -5,6 +5,10 @@
 splayNode* splay_create_node(int key)
 {
     splayNode* node = (splayNode*)malloc(sizeof(splayNode));
+    if (node == NULL)
+    {
+        return NULL;
+    }
     node->key = key;
     node->left = node->right = NULL;
     return node;


### PR DESCRIPTION
resolves #670 
## Summary
Adds a standard `NULL` pointer check to splay tree node allocation to avoid potential Segmentation Fault crashes under memory pressure.

## Details
- **File:** `src/trees/splay_tree.c`
- **Function:** `splay_create_node`
- **Change:**
  ```c
  splayNode* splay_create_node(int key)
  {
      splayNode* node = (splayNode*)malloc(sizeof(splayNode));
      if (node == NULL)
      {
          return NULL;
      }
      node->key = key;
     