### PR TITLE
Fix invalid include of non-existent data_structures.h

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -3,7 +3,6 @@
 #include "advanced_sorting_algorithms/advanced_sorting.h"
 #include "backtracking/backtracking.h"
 #include "benchmark.h"
-#include "data_structures/data_structures.h"
 #include "dynamic_programming/dynamic_programming.h"
 #include "error_correction_algorithms/error_correction_algorithms.h"
 #include "expression_evaluation/expression.h"


### PR DESCRIPTION
## Summary

This PR removes an invalid include from `src/main.c`.

The project includes:

```c
#include "data_structures/data_structures.h"
```

solves #734 