### PR TITLE
fix: prevent stack buffer overflow in infix to postfix/prefix conversions

### DIFF
--- a/src/expression_evaluation/infix_to_postfix.c
+++ b/src/expression_evaluation/infix_to_postfix.c
@@ -31,7 +31,7 @@ int isOperator(char ch)
 void infix_to_postfix_demo(void)
 {
     char infix_expr[50];
-    char postfix_expr[50];
+    char postfix_expr[100];
     int step;
 
     while (1)

--- a/src/expression_evaluation/infix_to_prefix.c
+++ b/src/expression_evaluation/infix_to_prefix.c
@@ -43,8 +43,8 @@ void infix_to_prefix_demo(void)
 {
     char infix_expr[50];
     char reversed_expr[50];
-    char postfix_expr[50];
-    char prefix_expr[50];
+    char postfix_expr[100];
+    char prefix_expr[100];
 
     while (1)
     {


### PR DESCRIPTION

# Description
Closes #708

### Summary of Changes
- Increased static buffer sizes of `postfix_expr` and `prefix_expr` from `50` to `100` in both `infix_to_postfix.c` and `infix_to_prefix.c`.
- This provides ample space for processing character outputs, operators, and null-termination up to the maximum validated expression size (49 characters), preventing out-of-bounds stack corruption.

### Verification
- Formatted the code with `make fmt`.
- Compiled and successfully executed all unit tests.