### PR TITLE
fix: add input validation and unit tests for Suffix Array module (#716)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -550,6 +550,7 @@ $(TEST_DIR)/test_string_algorithms$(EXE): \
     $(OBJ_DIR)/src/string_algorithms/naive_string_matching.o \
     $(OBJ_DIR)/src/string_algorithms/kmp.o \
     $(OBJ_DIR)/src/string_algorithms/rabin_karp.o \
+    $(OBJ_DIR)/src/string_algorithms/suffix_array.o \
     $(OBJ_DIR)/src/utils/safe_input_string.o \
     $(OBJ_DIR)/src/utils/clear_screen.o \
 	$(OBJ_DIR)/src/utils/safe_input_int.o $(OBJ_DIR)/src/help/help.o \

--- a/src/string_algorithms/suffix_array.c
+++ b/src/string_algorithms/suffix_array.c
@@ -23,6 +23,10 @@ int cmp(const void* a, const void* b)
 
 int* build_suffix_array(const char* txt, int n)
 {
+    if (txt == NULL || n <= 0)
+    {
+        return NULL;
+    }
     struct Suffix* suffixes = (struct Suffix*)malloc(n * sizeof(struct Suffix));
     if (suffixes == NULL)
     {
@@ -92,7 +96,7 @@ int* build_suffix_array(const char* txt, int n)
 
 int* build_lcp_array(const char* txt, int* suffix_arr, int n)
 {
-    if (suffix_arr == NULL)
+    if (txt == NULL || suffix_arr == NULL || n <= 0)
     {
         return NULL;
     }
@@ -138,6 +142,14 @@ int* build_lcp_array(const char* txt, int* suffix_arr, int n)
 
 void find_longest_repeated_substring(const char* txt, int n, char* output)
 {
+    if (txt == NULL || n <= 0 || output == NULL)
+    {
+        if (output != NULL)
+        {
+            output[0] = '\0';
+        }
+        return;
+    }
     int* sa = build_suffix_array(txt, n);
     if (sa == NULL)
     {

--- a/tests/string_algorithms/test_string_algorithms.c
+++ b/tests/string_algorithms/test_string_algorithms.c
@@ -20,6 +20,9 @@ int _fileno(FILE*);
 void naive_string_matching(char* text, char* pattern);
 void kmp_search(char* text, char* pattern);
 void rabin_karp_search(char* text, char* pattern, int q);
+void find_longest_repeated_substring(const char* txt, int n, char* output);
+int* build_suffix_array(const char* txt, int n);
+int* build_lcp_array(const char* txt, int* suffix_arr, int n);
 
 /* Run a matcher with stdout redirected to a temp file, then return how many
    "found at index" lines it printed. */
@@ -118,10 +121,35 @@ void test_non_ascii_bytes()
     printf("String matching non-ASCII tests passed\n");
 }
 
+void test_suffix_array()
+{
+    char txt[] = "banana";
+    int n = strlen(txt);
+    char lrs[50];
+    find_longest_repeated_substring(txt, n, lrs);
+    assert(strcmp(lrs, "an") == 0 || strcmp(lrs, "ana") == 0);
+
+    assert(build_suffix_array(NULL, 5) == NULL);
+    assert(build_suffix_array("abc", 0) == NULL);
+    assert(build_suffix_array("abc", -1) == NULL);
+
+    int sa[] = {0, 1, 2};
+    assert(build_lcp_array(NULL, sa, 3) == NULL);
+    assert(build_lcp_array("abc", NULL, 3) == NULL);
+    assert(build_lcp_array("abc", sa, 0) == NULL);
+
+    find_longest_repeated_substring(NULL, 5, lrs);
+    find_longest_repeated_substring("abc", 3, NULL);
+    find_longest_repeated_substring("abc", 0, lrs);
+
+    printf("Suffix Array validation tests passed\n");
+}
+
 int main()
 {
     test_basic_matches();
     test_non_ascii_bytes();
+    test_suffix_array();
     printf("All string algorithms tests passed\n");
     return 0;
 }


### PR DESCRIPTION
# Description
Closes #716

### Summary of Changes
- Added validation guards checking for `NULL` pointers (`txt`, `suffix_arr`, `output`) and invalid lengths (`n <= 0`) in `build_suffix_array`, `build_lcp_array`, and `find_longest_repeated_substring` in `src/string_algorithms/suffix_array.c`.
- Added comprehensive unit tests in `tests/string_algorithms/test_string_algorithms.c` to test the functionality and verify that `NULL` pointer/invalid input parameters are handled safely without segmentation faults.
- Integrated `suffix_array.o` into the `test_string_algorithms` test binary inside the `Makefile`.

### Verification
- Formatted all source files with `make fmt`.
- Built and ran `test_string_algorithms` successfully.