### PR TITLE
fix: validate input length in Suffix Array demo and visualizer (#717)

### DIFF
--- a/src/string_algorithms/suffix_array.c
+++ b/src/string_algorithms/suffix_array.c
@@ -178,7 +178,7 @@ void find_longest_repeated_substring(const char* txt, int n, char* output)
 
 void visualize_suffix_array(const char* txt, int n, int* sa, int* lcp)
 {
-    if (sa == NULL || lcp == NULL)
+    if (txt == NULL || n <= 0 || sa == NULL || lcp == NULL)
     {
         return;
     }
@@ -200,13 +200,13 @@ void suffix_array_demo(void)
     {
         txt[strcspn(txt, "\n")] = 0; // Remove newline
 
-        if (strlen(txt) == 0)
+        int n = (int)strlen(txt);
+        if (n <= 0)
         {
             printf("Error: Empty string provided.\n");
             return;
         }
 
-        int n = strlen(txt);
         int* sa = build_suffix_array(txt, n);
         if (sa == NULL)
         {


### PR DESCRIPTION
# Description
Closes #717

### Summary of Changes
- Updated `suffix_array_demo()` in `src/string_algorithms/suffix_array.c` to perform robust validation on string length `n <= 0` before passing to build functions.
- Added validation for `txt == NULL || n <= 0` to `visualize_suffix_array()` to protect against division-by-zero and memory issues on empty segments.

### Verification
- Formatted all source files with `make fmt`.
- Built the project successfully and ran suffix array demos to confirm stability under empty inputs.