### PR TITLE
feat: implement LRU and MRU cache replacement algorithms (PR 2)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,7 @@ set(SRC_DIRS
     memory_profiler
     src/debugger
     benchmark
+    src/cache_simulator
 )
 
 # Header search paths

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,8 @@ CFLAGS = -Wall -Wextra -Werror -std=c11 -g \
 	-Isrc/process_synchronization \
 	-Imemory_profiler \
 	-Isrc/debugger \
-	-Ibenchmark
+	-Ibenchmark \
+	-Isrc/cache_simulator
 	# -Itui
 
 # LDFLAGS = -lncurses
@@ -52,7 +53,8 @@ SRC_DIRS = \
 	src/process_synchronization \
 	memory_profiler \
 	src/debugger \
-	benchmark
+	benchmark \
+	src/cache_simulator
 
 # SRCS = $(foreach dir,$(SRC_DIRS),$(wildcard $(dir)/*.c))
 # OBJS = $(patsubst %.c,$(OBJ_DIR)/%.o,$(SRCS))
@@ -147,7 +149,7 @@ TEST_BINS = test_circ_queue test_bst test_search test_hash_func \
             test_string_algorithms test_expression_evaluation \
             test_fcfs test_sjf test_srtf test_round_robin test_priority_scheduling test_preemptive_priority \
             test_dining_philosophers test_petersons test_producer_consumer \
