### PR TITLE
feat: add help page accessible via 'help' command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ CFLAGS = -Wall -Wextra -Werror -std=c11 -g \
 	-Isrc/advanced_heaps \
 	-Isrc/hashing \
 	-Isrc/utils \
+	-Isrc/help \
 	-Isrc/trees \
 	-Isrc/error_correction_algorithms \
 	-Isrc/job_scheduling \
@@ -40,6 +41,7 @@ SRC_DIRS = \
 	src/advanced_heaps \
 	src/hashing \
 	src/utils \
+	src/help \
 	src/trees \
 	src/error_correction_algorithms \
 	src/job_scheduling \

--- a/src/help/help.c
+++ b/src/help/help.c
@@ -1,0 +1,107 @@
+#include "help.h"
+#include "../utils/display_header.h"
+#include <stdio.h>
+
+void display_help(void)
+{
+    display_header("HELP - DSA Interactive Suite");
+
+    printf("\n");
+    printf("Welcome to the DSA Interactive Suite Help!\n");
+    printf("=========================================\n");
+    printf("\n");
+
+    printf("GENERAL COMMANDS\n");
+    printf("-----------------\n");
+    printf("  help     - Display this help page\n");
+    printf("  X        - Exit the current module/demo\n");
+    printf("  -1       - Exit the current demo and return to menu\n");
+    printf("\n");
+
+    printf("NAVIGATION\n");
+    printf("-----------\n");
+    printf("  Enter the number corresponding to the module you want to explore.\n");
+    printf("\n");
+
+    printf("AVAILABLE MODULES\n");
+    printf("-----------------\n");
+    printf("  1.  Data Structures\n");
+    printf("      - Linked Lists, Stacks, Queues, Hash Tables\n");
+    printf("\n");
+    printf("  2.  Expression Evaluation\n");
+    printf("      - Infix to Postfix conversion\n");
+    printf("      - Postfix evaluation\n");
+    printf("\n");
+    printf("  3.  Sorting Algorithms (n² family)\n");
+    printf("      - Bubble Sort, Selection Sort, Insertion Sort\n");
+    printf("\n");
+    printf("  4.  Advanced Sorting Algorithms\n");
+    printf("      - Merge Sort, Quick Sort, Heap Sort, Shell Sort\n");
+    printf("\n");
+    printf("  5.  Searching Algorithms\n");
+    printf("      - Linear Search, Binary Search\n");
+    printf("\n");
+    printf("  6.  Graph Traversals\n");
+    printf("      - BFS, DFS, Dijkstra's, A*, Greedy BFS, Bellman Ford\n");
+    printf("\n");
+    printf("  7.  Hashing Algorithms\n");
+    printf("      - Various hashing techniques and collision resolution\n");
+    printf("\n");
+    printf("  8.  Trees\n");
+    printf("      - Binary Trees, BST, AVL, B-Trees, Tries\n");
+    printf("\n");
+    printf("  9.  Error Correction Algorithms\n");
+    printf("      - Hamming Code, CRC, Parity Checks\n");
+    printf("\n");
+    printf("  10. Job Scheduling\n");
+    printf("      - FCFS, SJF, Priority, Round Robin\n");
+    printf("\n");
+    printf("  11. Backtracking Algorithms\n");
+    printf("      - N-Queens, Sudoku Solver, Hamiltonian Path\n");
+    printf("\n");
+    printf("  12. Dynamic Programming\n");
+    printf("      - Fibonacci, LCS, Knapsack, Matrix Chain\n");
+    printf("\n");
+    printf("  13. String Algorithms\n");
+    printf("      - Naive String Matching, KMP, Rabin-Karp\n");
+    printf("\n");
+    printf("  14. Process Synchronization\n");
+    printf("      - Producer-Consumer, Readers-Writers, Dining Philosophers\n");
+    printf("\n");
+    printf("  15. Settings\n");
+    printf("      - Configure animation speed and display preferences\n");
+    printf("\n");
+    printf("  16. Algorithm Benchmarking & Profiling\n");
+    printf("      - Performance analysis and memory profiling\n");
+    printf("\n");
+    printf("  17. Advanced Graph Algorithms\n");
+    printf("      - Strongly Connected Components, Max Flow\n");
+    printf("      - Bipartite Matching, Eulerian Path\n");
+    printf("\n");
+    printf("  18. Advanced Heaps & Priority Queues\n");
+    printf("      - Fibonacci Heap, Binomial Heap\n");
+    printf("\n");
+
+    printf("INPUT GUIDELINES\n");
+    printf("-----------------\n");
+    printf("  - Enter only valid integer choices when prompted\n");
+    printf("  - For string inputs, avoid spaces unless explicitly allowed\n");
+    printf("  - Maximum input length is typically 99 characters\n");
+    printf("  - Press X at any prompt to exit the current module\n");
+    printf("\n");
+
+    printf("TIPS\n");
+    printf("----\n");
+    printf("  - Watch the animations to understand algorithm behavior\n");
+    printf("  - Use benchmarking to compare algorithm performance\n");
+    printf("  - Try different input values to explore edge cases\n");
+    printf("  - Check settings to adjust animation speed to your preference\n");
+    printf("\n");
+
+    printf("For more information, visit the project repository.\n");
+    printf("\n");
+
+    printf("Press Enter to continue...");
+    while (getchar() != '\n')
+        ;
+}

--- a/src/help/help.h
+++ b/src/help/help.h
@@ -1,0 +1,6 @@
+#ifndef HELP_H
+#define HELP_H
+
+void display_help(void);
+
+#endif

--- a/src/utils/safe_input_string.c
+++ b/src/utils/safe_input_string.c
@@ -1,4 +1,5 @@
 #include "safe_input.h"
+#include "../help/help.h"
 #include <stdio.h>
 #include <string.h>
 
@@ -25,6 +26,14 @@ int safe_input_string(char* buffer, const char* prompt)
         if (strcmp(buffer, "X") == 0)
         {
             return INPUT_EXIT_SIGNAL;
+        }
+
+        if (strcmp(buffer, "help") == 0)
+        {
+            display_help();
+            printf("%s", prompt);
+            fflush(stdout);
+            continue;
         }
 
         return 1;


### PR DESCRIPTION
## Description
Implements **Issue #657: add a help page in the suite.**

### Changes Made:

1. **Created `src/help/` directory** with:
   - `help.h` - Header file declaring `display_help()` function
   - `help.c` - Implementation with comprehensive help content

2. **Help Page Content**:
   - General commands (help, X, -1)
   - All 18 available modules with descriptions
   - Input guidelines
   - Tips for using the suite

3. **Modified `safe_input_string()`** in `src/utils/safe_input_string.c`:
   - Added detection for "help" command using `strcmp()`
   - Displays help page when "help" is typed at any input prompt
   - Continues prompting after help is displayed

4. **Updated `Makefile`**:
   - Added `-Isrc/help` to CFLAGS
   - Added `src/help` to SRC_DIRS

### Usage:
Type `help` at any string input prompt to display the help page.

### Acceptance Criteria:
✅ Help page displays when user types "help" at any input prompt
✅ Works like Linux `man` pages - just typing `help` launches the help page
✅ Check implemented in `safe_input_string()` using `strcmp()`
✅ Help page function lives in `src/help` directory

---
