### PR TITLE
fix(hashing): resolve SIGFPE division by zero in hash functions

### DIFF
--- a/src/hashing/double_hashing.c
+++ b/src/hashing/double_hashing.c
@@ -79,7 +79,12 @@ void double_hashing_demo(void)
             }
 
             int h1 = hash_function(value, length_of_array); // primary hash
-            int h2 = second_hash(value, length_of_array);   // step size, never 0
+            if (h1 == -1)
+            {
+                printf("\nInvalid array length for hashing.\n");
+                continue;
+            }
+            int h2 = second_hash(value, length_of_array); // step size, never 0
             bool inserted = false;
 
             for (int i = 0; i < length_of_array; i++)
@@ -121,6 +126,11 @@ void double_hashing_demo(void)
             }
 
             int h1 = hash_function(search_val, length_of_array);
+            if (h1 == -1)
+            {
+                printf("\nInvalid array length for hashing.\n");
+                continue;
+            }
             int h2 = second_hash(search_val, length_of_array);
             int found_index = -1;
 

--- a/src/hashing/linear_probing.c
+++ b/src/hashing/linear_probing.c
@@ -86,6 +86,12 @@ void linear_probing_demo(void)
             int hash_location = hash_function(
                 value, length_of_array); // calling the hash function on user input value
 
+            if (hash_location == -1)
+            {
+                printf("\nInvalid array length for hashing.\n");
+                continue;
+            }
+
             if (!arr[hash_location])
             {
                 arr[hash_location] = value; // inserting value at its hash location
@@ -136,6 +142,11 @@ void linear_probing_demo(void)
             // walk forward with wrap-around. instead of placing the value, we record the index
             // where it is found. this reflects the real cost of a hash-table lookup.
             int hash_location = hash_function(search_val, length_of_array);
+            if (hash_location == -1)
+            {
+                printf("\nInvalid array length for hashing.\n");
+                continue;
+            }
             int res = -1;
             int start = hash_location;
 

--- a/src/hashing/linear_probing.c
+++ b/src/hashing/linear_probing.c
@@ -9,6 +9,10 @@
 // modules
 static int next_prime(int n)
 {
+    if (n <= 1)
+    {
+        return 2;
+    }
     int size = sizeof(PRIMES) / sizeof(PRIMES[0]);
     for (int i = n + 1; i < size; i++)
     {
@@ -32,6 +36,10 @@ static int next_prime(int n)
 
 int hash_function(int value, int length_of_array)
 {
+    if (length_of_array <= 0)
+    {
+        return -1; 
+    }
     int next_prime_no = next_prime(length_of_array);
     return ((value + 1) * next_prime_no) % length_of_array;
 }

--- a/src/hashing/linear_probing.c
+++ b/src/hashing/linear_probing.c
@@ -38,7 +38,7 @@ int hash_function(int value, int length_of_array)
 {
     if (length_of_array <= 0)
     {
-        return -1; 
+        return -1;
     }
     int next_prime_no = next_prime(length_of_array);
     return ((value + 1) * next_prime_no) % length_of_array;

--- a/src/hashing/quadratic_probing.c
+++ b/src/hashing/quadratic_probing.c
@@ -44,6 +44,11 @@ void quadratic_probing_demo(void)
             }
 
             int base_hash_location = hash_function(value, length_of_array);
+            if (base_hash_location == -1)
+            {
+                printf("\nInvalid array length for hashing.\n");
+                continue;
+            }
             bool inserted = false;
 
             for (int i = 0; i < length_of_array; i++)
@@ -88,6 +93,11 @@ void quadratic_probing_demo(void)
             }
 
             int base_hash_location = hash_function(search_value, length_of_array);
+            if (base_hash_location == -1)
+            {
+                printf("\nInvalid array length for hashing.\n");
+                continue;
+            }
             bool found = false;
 
             for (int i = 0; i < length_of_array; i++)

--- a/src/hashing/separate_chaining.c
+++ b/src/hashing/separate_chaining.c
@@ -49,6 +49,11 @@ void separate_chaining_demo(void)
             }
 
             int hash_location = hash_function(value, hash_table_size);
+            if (hash_location == -1)
+            {
+                printf("\nInvalid array length for hashing.\n");
+                continue;
+            }
 
             sll_insertAtEnd(&table[hash_location],
                             value); // insert value by passing the address of the pointer to Node


### PR DESCRIPTION
### Summary
Fixed Division by Zero (SIGFPE): Added an if (length_of_array <= 0) return -1; guard to hash_function in linear_probing.c, safely securing all hashing modules against modulo-by-zero crashes.
Fixed next_prime Edge Cases: Added an if (n <= 1) return 2; check to guarantee it always returns a valid prime (2), preventing out-of-bounds table lookups and broken multipliers.
Formatting: Formatted the newly added logic to match the project's standard Allman style (new line for opening braces {).
Makefile: Verified that the existing Makefile doesn't require any updates, as we only modified existing source files without introducing new dependencies.

closes #713 