### PR TITLE
fix: set fallback sorting visualization bar width to 1 when all elements are equal (#715)

### DIFF
--- a/src/utils/sorting_visualizer.c
+++ b/src/utils/sorting_visualizer.c
@@ -81,7 +81,7 @@ void visualize_sort(const int arr[], int n, int active_idx1, int active_idx2, in
         long long denominator = (long long)max_val - min_val;
         if (denominator <= 0)
         {
-            width = 10;
+            width = 1;
         }
         else
         {


### PR DESCRIPTION
# Description
Closes #715

### Summary of Changes
- Modified `visualize_sort()` in `src/utils/sorting_visualizer.c` to use a fallback bar width of `1` (instead of `10`) when all elements in the array are equal (denominator `<= 0`).
- This establishes consistent scaling baseline across uniform and non-uniform arrays in the sorting visualization animations.

### Verification
- Formatted all source files with `make fmt`.
- Built the project successfully and ran sorting demos on uniform input arrays to confirm visual correctness.