-            test_dijkstra test_bellman_ford test_bfs test_dfs test_topological_sort test_benchmark test_scc test_ford_fulkerson test_edmonds_karp test_dinic test_bipartite_matching test_hopcroft_karp test_eulerian_path
+            test_dijkstra test_bellman_ford test_bfs test_dfs test_topological_sort test_benchmark test_scc test_ford_fulkerson test_edmonds_karp test_dinic test_bipartite_matching test_hopcroft_karp test_eulerian_path test_cache_simulator
 
 # Automatically find all advanced heap test sources and append their targets
 ADV_HEAP_TESTS = $(patsubst tests/advanced_heaps/%.c,%,$(wildcard tests/advanced_heaps/*.c))
@@ -788,6 +790,13 @@ test_memory_tracker: $(TEST_DIR)/test_memory_tracker$(EXE)
 	$(TEST_DIR)/test_memory_tracker$(EXE)
 
 $(TEST_DIR)/test_memory_tracker$(EXE): $(OBJS) tests/memory_profiler/test_memory_tracker.c
+	@$(call MKDIR_P,$(TEST_DIR))
+	$(CC) $(CFLAGS) $^ -o $@ $(LDFLAGS)
+
+test_cache_simulator: $(TEST_DIR)/test_cache_simulator$(EXE)
+	$(TEST_DIR)/test_cache_simulator$(EXE)
+
+$(TEST_DIR)/test_cache_simulator$(EXE): $(OBJ_DIR)/src/cache_simulator/cache.o tests/cache_simulator/test_cache_simulator.c
 	@$(call MKDIR_P,$(TEST_DIR))
 	$(CC) $(CFLAGS) $^ -o $@ $(LDFLAGS)
 

--- a/src/cache_simulator/cache.c
+++ b/src/cache_simulator/cache.c
@@ -1,0 +1,94 @@
+#include "cache.h"
+#include <stdio.h>
+
+void cache_init(Cache* cache, int capacity)
+{
+    if (capacity > CACHE_MAX_CAPACITY)
+    {
+        capacity = CACHE_MAX_CAPACITY;
+    }
+    if (capacity < 1)
+    {
+        capacity = 1;
+    }
+    cache->capacity = capacity;
+    cache->size = 0;
+    cache->fifo_index = 0;
+    cache->hits = 0;
+    cache->misses = 0;
+    for (int i = 0; i < CACHE_MAX_CAPACITY; i++)
+    {
+        cache->blocks[i].page_id = -1;
+        cache->blocks[i].is_valid = false;
+        cache->blocks[i].is_dirty = false;
+        cache->blocks[i].reference_bit = 0;
+        cache->blocks[i].frequency = 0;
+        cache->blocks[i].last_access_time = 0;
+    }
+}
+
+bool cache_access_fifo(Cache* cache, int page_id, bool is_write)
+{
+    // Search for page in the cache (Hit check)
+    for (int i = 0; i < cache->capacity; i++)
+    {
+        if (cache->blocks[i].is_valid && cache->blocks[i].page_id == page_id)
+        {
+            cache->hits++;
+            if (is_write)
+            {
+                cache->blocks[i].is_dirty = true;
+            }
+            return true; // Hit
+        }
+    }
+
+    // Cache Miss
+    cache->misses++;
+
+    // If cache is not full, insert in the first invalid slot
+    if (cache->size < cache->capacity)
+    {
+        for (int i = 0; i < cache->capacity; i++)
+        {
+            if (!cache->blocks[i].is_valid)
+            {
+                cache->blocks[i].page_id = page_id;
+                cache->blocks[i].is_valid = true;
+                cache->blocks[i].is_dirty = is_write;
+                cache->size++;
+                return false; // Miss (inserted without eviction)
+            }
+        }
+    }
+
+    // Cache is full: Evict using FIFO policy
+    int evict_idx = cache->fifo_index;
+
+    // Perform eviction
+    cache->blocks[evict_idx].page_id = page_id;
+    cache->blocks[evict_idx].is_valid = true;
+    cache->blocks[evict_idx].is_dirty = is_write;
+
+    // Update FIFO pointer (circular queue)
+    cache->fifo_index = (cache->fifo_index + 1) % cache->capacity;
+
+    return false; // Miss (with eviction)
+}
+
+void cache_print_status(const Cache* cache)
+{
+    printf("Cache state: [ ");
+    for (int i = 0; i < cache->capacity; i++)
+    {
+        if (cache->blocks[i].is_valid)
+        {
+            printf("%d ", cache->blocks[i].page_id);
+        }
+        else
+        {
+            printf("- ");
+        }
+    }
+    printf("] (Hits: %d, Misses: %d)\n", cache->hits, cache->misses);
+}

--- a/src/cache_simulator/cache.c
+++ b/src/cache_simulator/cache.c
@@ -14,6 +14,7 @@ void cache_init(Cache* cache, int capacity)
     cache->capacity = capacity;
     cache->size = 0;
     cache->fifo_index = 0;
+    cache->access_counter = 0;
     cache->hits = 0;
     cache->misses = 0;
     for (int i = 0; i < CACHE_MAX_CAPACITY; i++)
@@ -72,6 +73,126 @@ bool cache_access_fifo(Cache* cache, int page_id, bool is_write)
 
     // Update FIFO pointer (circular queue)
     cache->fifo_index = (cache->fifo_index + 1) % cache->capacity;
+
+    return false; // Miss (with eviction)
+}
+
+bool cache_access_lru(Cache* cache, int page_id, bool is_write)
+{
+    cache->access_counter++;
+
+    // Search for page in the cache (Hit check)
+    for (int i = 0; i < cache->capacity; i++)
+    {
+        if (cache->blocks[i].is_valid && cache->blocks[i].page_id == page_id)
+        {
+            cache->hits++;
+            cache->blocks[i].last_access_time = cache->access_counter;
+            if (is_write)
+            {
+                cache->blocks[i].is_dirty = true;
+            }
+            return true; // Hit
+        }
+    }
+
+    // Cache Miss
+    cache->misses++;
+
+    // If cache is not full, insert in the first invalid slot
+    if (cache->size < cache->capacity)
+    {
+        for (int i = 0; i < cache->capacity; i++)
+        {
+            if (!cache->blocks[i].is_valid)
+            {
+                cache->blocks[i].page_id = page_id;
+                cache->blocks[i].is_valid = true;
+                cache->blocks[i].is_dirty = is_write;
+                cache->blocks[i].last_access_time = cache->access_counter;
+                cache->size++;
+                return false; // Miss (inserted without eviction)
+            }
+        }
+    }
+
+    // Cache is full: Find block with MINIMUM last_access_time
+    int evict_idx = 0;
+    int min_access = cache->blocks[0].last_access_time;
+    for (int i = 1; i < cache->capacity; i++)
+    {
+        if (cache->blocks[i].last_access_time < min_access)
+        {
+            min_access = cache->blocks[i].last_access_time;
+            evict_idx = i;
+        }
+    }
+
+    // Perform eviction
+    cache->blocks[evict_idx].page_id = page_id;
+    cache->blocks[evict_idx].is_valid = true;
+    cache->blocks[evict_idx].is_dirty = is_write;
+    cache->blocks[evict_idx].last_access_time = cache->access_counter;
+
+    return false; // Miss (with eviction)
+}
+
+bool cache_access_mru(Cache* cache, int page_id, bool is_write)
+{
+    cache->access_counter++;
+
+    // Search for page in the cache (Hit check)
+    for (int i = 0; i < cache->capacity; i++)
+    {
+        if (cache->blocks[i].is_valid && cache->blocks[i].page_id == page_id)
+        {
+            cache->hits++;
+            cache->blocks[i].last_access_time = cache->access_counter;
+            if (is_write)
+            {
+                cache->blocks[i].is_dirty = true;
+            }
+            return true; // Hit
+        }
+    }
+
+    // Cache Miss
+    cache->misses++;
+
+    // If cache is not full, insert in the first invalid slot
+    if (cache->size < cache->capacity)
+    {
+        for (int i = 0; i < cache->capacity; i++)
+        {
+            if (!cache->blocks[i].is_valid)
+            {
+                cache->blocks[i].page_id = page_id;
+                cache->blocks[i].is_valid = true;
+                cache->blocks[i].is_dirty = is_write;
+                cache->blocks[i].last_access_time = cache->access_counter;
+                cache->size++;
+                return false; // Miss (inserted without eviction)
+            }
+        }
+    }
+
+    // Cache is full: Find block with MAXIMUM last_access_time
+    int evict_idx = 0;
+    int max_access = cache->blocks[0].last_access_time;
+    for (int i = 1; i < cache->capacity; i++)
+    {
+        if (cache->blocks[i].last_access_time > max_access)
+        {
+            max_access = cache->blocks[i].last_access_time;
+            evict_idx = i;
+        }
+    }
+
+    // Perform eviction
+    cache->blocks[evict_idx].page_id = page_id;
+    cache->blocks[evict_idx].is_valid = true;
+    cache->blocks[evict_idx].is_dirty = is_write;
+    cache->blocks[evict_idx].last_access_time = cache->access_counter;
 
     return false; // Miss (with eviction)
 }

--- a/src/cache_simulator/cache.h
+++ b/src/cache_simulator/cache.h
@@ -21,6 +21,7 @@ typedef struct
     int capacity;
     int size;
     int fifo_index;
+    int access_counter;
 
     // Statistics
     int hits;
@@ -29,6 +30,8 @@ typedef struct
 
 void cache_init(Cache* cache, int capacity);
 bool cache_access_fifo(Cache* cache, int page_id, bool is_write);
+bool cache_access_lru(Cache* cache, int page_id, bool is_write);
+bool cache_access_mru(Cache* cache, int page_id, bool is_write);
 void cache_print_status(const Cache* cache);
 void cache_simulator_demo(void);
 

--- a/src/cache_simulator/cache.h
+++ b/src/cache_simulator/cache.h
@@ -1,0 +1,35 @@
+#ifndef CACHE_H
+#define CACHE_H
+
+#include <stdbool.h>
+
+#define CACHE_MAX_CAPACITY 10
+
+typedef struct
+{
+    int page_id;
+    bool is_valid;
+    bool is_dirty;
+    int reference_bit;
+    int frequency;
+    int last_access_time;
+} CacheBlock;
+
+typedef struct
+{
+    CacheBlock blocks[CACHE_MAX_CAPACITY];
+    int capacity;
+    int size;
+    int fifo_index;
+
+    // Statistics
+    int hits;
+    int misses;
+} Cache;
+
+void cache_init(Cache* cache, int capacity);
+bool cache_access_fifo(Cache* cache, int page_id, bool is_write);
+void cache_print_status(const Cache* cache);
+void cache_simulator_demo(void);
+
+#endif // CACHE_H

--- a/src/cache_simulator/cache_demo.c
+++ b/src/cache_simulator/cache_demo.c
@@ -1,0 +1,62 @@
+#include "cache.h"
+#include "display_header.h"
+#include "safe_input.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+void cache_simulator_demo(void)
+{
+    while (1)
+    {
+        display_header("Cache Replacement Simulator");
+
+        int capacity;
+        int cap_status =
+            safe_input_int(&capacity, "\nEnter cache capacity (1 to 10), or '-1' to exit: ", 1,
+                           CACHE_MAX_CAPACITY);
+        if (cap_status == INPUT_EXIT_SIGNAL)
+        {
+            return;
+        }
+        if (cap_status == 0)
+        {
+            continue;
+        }
+
+        Cache cache;
+        cache_init(&cache, capacity);
+
+        char ref_str[256];
+        int ref_status = safe_input_string(
+            ref_str, "Enter page reference string (e.g., 1,2,3,4,1,2), or 'X' to exit: ");
+        if (ref_status == INPUT_EXIT_SIGNAL)
+        {
+            return;
+        }
+
+        printf("\nSimulating FIFO Cache Replacement:\n");
+        printf("------------------------------------\n");
+
+        char* token = strtok(ref_str, ", ");
+        while (token != NULL)
+        {
+            int page_id = atoi(token);
+            bool is_hit = cache_access_fifo(&cache, page_id, false);
+            printf("Access page %d -> %s | ", page_id, is_hit ? "🟢 HIT " : "🔴 MISS");
+            cache_print_status(&cache);
+            token = strtok(NULL, ", ");
+        }
+
+        printf("------------------------------------\n");
+        printf("Simulation finished.\n");
+        printf("Total Hits: %d, Total Misses (Page Faults): %d\n", cache.hits, cache.misses);
+        if (cache.hits + cache.misses > 0)
+        {
+            printf("Hit Rate: %.2f%%\n", (double)cache.hits * 100 / (cache.hits + cache.misses));
+        }
+
+        printf("\nPress [ENTER] to continue...");
+        getchar();
+    }
+}

--- a/src/cache_simulator/cache_demo.c
+++ b/src/cache_simulator/cache_demo.c
@@ -24,6 +24,20 @@ void cache_simulator_demo(void)
             continue;
         }
 
+        int algo_choice;
+        int algo_status = safe_input_int(&algo_choice,
+                                         "\nSelect Cache Algorithm:\n1. FIFO\n2. LRU\n3. "
+                                         "MRU\nEnter choice (1 to 3), or '-1' to exit: ",
+                                         1, 3);
+        if (algo_status == INPUT_EXIT_SIGNAL)
+        {
+            return;
+        }
+        if (algo_status == 0)
+        {
+            continue;
+        }
+
         Cache cache;
         cache_init(&cache, capacity);
 
@@ -35,14 +49,27 @@ void cache_simulator_demo(void)
             return;
         }
 
-        printf("\nSimulating FIFO Cache Replacement:\n");
+        printf("\nSimulating %s Cache Replacement:\n",
+               algo_choice == 1 ? "FIFO" : (algo_choice == 2 ? "LRU" : "MRU"));
         printf("------------------------------------\n");
 
         char* token = strtok(ref_str, ", ");
         while (token != NULL)
         {
             int page_id = atoi(token);
-            bool is_hit = cache_access_fifo(&cache, page_id, false);
+            bool is_hit = false;
+            if (algo_choice == 1)
+            {
+                is_hit = cache_access_fifo(&cache, page_id, false);
+            }
+            else if (algo_choice == 2)
+            {
+                is_hit = cache_access_lru(&cache, page_id, false);
+            }
+            else
+            {
+                is_hit = cache_access_mru(&cache, page_id, false);
+            }
             printf("Access page %d -> %s | ", page_id, is_hit ? "🟢 HIT " : "🔴 MISS");
             cache_print_status(&cache);
             token = strtok(NULL, ", ");

--- a/src/main.c
+++ b/src/main.c
@@ -7,6 +7,7 @@
 #include "array.h"
 #include "backtracking.h"
 #include "benchmark.h"
+#include "cache.h"
 #include "config.h"
 #include "dcll.h"
 #include "display_header.h"
@@ -70,8 +71,9 @@ void run_legacy_menu()
             "eulerian path) demo\n"
             "click 18 for advanced heaps & priority queues suite demo\n"
             "click 19 for interactive algorithm step-debugger demo\n"
+            "click 20 for cache replacement simulator demo\n"
             "enter choice : ",
-            1, 19 // limits
+            1, 20 // limits
         );
 
         if (status == -111)
@@ -144,6 +146,9 @@ void run_legacy_menu()
                 break;
             case 19:
                 debugger_demo();
+                break;
+            case 20:
+                cache_simulator_demo();
                 break;
         }
     }

--- a/tests/cache_simulator/test_cache_simulator.c
+++ b/tests/cache_simulator/test_cache_simulator.c
@@ -1,0 +1,70 @@
+#include "cache.h"
+#include <assert.h>
+#include <stdio.h>
+
+void test_fifo_basic()
+{
+    Cache cache;
+    cache_init(&cache, 3);
+
+    // Initial state
+    assert(cache.capacity == 3);
+    assert(cache.size == 0);
+    assert(cache.hits == 0);
+    assert(cache.misses == 0);
+
+    // Access 1: Miss
+    assert(!cache_access_fifo(&cache, 1, false));
+    assert(cache.size == 1);
+    assert(cache.misses == 1);
+
+    // Access 2: Miss
+    assert(!cache_access_fifo(&cache, 2, false));
+    assert(cache.size == 2);
+    assert(cache.misses == 2);
+
+    // Access 3: Miss
+    assert(!cache_access_fifo(&cache, 3, false));
+    assert(cache.size == 3);
+    assert(cache.misses == 3);
+
+    // Access 1: Hit
+    assert(cache_access_fifo(&cache, 1, false));
+    assert(cache.size == 3);
+    assert(cache.hits == 1);
+
+    // Access 4: Miss (FIFO evicts 1)
+    assert(!cache_access_fifo(&cache, 4, false));
+    assert(cache.misses == 4);
+
+    // 1 should no longer be in the cache
+    bool found_1 = false;
+    for (int i = 0; i < 3; i++)
+    {
+        if (cache.blocks[i].page_id == 1)
+            found_1 = true;
+    }
+    assert(!found_1);
+
+    // Access 1: Miss (FIFO evicts 2)
+    assert(!cache_access_fifo(&cache, 1, false));
+    assert(cache.misses == 5);
+
+    // 2 should no longer be in cache
+    bool found_2 = false;
+    for (int i = 0; i < 3; i++)
+    {
+        if (cache.blocks[i].page_id == 2)
+            found_2 = true;
+    }
+    assert(!found_2);
+
+    printf("FIFO basic cache tests passed\n");
+}
+
+int main()
+{
+    test_fifo_basic();
+    printf("All cache simulator tests passed\n");
+    return 0;
+}

--- a/tests/cache_simulator/test_cache_simulator.c
+++ b/tests/cache_simulator/test_cache_simulator.c
@@ -62,9 +62,70 @@ void test_fifo_basic()
     printf("FIFO basic cache tests passed\n");
 }
 
+void test_lru_basic()
+{
+    Cache cache;
+    cache_init(&cache, 3);
+
+    // Access 1, 2, 3: Misses
+    assert(!cache_access_lru(&cache, 1, false));
+    assert(!cache_access_lru(&cache, 2, false));
+    assert(!cache_access_lru(&cache, 3, false));
+
+    // Access 1: Hit (updates recency)
+    assert(cache_access_lru(&cache, 1, false));
+
+    // Access 2: Hit (updates recency)
+    assert(cache_access_lru(&cache, 2, false));
+
+    // Access 4: Miss. Recency list: 3 (least recent), 1, 2. So evict 3.
+    assert(!cache_access_lru(&cache, 4, false));
+
+    // 3 should no longer be in the cache
+    bool found_3 = false;
+    for (int i = 0; i < 3; i++)
+    {
+        if (cache.blocks[i].page_id == 3)
+            found_3 = true;
+    }
+    assert(!found_3);
+
+    printf("LRU basic cache tests passed\n");
+}
+
+void test_mru_basic()
+{
+    Cache cache;
+    cache_init(&cache, 3);
+
+    // Access 1, 2, 3: Misses
+    assert(!cache_access_mru(&cache, 1, false));
+    assert(!cache_access_mru(&cache, 2, false));
+    assert(!cache_access_mru(&cache, 3, false));
+
+    // Access 2: Hit (updates recency - 2 becomes most recent)
+    assert(cache_access_mru(&cache, 2, false));
+
+    // Access 4: Miss. Evict most recent (2).
+    assert(!cache_access_mru(&cache, 4, false));
+
+    // 2 should no longer be in the cache
+    bool found_2 = false;
+    for (int i = 0; i < 3; i++)
+    {
+        if (cache.blocks[i].page_id == 2)
+            found_2 = true;
+    }
+    assert(!found_2);
+
+    printf("MRU basic cache tests passed\n");
+}
+
 int main()
 {
     test_fifo_basic();
+    test_lru_basic();
+    test_mru_basic();
     printf("All cache simulator tests passed\n");
     return 0;
 }


### PR DESCRIPTION
# Description
Closes #738 (PR 2 of 7)

### Summary of Changes
- Added access logical clocks (`access_counter`) to the core cache state tracker.
- Implemented `cache_access_lru` and `cache_access_mru` eviction functions inside `src/cache_simulator/cache.c`.
- Integrated LRU and MRU algorithms as choice options inside the interactive demo menu in `src/cache_simulator/cache_demo.c`.
- Implemented `test_lru_basic()` and `test_mru_basic()` unit tests in `tests/cache_simulator/test_cache_simulator.c`.

### Verification
- Formatted source files with `make fmt`.
- Rebuilt project with `make` and ran all unit verification tests successfully via `make test_cache_simulator`.