### PR TITLE
fix: prevent out-of-bounds array read in Gantt chart rendering

### DIFF
--- a/src/job_scheduling/job_scheduling_demo.c
+++ b/src/job_scheduling/job_scheduling_demo.c
@@ -137,6 +137,12 @@ void js_add_segment(GanttSegment* segments, int* count, int id, int time)
 
 void js_print_gantt(const GanttSegment* segments, int count)
 {
+    if (count <= 0)
+    {
+        printf("\nNo scheduling segments to display.\n");
+        return;
+    }
+
     printf("\nGantt chart:\n");
 
     printf("|");


### PR DESCRIPTION
# Description
Closes #709

### Summary of Changes
- Added a safety check at the beginning of `js_print_gantt` in `src/job_scheduling/job_scheduling_demo.c` to return early if the segment count is `0` or negative.
- This prevents `segments[0].start` from being dereferenced when no process execution segments exist, eliminating out-of-bounds reads/segfaults.

### Verification
- Compiled and formatted code with `make fmt`.
- Tested the scheduler demo under empty/invalid segment states and confirmed it no longer crashes.