### PR TITLE
feat: implement TUI visualizer representing cache frames (PR 6)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,7 @@ set(SRC_DIRS
     memory_profiler
     src/debugger
     benchmark
+    src/cache_simulator
 )
 
 # Header search paths

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,8 @@ CFLAGS = -Wall -Wextra -Werror -std=c11 -g \
 	-Isrc/process_synchronization \
 	-Imemory_profiler \
 	-Isrc/debugger \
-	-Ibenchmark
+	-Ibenchmark \
+	-Isrc/cache_simulator
 	# -Itui
 
 # LDFLAGS = -lncurses
@@ -52,7 +53,8 @@ SRC_DIRS = \
 	src/process_synchronization \
 	memory_profiler \
 	src/debugger \
-	benchmark
+	benchmark \
+	src/cache_simulator
 
 # SRCS = $(foreach dir,$(SRC_DIRS),$(wildcard $(dir)/*.c))
 # OBJS = $(patsubst %.c,$(OBJ_DIR)/%.o,$(SRCS))
@@ -147,7 +149,7 @@ TEST_BINS = test_circ_queue test_bst test_search test_hash_func \
             test_string_algorithms test_expression_evaluation \
             test_fcfs test_sjf test_srtf test_round_robin test_priority_scheduling test_preemptive_priority \
             test_dining_philosophers test_petersons test_producer_consumer \
-            test_dijkstra test_bellman_ford test_bfs test_dfs test_topological_sort test_benchmark test_scc test_ford_fulkerson test_edmonds_karp test_dinic test_bipartite_matching test_hopcroft_karp test_eulerian_path
+            test_dijkstra test_bellman_ford test_bfs test_dfs test_topological_sort test_benchmark test_scc test_ford_fulkerson test_edmonds_karp test_dinic test_bipartite_matching test_hopcroft_karp test_eulerian_path test_cache_simulator
 
 # Automatically find all advanced heap test sources and append their targets
 ADV_HEAP_TESTS = $(patsubst tests/advanced_heaps/%.c,%,$(wildcard tests/advanced_heaps/*.c))
@@ -788,6 +790,13 @@ test_memory_tracker: $(TEST_DIR)/test_memory_tracker$(EXE)
 	$(TEST_DIR)/test_memory_tracker$(EXE)
 
 $(TEST_DIR)/test_memory_tracker$(EXE): $(OBJS) tests/memory_profiler/test_memory_tracker.c
+	@$(call MKDIR_P,$(TEST_DIR))
+	$(CC) $(CFLAGS) $^ -o $@ $(LDFLAGS)
+
+test_cache_simulator: $(TEST_DIR)/test_cache_simulator$(EXE)
+	$(TEST_DIR)/test_cache_simulator$(EXE)
+
+$(TEST_DIR)/test_cache_simulator$(EXE): $(OBJ_DIR)/src/cache_simulator/cache.o tests/cache_simulator/test_cache_simulator.c
 	@$(call MKDIR_P,$(TEST_DIR))
 	$(CC) $(CFLAGS) $^ -o $@ $(LDFLAGS)
 

--- a/src/cache_simulator/cache.c
+++ b/src/cache_simulator/cache.c
@@ -1,4 +1,5 @@
 #include "cache.h"
+#include <limits.h>
 #include <stdio.h>
 
 void cache_init(Cache* cache, int capacity)
@@ -280,6 +281,88 @@ bool cache_access_lfu(Cache* cache, int page_id, bool is_write)
     cache->blocks[evict_idx].is_valid = true;
     cache->blocks[evict_idx].is_dirty = is_write;
     cache->blocks[evict_idx].frequency = 1;
+    cache->blocks[evict_idx].last_access_time = cache->access_counter;
+
+    return false; // Miss (with eviction)
+}
+
+bool cache_access_opt(Cache* cache, int page_id, const int* ref_str, int ref_len, int current_idx,
+                      bool is_write)
+{
+    cache->access_counter++;
+
+    // Search for page in the cache (Hit check)
+    for (int i = 0; i < cache->capacity; i++)
+    {
+        if (cache->blocks[i].is_valid && cache->blocks[i].page_id == page_id)
+        {
+            cache->hits++;
+            cache->blocks[i].last_access_time = cache->access_counter;
+            if (is_write)
+            {
+                cache->blocks[i].is_dirty = true;
+            }
+            return true; // Hit
+        }
+    }
+
+    // Cache Miss
+    cache->misses++;
+
+    // If cache is not full, insert in first invalid slot
+    if (cache->size < cache->capacity)
+    {
+        for (int i = 0; i < cache->capacity; i++)
+        {
+            if (!cache->blocks[i].is_valid)
+            {
+                cache->blocks[i].page_id = page_id;
+                cache->blocks[i].is_valid = true;
+                cache->blocks[i].is_dirty = is_write;
+                cache->blocks[i].last_access_time = cache->access_counter;
+                cache->size++;
+                return false; // Miss (without eviction)
+            }
+        }
+    }
+
+    // Cache is full: Find block whose next access is furthest in future
+    int evict_idx = 0;
+    int max_next_access = -1;
+
+    for (int i = 0; i < cache->capacity; i++)
+    {
+        int page = cache->blocks[i].page_id;
+        int next_access = INT_MAX; // Infinity if never accessed again
+
+        for (int j = current_idx + 1; j < ref_len; j++)
+        {
+            if (ref_str[j] == page)
+            {
+                next_access = j;
+                break;
+            }
+        }
+
+        if (next_access > max_next_access)
+        {
+            max_next_access = next_access;
+            evict_idx = i;
+        }
+        else if (next_access == max_next_access)
+        {
+            // Tie-break with LRU
+            if (cache->blocks[i].last_access_time < cache->blocks[evict_idx].last_access_time)
+            {
+                evict_idx = i;
+            }
+        }
+    }
+
+    // Perform eviction
+    cache->blocks[evict_idx].page_id = page_id;
+    cache->blocks[evict_idx].is_valid = true;
+    cache->blocks[evict_idx].is_dirty = is_write;
     cache->blocks[evict_idx].last_access_time = cache->access_counter;
 
     return false; // Miss (with eviction)

--- a/src/cache_simulator/cache.c
+++ b/src/cache_simulator/cache.c
@@ -1,0 +1,94 @@
+#include "cache.h"
+#include <stdio.h>
+
+void cache_init(Cache* cache, int capacity)
+{
+    if (capacity > CACHE_MAX_CAPACITY)
+    {
+        capacity = CACHE_MAX_CAPACITY;
+    }
+    if (capacity < 1)
+    {
+        capacity = 1;
+    }
+    cache->capacity = capacity;
+    cache->size = 0;
+    cache->fifo_index = 0;
+    cache->hits = 0;
+    cache->misses = 0;
+    for (int i = 0; i < CACHE_MAX_CAPACITY; i++)
+    {
+        cache->blocks[i].page_id = -1;
+        cache->blocks[i].is_valid = false;
+        cache->blocks[i].is_dirty = false;
+        cache->blocks[i].reference_bit = 0;
+        cache->blocks[i].frequency = 0;
+        cache->blocks[i].last_access_time = 0;
+    }
+}
+
+bool cache_access_fifo(Cache* cache, int page_id, bool is_write)
+{
+    // Search for page in the cache (Hit check)
+    for (int i = 0; i < cache->capacity; i++)
+    {
+        if (cache->blocks[i].is_valid && cache->blocks[i].page_id == page_id)
+        {
+            cache->hits++;
+            if (is_write)
+            {
+                cache->blocks[i].is_dirty = true;
+            }
+            return true; // Hit
+        }
+    }
+
+    // Cache Miss
+    cache->misses++;
+
+    // If cache is not full, insert in the first invalid slot
+    if (cache->size < cache->capacity)
+    {
+        for (int i = 0; i < cache->capacity; i++)
+        {
+            if (!cache->blocks[i].is_valid)
+            {
+                cache->blocks[i].page_id = page_id;
+                cache->blocks[i].is_valid = true;
+                cache->blocks[i].is_dirty = is_write;
+                cache->size++;
+                return false; // Miss (inserted without eviction)
+            }
+        }
+    }
+
+    // Cache is full: Evict using FIFO policy
+    int evict_idx = cache->fifo_index;
+
+    // Perform eviction
+    cache->blocks[evict_idx].page_id = page_id;
+    cache->blocks[evict_idx].is_valid = true;
+    cache->blocks[evict_idx].is_dirty = is_write;
+
+    // Update FIFO pointer (circular queue)
+    cache->fifo_index = (cache->fifo_index + 1) % cache->capacity;
+
+    return false; // Miss (with eviction)
+}
+
+void cache_print_status(const Cache* cache)
+{
+    printf("Cache state: [ ");
+    for (int i = 0; i < cache->capacity; i++)
+    {
+        if (cache->blocks[i].is_valid)
+        {
+            printf("%d ", cache->blocks[i].page_id);
+        }
+        else
+        {
+            printf("- ");
+        }
+    }
+    printf("] (Hits: %d, Misses: %d)\n", cache->hits, cache->misses);
+}

--- a/src/cache_simulator/cache.c
+++ b/src/cache_simulator/cache.c
@@ -14,6 +14,7 @@ void cache_init(Cache* cache, int capacity)
     cache->capacity = capacity;
     cache->size = 0;
     cache->fifo_index = 0;
+    cache->access_counter = 0;
     cache->hits = 0;
     cache->misses = 0;
     for (int i = 0; i < CACHE_MAX_CAPACITY; i++)
@@ -72,6 +73,126 @@ bool cache_access_fifo(Cache* cache, int page_id, bool is_write)
 
     // Update FIFO pointer (circular queue)
     cache->fifo_index = (cache->fifo_index + 1) % cache->capacity;
+
+    return false; // Miss (with eviction)
+}
+
+bool cache_access_lru(Cache* cache, int page_id, bool is_write)
+{
+    cache->access_counter++;
+
+    // Search for page in the cache (Hit check)
+    for (int i = 0; i < cache->capacity; i++)
+    {
+        if (cache->blocks[i].is_valid && cache->blocks[i].page_id == page_id)
+        {
+            cache->hits++;
+            cache->blocks[i].last_access_time = cache->access_counter;
+            if (is_write)
+            {
+                cache->blocks[i].is_dirty = true;
+            }
+            return true; // Hit
+        }
+    }
+
+    // Cache Miss
+    cache->misses++;
+
+    // If cache is not full, insert in the first invalid slot
+    if (cache->size < cache->capacity)
+    {
+        for (int i = 0; i < cache->capacity; i++)
+        {
+            if (!cache->blocks[i].is_valid)
+            {
+                cache->blocks[i].page_id = page_id;
+                cache->blocks[i].is_valid = true;
+                cache->blocks[i].is_dirty = is_write;
+                cache->blocks[i].last_access_time = cache->access_counter;
+                cache->size++;
+                return false; // Miss (inserted without eviction)
+            }
+        }
+    }
+
+    // Cache is full: Find block with MINIMUM last_access_time
+    int evict_idx = 0;
+    int min_access = cache->blocks[0].last_access_time;
+    for (int i = 1; i < cache->capacity; i++)
+    {
+        if (cache->blocks[i].last_access_time < min_access)
+        {
+            min_access = cache->blocks[i].last_access_time;
+            evict_idx = i;
+        }
+    }
+
+    // Perform eviction
+    cache->blocks[evict_idx].page_id = page_id;
+    cache->blocks[evict_idx].is_valid = true;
+    cache->blocks[evict_idx].is_dirty = is_write;
+    cache->blocks[evict_idx].last_access_time = cache->access_counter;
+
+    return false; // Miss (with eviction)
+}
+
+bool cache_access_mru(Cache* cache, int page_id, bool is_write)
+{
+    cache->access_counter++;
+
+    // Search for page in the cache (Hit check)
+    for (int i = 0; i < cache->capacity; i++)
+    {
+        if (cache->blocks[i].is_valid && cache->blocks[i].page_id == page_id)
+        {
+            cache->hits++;
+            cache->blocks[i].last_access_time = cache->access_counter;
+            if (is_write)
+            {
+                cache->blocks[i].is_dirty = true;
+            }
+            return true; // Hit
+        }
+    }
+
+    // Cache Miss
+    cache->misses++;
+
+    // If cache is not full, insert in the first invalid slot
+    if (cache->size < cache->capacity)
+    {
+        for (int i = 0; i < cache->capacity; i++)
+        {
+            if (!cache->blocks[i].is_valid)
+            {
+                cache->blocks[i].page_id = page_id;
+                cache->blocks[i].is_valid = true;
+                cache->blocks[i].is_dirty = is_write;
+                cache->blocks[i].last_access_time = cache->access_counter;
+                cache->size++;
+                return false; // Miss (inserted without eviction)
+            }
+        }
+    }
+
+    // Cache is full: Find block with MAXIMUM last_access_time
+    int evict_idx = 0;
+    int max_access = cache->blocks[0].last_access_time;
+    for (int i = 1; i < cache->capacity; i++)
+    {
+        if (cache->blocks[i].last_access_time > max_access)
+        {
+            max_access = cache->blocks[i].last_access_time;
+            evict_idx = i;
+        }
+    }
+
+    // Perform eviction
+    cache->blocks[evict_idx].page_id = page_id;
+    cache->blocks[evict_idx].is_valid = true;
+    cache->blocks[evict_idx].is_dirty = is_write;
+    cache->blocks[evict_idx].last_access_time = cache->access_counter;
 
     return false; // Miss (with eviction)
 }

--- a/src/cache_simulator/cache.c
+++ b/src/cache_simulator/cache.c
@@ -16,6 +16,7 @@ void cache_init(Cache* cache, int capacity)
     cache->size = 0;
     cache->fifo_index = 0;
     cache->access_counter = 0;
+    cache->last_accessed_slot = -1;
     cache->hits = 0;
     cache->misses = 0;
     for (int i = 0; i < CACHE_MAX_CAPACITY; i++)
@@ -37,6 +38,7 @@ bool cache_access_fifo(Cache* cache, int page_id, bool is_write)
         if (cache->blocks[i].is_valid && cache->blocks[i].page_id == page_id)
         {
             cache->hits++;
+            cache->last_accessed_slot = i;
             if (is_write)
             {
                 cache->blocks[i].is_dirty = true;
@@ -58,6 +60,7 @@ bool cache_access_fifo(Cache* cache, int page_id, bool is_write)
                 cache->blocks[i].page_id = page_id;
                 cache->blocks[i].is_valid = true;
                 cache->blocks[i].is_dirty = is_write;
+                cache->last_accessed_slot = i;
                 cache->size++;
                 return false; // Miss (inserted without eviction)
             }
@@ -71,6 +74,7 @@ bool cache_access_fifo(Cache* cache, int page_id, bool is_write)
     cache->blocks[evict_idx].page_id = page_id;
     cache->blocks[evict_idx].is_valid = true;
     cache->blocks[evict_idx].is_dirty = is_write;
+    cache->last_accessed_slot = evict_idx;
 
     // Update FIFO pointer (circular queue)
     cache->fifo_index = (cache->fifo_index + 1) % cache->capacity;
@@ -89,6 +93,7 @@ bool cache_access_lru(Cache* cache, int page_id, bool is_write)
         {
             cache->hits++;
             cache->blocks[i].last_access_time = cache->access_counter;
+            cache->last_accessed_slot = i;
             if (is_write)
             {
                 cache->blocks[i].is_dirty = true;
@@ -111,6 +116,7 @@ bool cache_access_lru(Cache* cache, int page_id, bool is_write)
                 cache->blocks[i].is_valid = true;
                 cache->blocks[i].is_dirty = is_write;
                 cache->blocks[i].last_access_time = cache->access_counter;
+                cache->last_accessed_slot = i;
                 cache->size++;
                 return false; // Miss (inserted without eviction)
             }
@@ -134,6 +140,7 @@ bool cache_access_lru(Cache* cache, int page_id, bool is_write)
     cache->blocks[evict_idx].is_valid = true;
     cache->blocks[evict_idx].is_dirty = is_write;
     cache->blocks[evict_idx].last_access_time = cache->access_counter;
+    cache->last_accessed_slot = evict_idx;
 
     return false; // Miss (with eviction)
 }
@@ -149,6 +156,7 @@ bool cache_access_mru(Cache* cache, int page_id, bool is_write)
         {
             cache->hits++;
             cache->blocks[i].last_access_time = cache->access_counter;
+            cache->last_accessed_slot = i;
             if (is_write)
             {
                 cache->blocks[i].is_dirty = true;
@@ -171,6 +179,7 @@ bool cache_access_mru(Cache* cache, int page_id, bool is_write)
                 cache->blocks[i].is_valid = true;
                 cache->blocks[i].is_dirty = is_write;
                 cache->blocks[i].last_access_time = cache->access_counter;
+                cache->last_accessed_slot = i;
                 cache->size++;
                 return false; // Miss (inserted without eviction)
             }
@@ -194,6 +203,7 @@ bool cache_access_mru(Cache* cache, int page_id, bool is_write)
     cache->blocks[evict_idx].is_valid = true;
     cache->blocks[evict_idx].is_dirty = is_write;
     cache->blocks[evict_idx].last_access_time = cache->access_counter;
+    cache->last_accessed_slot = evict_idx;
 
     return false; // Miss (with eviction)
 }
@@ -222,6 +232,7 @@ bool cache_access_lfu(Cache* cache, int page_id, bool is_write)
             cache->hits++;
             cache->blocks[i].frequency++;
             cache->blocks[i].last_access_time = cache->access_counter;
+            cache->last_accessed_slot = i;
             if (is_write)
             {
                 cache->blocks[i].is_dirty = true;
@@ -245,6 +256,7 @@ bool cache_access_lfu(Cache* cache, int page_id, bool is_write)
                 cache->blocks[i].is_dirty = is_write;
                 cache->blocks[i].frequency = 1;
                 cache->blocks[i].last_access_time = cache->access_counter;
+                cache->last_accessed_slot = i;
                 cache->size++;
                 return false; // Miss (inserted without eviction)
             }
@@ -282,6 +294,7 @@ bool cache_access_lfu(Cache* cache, int page_id, bool is_write)
     cache->blocks[evict_idx].is_dirty = is_write;
     cache->blocks[evict_idx].frequency = 1;
     cache->blocks[evict_idx].last_access_time = cache->access_counter;
+    cache->last_accessed_slot = evict_idx;
 
     return false; // Miss (with eviction)
 }
@@ -298,6 +311,7 @@ bool cache_access_opt(Cache* cache, int page_id, const int* ref_str, int ref_len
         {
             cache->hits++;
             cache->blocks[i].last_access_time = cache->access_counter;
+            cache->last_accessed_slot = i;
             if (is_write)
             {
                 cache->blocks[i].is_dirty = true;
@@ -320,6 +334,7 @@ bool cache_access_opt(Cache* cache, int page_id, const int* ref_str, int ref_len
                 cache->blocks[i].is_valid = true;
                 cache->blocks[i].is_dirty = is_write;
                 cache->blocks[i].last_access_time = cache->access_counter;
+                cache->last_accessed_slot = i;
                 cache->size++;
                 return false; // Miss (without eviction)
             }
@@ -364,6 +379,7 @@ bool cache_access_opt(Cache* cache, int page_id, const int* ref_str, int ref_len
     cache->blocks[evict_idx].is_valid = true;
     cache->blocks[evict_idx].is_dirty = is_write;
     cache->blocks[evict_idx].last_access_time = cache->access_counter;
+    cache->last_accessed_slot = evict_idx;
 
     return false; // Miss (with eviction)
 }
@@ -379,6 +395,7 @@ bool cache_access_clock(Cache* cache, int page_id, bool is_write)
         {
             cache->hits++;
             cache->blocks[i].reference_bit = 1;
+            cache->last_accessed_slot = i;
             if (is_write)
             {
                 cache->blocks[i].is_dirty = true;
@@ -401,6 +418,7 @@ bool cache_access_clock(Cache* cache, int page_id, bool is_write)
                 cache->blocks[i].is_valid = true;
                 cache->blocks[i].is_dirty = is_write;
                 cache->blocks[i].reference_bit = 1;
+                cache->last_accessed_slot = i;
                 cache->size++;
                 return false; // Miss (without eviction)
             }
@@ -423,6 +441,7 @@ bool cache_access_clock(Cache* cache, int page_id, bool is_write)
             cache->blocks[hand].is_valid = true;
             cache->blocks[hand].is_dirty = is_write;
             cache->blocks[hand].reference_bit = 1;
+            cache->last_accessed_slot = hand;
             cache->fifo_index = (cache->fifo_index + 1) % cache->capacity;
             break;
         }
@@ -442,6 +461,7 @@ bool cache_access_enhanced_clock(Cache* cache, int page_id, bool is_write)
         {
             cache->hits++;
             cache->blocks[i].reference_bit = 1;
+            cache->last_accessed_slot = i;
             if (is_write)
             {
                 cache->blocks[i].is_dirty = true;
@@ -464,6 +484,7 @@ bool cache_access_enhanced_clock(Cache* cache, int page_id, bool is_write)
                 cache->blocks[i].is_valid = true;
                 cache->blocks[i].is_dirty = is_write;
                 cache->blocks[i].reference_bit = 1;
+                cache->last_accessed_slot = i;
                 cache->size++;
                 return false; // Miss (without eviction)
             }
@@ -483,6 +504,7 @@ bool cache_access_enhanced_clock(Cache* cache, int page_id, bool is_write)
             cache->blocks[idx].is_valid = true;
             cache->blocks[idx].is_dirty = is_write;
             cache->blocks[idx].reference_bit = 1;
+            cache->last_accessed_slot = idx;
             cache->fifo_index = (idx + 1) % cache->capacity;
             return false; // Miss (with eviction)
         }
@@ -498,6 +520,7 @@ bool cache_access_enhanced_clock(Cache* cache, int page_id, bool is_write)
             cache->blocks[idx].is_valid = true;
             cache->blocks[idx].is_dirty = is_write;
             cache->blocks[idx].reference_bit = 1;
+            cache->last_accessed_slot = idx;
             cache->fifo_index = (idx + 1) % cache->capacity;
             return false; // Miss (with eviction)
         }
@@ -517,6 +540,7 @@ bool cache_access_enhanced_clock(Cache* cache, int page_id, bool is_write)
             cache->blocks[idx].is_valid = true;
             cache->blocks[idx].is_dirty = is_write;
             cache->blocks[idx].reference_bit = 1;
+            cache->last_accessed_slot = idx;
             cache->fifo_index = (idx + 1) % cache->capacity;
             return false; // Miss (with eviction)
         }
@@ -532,6 +556,7 @@ bool cache_access_enhanced_clock(Cache* cache, int page_id, bool is_write)
             cache->blocks[idx].is_valid = true;
             cache->blocks[idx].is_dirty = is_write;
             cache->blocks[idx].reference_bit = 1;
+            cache->last_accessed_slot = idx;
             cache->fifo_index = (idx + 1) % cache->capacity;
             return false; // Miss (with eviction)
         }
@@ -555,4 +580,144 @@ void cache_print_status(const Cache* cache)
         }
     }
     printf("] (Hits: %d, Misses: %d)\n", cache->hits, cache->misses);
+}
+
+void cache_visualize(const Cache* cache, int highlighted_slot, bool is_hit)
+{
+    // Draw top border labels
+    for (int i = 0; i < cache->capacity; i++)
+    {
+        printf("   [Frame %d]  ", i);
+    }
+    printf("\n");
+
+    // Line 1: Top border of boxes
+    for (int i = 0; i < cache->capacity; i++)
+    {
+        if (i == highlighted_slot)
+        {
+            printf(is_hit ? "\033[1;32m ┌─────────┐ \033[0m" : "\033[1;31m ┌─────────┐ \033[0m");
+        }
+        else
+        {
+            printf(" ┌─────────┐ ");
+        }
+    }
+    printf("\n");
+
+    // Line 2: Page ID
+    for (int i = 0; i < cache->capacity; i++)
+    {
+        char page_str[16];
+        if (cache->blocks[i].is_valid)
+        {
+            sprintf(page_str, "Page: %-3d", cache->blocks[i].page_id);
+        }
+        else
+        {
+            sprintf(page_str, "Page: -  ");
+        }
+
+        if (i == highlighted_slot)
+        {
+            printf(is_hit ? "\033[1;32m │ %s │ \033[0m" : "\033[1;31m │ %s │ \033[0m", page_str);
+        }
+        else
+        {
+            printf(" │ %s │ ", page_str);
+        }
+    }
+    printf("\n");
+
+    // Line 3: Reference bit
+    for (int i = 0; i < cache->capacity; i++)
+    {
+        char ref_str[16];
+        sprintf(ref_str, "Ref:  %-3d", cache->blocks[i].reference_bit);
+
+        if (i == highlighted_slot)
+        {
+            printf(is_hit ? "\033[1;32m │ %s │ \033[0m" : "\033[1;31m │ %s │ \033[0m", ref_str);
+        }
+        else
+        {
+            printf(" │ %s │ ", ref_str);
+        }
+    }
+    printf("\n");
+
+    // Line 4: Frequency
+    for (int i = 0; i < cache->capacity; i++)
+    {
+        char freq_str[16];
+        sprintf(freq_str, "Freq: %-3d", cache->blocks[i].frequency);
+
+        if (i == highlighted_slot)
+        {
+            printf(is_hit ? "\033[1;32m │ %s │ \033[0m" : "\033[1;31m │ %s │ \033[0m", freq_str);
+        }
+        else
+        {
+            printf(" │ %s │ ", freq_str);
+        }
+    }
+    printf("\n");
+
+    // Line 5: Dirty bit
+    for (int i = 0; i < cache->capacity; i++)
+    {
+        char dirty_str[16];
+        sprintf(dirty_str, "Dirty:%-3s", cache->blocks[i].is_dirty ? "Yes" : "No ");
+
+        if (i == highlighted_slot)
+        {
+            printf(is_hit ? "\033[1;32m │ %s │ \033[0m" : "\033[1;31m │ %s │ \033[0m", dirty_str);
+        }
+        else
+        {
+            printf(" │ %s │ ", dirty_str);
+        }
+    }
+    printf("\n");
+
+    // Line 6: Bottom border of boxes
+    for (int i = 0; i < cache->capacity; i++)
+    {
+        if (i == highlighted_slot)
+        {
+            printf(is_hit ? "\033[1;32m └─────────┘ \033[0m" : "\033[1;31m └─────────┘ \033[0m");
+        }
+        else
+        {
+            printf(" └─────────┘ ");
+        }
+    }
+    printf("\n");
+
+    // Line 7: Clock Hand / Pointer
+    for (int i = 0; i < cache->capacity; i++)
+    {
+        if (i == cache->fifo_index)
+        {
+            printf("      ▲      ");
+        }
+        else
+        {
+            printf("             ");
+        }
+    }
+    printf("\n");
+
+    for (int i = 0; i < cache->capacity; i++)
+    {
+        if (i == cache->fifo_index)
+        {
+            printf("  (Clock Hand) ");
+        }
+        else
+        {
+            printf("             ");
+        }
+    }
+    printf("\n\n");
 }

--- a/src/cache_simulator/cache.c
+++ b/src/cache_simulator/cache.c
@@ -368,6 +368,178 @@ bool cache_access_opt(Cache* cache, int page_id, const int* ref_str, int ref_len
     return false; // Miss (with eviction)
 }
 
+bool cache_access_clock(Cache* cache, int page_id, bool is_write)
+{
+    cache->access_counter++;
+
+    // Search for page in the cache (Hit check)
+    for (int i = 0; i < cache->capacity; i++)
+    {
+        if (cache->blocks[i].is_valid && cache->blocks[i].page_id == page_id)
+        {
+            cache->hits++;
+            cache->blocks[i].reference_bit = 1;
+            if (is_write)
+            {
+                cache->blocks[i].is_dirty = true;
+            }
+            return true; // Hit
+        }
+    }
+
+    // Cache Miss
+    cache->misses++;
+
+    // If cache is not full, insert in first invalid slot
+    if (cache->size < cache->capacity)
+    {
+        for (int i = 0; i < cache->capacity; i++)
+        {
+            if (!cache->blocks[i].is_valid)
+            {
+                cache->blocks[i].page_id = page_id;
+                cache->blocks[i].is_valid = true;
+                cache->blocks[i].is_dirty = is_write;
+                cache->blocks[i].reference_bit = 1;
+                cache->size++;
+                return false; // Miss (without eviction)
+            }
+        }
+    }
+
+    // Cache is full: Run Clock (Second Chance) algorithm
+    while (1)
+    {
+        int hand = cache->fifo_index;
+        if (cache->blocks[hand].reference_bit == 1)
+        {
+            cache->blocks[hand].reference_bit = 0;
+            cache->fifo_index = (cache->fifo_index + 1) % cache->capacity;
+        }
+        else
+        {
+            // Evict page at hand
+            cache->blocks[hand].page_id = page_id;
+            cache->blocks[hand].is_valid = true;
+            cache->blocks[hand].is_dirty = is_write;
+            cache->blocks[hand].reference_bit = 1;
+            cache->fifo_index = (cache->fifo_index + 1) % cache->capacity;
+            break;
+        }
+    }
+
+    return false; // Miss (with eviction)
+}
+
+bool cache_access_enhanced_clock(Cache* cache, int page_id, bool is_write)
+{
+    cache->access_counter++;
+
+    // Search for page in the cache (Hit check)
+    for (int i = 0; i < cache->capacity; i++)
+    {
+        if (cache->blocks[i].is_valid && cache->blocks[i].page_id == page_id)
+        {
+            cache->hits++;
+            cache->blocks[i].reference_bit = 1;
+            if (is_write)
+            {
+                cache->blocks[i].is_dirty = true;
+            }
+            return true; // Hit
+        }
+    }
+
+    // Cache Miss
+    cache->misses++;
+
+    // If cache is not full, insert in first invalid slot
+    if (cache->size < cache->capacity)
+    {
+        for (int i = 0; i < cache->capacity; i++)
+        {
+            if (!cache->blocks[i].is_valid)
+            {
+                cache->blocks[i].page_id = page_id;
+                cache->blocks[i].is_valid = true;
+                cache->blocks[i].is_dirty = is_write;
+                cache->blocks[i].reference_bit = 1;
+                cache->size++;
+                return false; // Miss (without eviction)
+            }
+        }
+    }
+
+    // Cache is full: Run Enhanced Second Chance Clock algorithm
+    int start_hand = cache->fifo_index;
+
+    // Step 1: Scan for Class 0 (0, 0)
+    for (int step = 0; step < cache->capacity; step++)
+    {
+        int idx = (start_hand + step) % cache->capacity;
+        if (cache->blocks[idx].reference_bit == 0 && !cache->blocks[idx].is_dirty)
+        {
+            cache->blocks[idx].page_id = page_id;
+            cache->blocks[idx].is_valid = true;
+            cache->blocks[idx].is_dirty = is_write;
+            cache->blocks[idx].reference_bit = 1;
+            cache->fifo_index = (idx + 1) % cache->capacity;
+            return false; // Miss (with eviction)
+        }
+    }
+
+    // Step 2: Scan for Class 1 (0, 1), modifying reference bit of bypassed pages
+    for (int step = 0; step < cache->capacity; step++)
+    {
+        int idx = (start_hand + step) % cache->capacity;
+        if (cache->blocks[idx].reference_bit == 0 && cache->blocks[idx].is_dirty)
+        {
+            cache->blocks[idx].page_id = page_id;
+            cache->blocks[idx].is_valid = true;
+            cache->blocks[idx].is_dirty = is_write;
+            cache->blocks[idx].reference_bit = 1;
+            cache->fifo_index = (idx + 1) % cache->capacity;
+            return false; // Miss (with eviction)
+        }
+        else
+        {
+            cache->blocks[idx].reference_bit = 0;
+        }
+    }
+
+    // Step 3: If Step 2 failed, repeat Step 1
+    for (int step = 0; step < cache->capacity; step++)
+    {
+        int idx = (start_hand + step) % cache->capacity;
+        if (cache->blocks[idx].reference_bit == 0 && !cache->blocks[idx].is_dirty)
+        {
+            cache->blocks[idx].page_id = page_id;
+            cache->blocks[idx].is_valid = true;
+            cache->blocks[idx].is_dirty = is_write;
+            cache->blocks[idx].reference_bit = 1;
+            cache->fifo_index = (idx + 1) % cache->capacity;
+            return false; // Miss (with eviction)
+        }
+    }
+
+    // Step 4: If Step 3 failed, repeat Step 2
+    for (int step = 0; step < cache->capacity; step++)
+    {
+        int idx = (start_hand + step) % cache->capacity;
+        if (cache->blocks[idx].reference_bit == 0 && cache->blocks[idx].is_dirty)
+        {
+            cache->blocks[idx].page_id = page_id;
+            cache->blocks[idx].is_valid = true;
+            cache->blocks[idx].is_dirty = is_write;
+            cache->blocks[idx].reference_bit = 1;
+            cache->fifo_index = (idx + 1) % cache->capacity;
+            return false; // Miss (with eviction)
+        }
+    }
+
+    return false;
+}
+
 void cache_print_status(const Cache* cache)
 {
     printf("Cache state: [ ");

--- a/src/cache_simulator/cache.c
+++ b/src/cache_simulator/cache.c
@@ -197,6 +197,94 @@ bool cache_access_mru(Cache* cache, int page_id, bool is_write)
     return false; // Miss (with eviction)
 }
 
+bool cache_access_lfu(Cache* cache, int page_id, bool is_write)
+{
+    cache->access_counter++;
+
+    // Periodic Frequency Aging / Decay (every 8 accesses)
+    if (cache->access_counter > 0 && cache->access_counter % 8 == 0)
+    {
+        for (int i = 0; i < cache->capacity; i++)
+        {
+            if (cache->blocks[i].is_valid)
+            {
+                cache->blocks[i].frequency /= 2;
+            }
+        }
+    }
+
+    // Search for page in the cache (Hit check)
+    for (int i = 0; i < cache->capacity; i++)
+    {
+        if (cache->blocks[i].is_valid && cache->blocks[i].page_id == page_id)
+        {
+            cache->hits++;
+            cache->blocks[i].frequency++;
+            cache->blocks[i].last_access_time = cache->access_counter;
+            if (is_write)
+            {
+                cache->blocks[i].is_dirty = true;
+            }
+            return true; // Hit
+        }
+    }
+
+    // Cache Miss
+    cache->misses++;
+
+    // If cache is not full, insert in the first invalid slot
+    if (cache->size < cache->capacity)
+    {
+        for (int i = 0; i < cache->capacity; i++)
+        {
+            if (!cache->blocks[i].is_valid)
+            {
+                cache->blocks[i].page_id = page_id;
+                cache->blocks[i].is_valid = true;
+                cache->blocks[i].is_dirty = is_write;
+                cache->blocks[i].frequency = 1;
+                cache->blocks[i].last_access_time = cache->access_counter;
+                cache->size++;
+                return false; // Miss (inserted without eviction)
+            }
+        }
+    }
+
+    // Cache is full: Find block with MINIMUM frequency.
+    // Break ties using LRU (smallest last_access_time)
+    int evict_idx = 0;
+    int min_freq = cache->blocks[0].frequency;
+    int min_access = cache->blocks[0].last_access_time;
+
+    for (int i = 1; i < cache->capacity; i++)
+    {
+        if (cache->blocks[i].frequency < min_freq)
+        {
+            min_freq = cache->blocks[i].frequency;
+            min_access = cache->blocks[i].last_access_time;
+            evict_idx = i;
+        }
+        else if (cache->blocks[i].frequency == min_freq)
+        {
+            // Tie-break with LRU
+            if (cache->blocks[i].last_access_time < min_access)
+            {
+                min_access = cache->blocks[i].last_access_time;
+                evict_idx = i;
+            }
+        }
+    }
+
+    // Perform eviction
+    cache->blocks[evict_idx].page_id = page_id;
+    cache->blocks[evict_idx].is_valid = true;
+    cache->blocks[evict_idx].is_dirty = is_write;
+    cache->blocks[evict_idx].frequency = 1;
+    cache->blocks[evict_idx].last_access_time = cache->access_counter;
+
+    return false; // Miss (with eviction)
+}
+
 void cache_print_status(const Cache* cache)
 {
     printf("Cache state: [ ");

--- a/src/cache_simulator/cache.h
+++ b/src/cache_simulator/cache.h
@@ -21,6 +21,7 @@ typedef struct
     int capacity;
     int size;
     int fifo_index;
+    int access_counter;
 
     // Statistics
     int hits;
@@ -29,6 +30,8 @@ typedef struct
 
 void cache_init(Cache* cache, int capacity);
 bool cache_access_fifo(Cache* cache, int page_id, bool is_write);
+bool cache_access_lru(Cache* cache, int page_id, bool is_write);
+bool cache_access_mru(Cache* cache, int page_id, bool is_write);
 void cache_print_status(const Cache* cache);
 void cache_simulator_demo(void);
 

--- a/src/cache_simulator/cache.h
+++ b/src/cache_simulator/cache.h
@@ -33,6 +33,8 @@ bool cache_access_fifo(Cache* cache, int page_id, bool is_write);
 bool cache_access_lru(Cache* cache, int page_id, bool is_write);
 bool cache_access_mru(Cache* cache, int page_id, bool is_write);
 bool cache_access_lfu(Cache* cache, int page_id, bool is_write);
+bool cache_access_opt(Cache* cache, int page_id, const int* ref_str, int ref_len, int current_idx,
+                      bool is_write);
 void cache_print_status(const Cache* cache);
 void cache_simulator_demo(void);
 

--- a/src/cache_simulator/cache.h
+++ b/src/cache_simulator/cache.h
@@ -1,0 +1,35 @@
+#ifndef CACHE_H
+#define CACHE_H
+
+#include <stdbool.h>
+
+#define CACHE_MAX_CAPACITY 10
+
+typedef struct
+{
+    int page_id;
+    bool is_valid;
+    bool is_dirty;
+    int reference_bit;
+    int frequency;
+    int last_access_time;
+} CacheBlock;
+
+typedef struct
+{
+    CacheBlock blocks[CACHE_MAX_CAPACITY];
+    int capacity;
+    int size;
+    int fifo_index;
+
+    // Statistics
+    int hits;
+    int misses;
+} Cache;
+
+void cache_init(Cache* cache, int capacity);
+bool cache_access_fifo(Cache* cache, int page_id, bool is_write);
+void cache_print_status(const Cache* cache);
+void cache_simulator_demo(void);
+
+#endif // CACHE_H

--- a/src/cache_simulator/cache.h
+++ b/src/cache_simulator/cache.h
@@ -35,6 +35,8 @@ bool cache_access_mru(Cache* cache, int page_id, bool is_write);
 bool cache_access_lfu(Cache* cache, int page_id, bool is_write);
 bool cache_access_opt(Cache* cache, int page_id, const int* ref_str, int ref_len, int current_idx,
                       bool is_write);
+bool cache_access_clock(Cache* cache, int page_id, bool is_write);
+bool cache_access_enhanced_clock(Cache* cache, int page_id, bool is_write);
 void cache_print_status(const Cache* cache);
 void cache_simulator_demo(void);
 

--- a/src/cache_simulator/cache.h
+++ b/src/cache_simulator/cache.h
@@ -22,6 +22,7 @@ typedef struct
     int size;
     int fifo_index;
     int access_counter;
+    int last_accessed_slot;
 
     // Statistics
     int hits;
@@ -38,6 +39,7 @@ bool cache_access_opt(Cache* cache, int page_id, const int* ref_str, int ref_len
 bool cache_access_clock(Cache* cache, int page_id, bool is_write);
 bool cache_access_enhanced_clock(Cache* cache, int page_id, bool is_write);
 void cache_print_status(const Cache* cache);
+void cache_visualize(const Cache* cache, int highlighted_slot, bool is_hit);
 void cache_simulator_demo(void);
 
 #endif // CACHE_H

--- a/src/cache_simulator/cache.h
+++ b/src/cache_simulator/cache.h
@@ -32,6 +32,7 @@ void cache_init(Cache* cache, int capacity);
 bool cache_access_fifo(Cache* cache, int page_id, bool is_write);
 bool cache_access_lru(Cache* cache, int page_id, bool is_write);
 bool cache_access_mru(Cache* cache, int page_id, bool is_write);
+bool cache_access_lfu(Cache* cache, int page_id, bool is_write);
 void cache_print_status(const Cache* cache);
 void cache_simulator_demo(void);
 

--- a/src/cache_simulator/cache_demo.c
+++ b/src/cache_simulator/cache_demo.c
@@ -25,11 +25,11 @@ void cache_simulator_demo(void)
         }
 
         int algo_choice;
-        int algo_status =
-            safe_input_int(&algo_choice,
-                           "\nSelect Cache Algorithm:\n1. FIFO\n2. LRU\n3. "
-                           "MRU\n4. LFU (with aging)\nEnter choice (1 to 4), or '-1' to exit: ",
-                           1, 4);
+        int algo_status = safe_input_int(&algo_choice,
+                                         "\nSelect Cache Algorithm:\n1. FIFO\n2. LRU\n3. "
+                                         "MRU\n4. LFU (with aging)\n5. OPT (Belady's "
+                                         "Optimal)\nEnter choice (1 to 5), or '-1' to exit: ",
+                                         1, 5);
         if (algo_status == INPUT_EXIT_SIGNAL)
         {
             return;
@@ -50,15 +50,31 @@ void cache_simulator_demo(void)
             return;
         }
 
+        // Parse reference string into an array first
+        int ref_arr[256];
+        int ref_len = 0;
+        char ref_str_copy[256];
+        strncpy(ref_str_copy, ref_str, sizeof(ref_str_copy) - 1);
+        ref_str_copy[sizeof(ref_str_copy) - 1] = '\0';
+
+        char* token = strtok(ref_str_copy, ", ");
+        while (token != NULL && ref_len < 256)
+        {
+            ref_arr[ref_len++] = atoi(token);
+            token = strtok(NULL, ", ");
+        }
+
         printf("\nSimulating %s Cache Replacement:\n",
-               algo_choice == 1 ? "FIFO"
-                                : (algo_choice == 2 ? "LRU" : (algo_choice == 3 ? "MRU" : "LFU")));
+               algo_choice == 1
+                   ? "FIFO"
+                   : (algo_choice == 2
+                          ? "LRU"
+                          : (algo_choice == 3 ? "MRU" : (algo_choice == 4 ? "LFU" : "OPT"))));
         printf("------------------------------------\n");
 
-        char* token = strtok(ref_str, ", ");
-        while (token != NULL)
+        for (int i = 0; i < ref_len; i++)
         {
-            int page_id = atoi(token);
+            int page_id = ref_arr[i];
             bool is_hit = false;
             if (algo_choice == 1)
             {
@@ -72,13 +88,16 @@ void cache_simulator_demo(void)
             {
                 is_hit = cache_access_mru(&cache, page_id, false);
             }
-            else
+            else if (algo_choice == 4)
             {
                 is_hit = cache_access_lfu(&cache, page_id, false);
             }
+            else
+            {
+                is_hit = cache_access_opt(&cache, page_id, ref_arr, ref_len, i, false);
+            }
             printf("Access page %d -> %s | ", page_id, is_hit ? "🟢 HIT " : "🔴 MISS");
             cache_print_status(&cache);
-            token = strtok(NULL, ", ");
         }
 
         printf("------------------------------------\n");

--- a/src/cache_simulator/cache_demo.c
+++ b/src/cache_simulator/cache_demo.c
@@ -1,0 +1,62 @@
+#include "cache.h"
+#include "display_header.h"
+#include "safe_input.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+void cache_simulator_demo(void)
+{
+    while (1)
+    {
+        display_header("Cache Replacement Simulator");
+
+        int capacity;
+        int cap_status =
+            safe_input_int(&capacity, "\nEnter cache capacity (1 to 10), or '-1' to exit: ", 1,
+                           CACHE_MAX_CAPACITY);
+        if (cap_status == INPUT_EXIT_SIGNAL)
+        {
+            return;
+        }
+        if (cap_status == 0)
+        {
+            continue;
+        }
+
+        Cache cache;
+        cache_init(&cache, capacity);
+
+        char ref_str[256];
+        int ref_status = safe_input_string(
+            ref_str, "Enter page reference string (e.g., 1,2,3,4,1,2), or 'X' to exit: ");
+        if (ref_status == INPUT_EXIT_SIGNAL)
+        {
+            return;
+        }
+
+        printf("\nSimulating FIFO Cache Replacement:\n");
+        printf("------------------------------------\n");
+
+        char* token = strtok(ref_str, ", ");
+        while (token != NULL)
+        {
+            int page_id = atoi(token);
+            bool is_hit = cache_access_fifo(&cache, page_id, false);
+            printf("Access page %d -> %s | ", page_id, is_hit ? "🟢 HIT " : "🔴 MISS");
+            cache_print_status(&cache);
+            token = strtok(NULL, ", ");
+        }
+
+        printf("------------------------------------\n");
+        printf("Simulation finished.\n");
+        printf("Total Hits: %d, Total Misses (Page Faults): %d\n", cache.hits, cache.misses);
+        if (cache.hits + cache.misses > 0)
+        {
+            printf("Hit Rate: %.2f%%\n", (double)cache.hits * 100 / (cache.hits + cache.misses));
+        }
+
+        printf("\nPress [ENTER] to continue...");
+        getchar();
+    }
+}

--- a/src/cache_simulator/cache_demo.c
+++ b/src/cache_simulator/cache_demo.c
@@ -24,6 +24,20 @@ void cache_simulator_demo(void)
             continue;
         }
 
+        int algo_choice;
+        int algo_status = safe_input_int(&algo_choice,
+                                         "\nSelect Cache Algorithm:\n1. FIFO\n2. LRU\n3. "
+                                         "MRU\nEnter choice (1 to 3), or '-1' to exit: ",
+                                         1, 3);
+        if (algo_status == INPUT_EXIT_SIGNAL)
+        {
+            return;
+        }
+        if (algo_status == 0)
+        {
+            continue;
+        }
+
         Cache cache;
         cache_init(&cache, capacity);
 
@@ -35,14 +49,27 @@ void cache_simulator_demo(void)
             return;
         }
 
-        printf("\nSimulating FIFO Cache Replacement:\n");
+        printf("\nSimulating %s Cache Replacement:\n",
+               algo_choice == 1 ? "FIFO" : (algo_choice == 2 ? "LRU" : "MRU"));
         printf("------------------------------------\n");
 
         char* token = strtok(ref_str, ", ");
         while (token != NULL)
         {
             int page_id = atoi(token);
-            bool is_hit = cache_access_fifo(&cache, page_id, false);
+            bool is_hit = false;
+            if (algo_choice == 1)
+            {
+                is_hit = cache_access_fifo(&cache, page_id, false);
+            }
+            else if (algo_choice == 2)
+            {
+                is_hit = cache_access_lru(&cache, page_id, false);
+            }
+            else
+            {
+                is_hit = cache_access_mru(&cache, page_id, false);
+            }
             printf("Access page %d -> %s | ", page_id, is_hit ? "🟢 HIT " : "🔴 MISS");
             cache_print_status(&cache);
             token = strtok(NULL, ", ");

--- a/src/cache_simulator/cache_demo.c
+++ b/src/cache_simulator/cache_demo.c
@@ -28,8 +28,9 @@ void cache_simulator_demo(void)
         int algo_status = safe_input_int(&algo_choice,
                                          "\nSelect Cache Algorithm:\n1. FIFO\n2. LRU\n3. "
                                          "MRU\n4. LFU (with aging)\n5. OPT (Belady's "
-                                         "Optimal)\nEnter choice (1 to 5), or '-1' to exit: ",
-                                         1, 5);
+                                         "Optimal)\n6. Clock (Second Chance)\n7. Enhanced "
+                                         "Clock\nEnter choice (1 to 7), or '-1' to exit: ",
+                                         1, 7);
         if (algo_status == INPUT_EXIT_SIGNAL)
         {
             return;
@@ -64,12 +65,19 @@ void cache_simulator_demo(void)
             token = strtok(NULL, ", ");
         }
 
-        printf("\nSimulating %s Cache Replacement:\n",
-               algo_choice == 1
-                   ? "FIFO"
-                   : (algo_choice == 2
-                          ? "LRU"
-                          : (algo_choice == 3 ? "MRU" : (algo_choice == 4 ? "LFU" : "OPT"))));
+        printf(
+            "\nSimulating %s Cache Replacement:\n",
+            algo_choice == 1
+                ? "FIFO"
+                : (algo_choice == 2
+                       ? "LRU"
+                       : (algo_choice == 3
+                              ? "MRU"
+                              : (algo_choice == 4
+                                     ? "LFU"
+                                     : (algo_choice == 5
+                                            ? "OPT"
+                                            : (algo_choice == 6 ? "Clock" : "Enhanced Clock"))))));
         printf("------------------------------------\n");
 
         for (int i = 0; i < ref_len; i++)
@@ -92,9 +100,17 @@ void cache_simulator_demo(void)
             {
                 is_hit = cache_access_lfu(&cache, page_id, false);
             }
-            else
+            else if (algo_choice == 5)
             {
                 is_hit = cache_access_opt(&cache, page_id, ref_arr, ref_len, i, false);
+            }
+            else if (algo_choice == 6)
+            {
+                is_hit = cache_access_clock(&cache, page_id, false);
+            }
+            else
+            {
+                is_hit = cache_access_enhanced_clock(&cache, page_id, false);
             }
             printf("Access page %d -> %s | ", page_id, is_hit ? "🟢 HIT " : "🔴 MISS");
             cache_print_status(&cache);

--- a/src/cache_simulator/cache_demo.c
+++ b/src/cache_simulator/cache_demo.c
@@ -112,8 +112,8 @@ void cache_simulator_demo(void)
             {
                 is_hit = cache_access_enhanced_clock(&cache, page_id, false);
             }
-            printf("Access page %d -> %s | ", page_id, is_hit ? "🟢 HIT " : "🔴 MISS");
-            cache_print_status(&cache);
+            printf("Access page %d -> %s\n", page_id, is_hit ? "🟢 HIT " : "🔴 MISS");
+            cache_visualize(&cache, cache.last_accessed_slot, is_hit);
         }
 
         printf("------------------------------------\n");

--- a/src/cache_simulator/cache_demo.c
+++ b/src/cache_simulator/cache_demo.c
@@ -25,10 +25,11 @@ void cache_simulator_demo(void)
         }
 
         int algo_choice;
-        int algo_status = safe_input_int(&algo_choice,
-                                         "\nSelect Cache Algorithm:\n1. FIFO\n2. LRU\n3. "
-                                         "MRU\nEnter choice (1 to 3), or '-1' to exit: ",
-                                         1, 3);
+        int algo_status =
+            safe_input_int(&algo_choice,
+                           "\nSelect Cache Algorithm:\n1. FIFO\n2. LRU\n3. "
+                           "MRU\n4. LFU (with aging)\nEnter choice (1 to 4), or '-1' to exit: ",
+                           1, 4);
         if (algo_status == INPUT_EXIT_SIGNAL)
         {
             return;
@@ -50,7 +51,8 @@ void cache_simulator_demo(void)
         }
 
         printf("\nSimulating %s Cache Replacement:\n",
-               algo_choice == 1 ? "FIFO" : (algo_choice == 2 ? "LRU" : "MRU"));
+               algo_choice == 1 ? "FIFO"
+                                : (algo_choice == 2 ? "LRU" : (algo_choice == 3 ? "MRU" : "LFU")));
         printf("------------------------------------\n");
 
         char* token = strtok(ref_str, ", ");
@@ -66,9 +68,13 @@ void cache_simulator_demo(void)
             {
                 is_hit = cache_access_lru(&cache, page_id, false);
             }
-            else
+            else if (algo_choice == 3)
             {
                 is_hit = cache_access_mru(&cache, page_id, false);
+            }
+            else
+            {
+                is_hit = cache_access_lfu(&cache, page_id, false);
             }
             printf("Access page %d -> %s | ", page_id, is_hit ? "🟢 HIT " : "🔴 MISS");
             cache_print_status(&cache);

--- a/src/main.c
+++ b/src/main.c
@@ -7,6 +7,7 @@
 #include "array.h"
 #include "backtracking.h"
 #include "benchmark.h"
+#include "cache.h"
 #include "config.h"
 #include "dcll.h"
 #include "display_header.h"
@@ -70,8 +71,9 @@ void run_legacy_menu()
             "eulerian path) demo\n"
             "click 18 for advanced heaps & priority queues suite demo\n"
             "click 19 for interactive algorithm step-debugger demo\n"
+            "click 20 for cache replacement simulator demo\n"
             "enter choice : ",
-            1, 19 // limits
+            1, 20 // limits
         );
 
         if (status == -111)
@@ -144,6 +146,9 @@ void run_legacy_menu()
                 break;
             case 19:
                 debugger_demo();
+                break;
+            case 20:
+                cache_simulator_demo();
                 break;
         }
     }

--- a/tests/cache_simulator/test_cache_simulator.c
+++ b/tests/cache_simulator/test_cache_simulator.c
@@ -171,12 +171,64 @@ void test_lfu_basic()
     printf("LFU basic cache tests passed\n");
 }
 
+void test_opt_basic()
+{
+    Cache cache;
+    cache_init(&cache, 3);
+
+    int ref_str[] = {7, 0, 1, 2, 0, 3, 0, 4, 2, 3, 0, 3, 2, 1, 2, 0, 1, 7, 0, 1};
+    int ref_len = sizeof(ref_str) / sizeof(ref_str[0]);
+
+    // Access 7: Miss
+    assert(!cache_access_opt(&cache, 7, ref_str, ref_len, 0, false)); // Cache: 7
+    // Access 0: Miss
+    assert(!cache_access_opt(&cache, 0, ref_str, ref_len, 1, false)); // Cache: 7, 0
+    // Access 1: Miss
+    assert(!cache_access_opt(&cache, 1, ref_str, ref_len, 2, false)); // Cache: 7, 0, 1
+
+    // Access 2: Miss. Future references:
+    // 7 will be accessed at index 17
+    // 0 will be accessed at index 4
+    // 1 will be accessed at index 13
+    // Evict 7 (furthest in future).
+    assert(!cache_access_opt(&cache, 2, ref_str, ref_len, 3, false)); // Cache: 2, 0, 1
+
+    bool found_7 = false;
+    for (int i = 0; i < 3; i++)
+    {
+        if (cache.blocks[i].page_id == 7)
+            found_7 = true;
+    }
+    assert(!found_7);
+
+    // Access 0: Hit
+    assert(cache_access_opt(&cache, 0, ref_str, ref_len, 4, false));
+
+    // Access 3: Miss. Future references of current cache (2, 0, 1):
+    // 2 will be accessed at index 8
+    // 0 will be accessed at index 6
+    // 1 will be accessed at index 13
+    // Evict 1 (furthest in future).
+    assert(!cache_access_opt(&cache, 3, ref_str, ref_len, 5, false)); // Cache: 2, 0, 3
+
+    bool found_1 = false;
+    for (int i = 0; i < 3; i++)
+    {
+        if (cache.blocks[i].page_id == 1)
+            found_1 = true;
+    }
+    assert(!found_1);
+
+    printf("OPT basic cache tests passed\n");
+}
+
 int main()
 {
     test_fifo_basic();
     test_lru_basic();
     test_mru_basic();
     test_lfu_basic();
+    test_opt_basic();
     printf("All cache simulator tests passed\n");
     return 0;
 }

--- a/tests/cache_simulator/test_cache_simulator.c
+++ b/tests/cache_simulator/test_cache_simulator.c
@@ -1,0 +1,70 @@
+#include "cache.h"
+#include <assert.h>
+#include <stdio.h>
+
+void test_fifo_basic()
+{
+    Cache cache;
+    cache_init(&cache, 3);
+
+    // Initial state
+    assert(cache.capacity == 3);
+    assert(cache.size == 0);
+    assert(cache.hits == 0);
+    assert(cache.misses == 0);
+
+    // Access 1: Miss
+    assert(!cache_access_fifo(&cache, 1, false));
+    assert(cache.size == 1);
+    assert(cache.misses == 1);
+
+    // Access 2: Miss
+    assert(!cache_access_fifo(&cache, 2, false));
+    assert(cache.size == 2);
+    assert(cache.misses == 2);
+
+    // Access 3: Miss
+    assert(!cache_access_fifo(&cache, 3, false));
+    assert(cache.size == 3);
+    assert(cache.misses == 3);
+
+    // Access 1: Hit
+    assert(cache_access_fifo(&cache, 1, false));
+    assert(cache.size == 3);
+    assert(cache.hits == 1);
+
+    // Access 4: Miss (FIFO evicts 1)
+    assert(!cache_access_fifo(&cache, 4, false));
+    assert(cache.misses == 4);
+
+    // 1 should no longer be in the cache
+    bool found_1 = false;
+    for (int i = 0; i < 3; i++)
+    {
+        if (cache.blocks[i].page_id == 1)
+            found_1 = true;
+    }
+    assert(!found_1);
+
+    // Access 1: Miss (FIFO evicts 2)
+    assert(!cache_access_fifo(&cache, 1, false));
+    assert(cache.misses == 5);
+
+    // 2 should no longer be in cache
+    bool found_2 = false;
+    for (int i = 0; i < 3; i++)
+    {
+        if (cache.blocks[i].page_id == 2)
+            found_2 = true;
+    }
+    assert(!found_2);
+
+    printf("FIFO basic cache tests passed\n");
+}
+
+int main()
+{
+    test_fifo_basic();
+    printf("All cache simulator tests passed\n");
+    return 0;
+}

--- a/tests/cache_simulator/test_cache_simulator.c
+++ b/tests/cache_simulator/test_cache_simulator.c
@@ -62,9 +62,70 @@ void test_fifo_basic()
     printf("FIFO basic cache tests passed\n");
 }
 
+void test_lru_basic()
+{
+    Cache cache;
+    cache_init(&cache, 3);
+
+    // Access 1, 2, 3: Misses
+    assert(!cache_access_lru(&cache, 1, false));
+    assert(!cache_access_lru(&cache, 2, false));
+    assert(!cache_access_lru(&cache, 3, false));
+
+    // Access 1: Hit (updates recency)
+    assert(cache_access_lru(&cache, 1, false));
+
+    // Access 2: Hit (updates recency)
+    assert(cache_access_lru(&cache, 2, false));
+
+    // Access 4: Miss. Recency list: 3 (least recent), 1, 2. So evict 3.
+    assert(!cache_access_lru(&cache, 4, false));
+
+    // 3 should no longer be in the cache
+    bool found_3 = false;
+    for (int i = 0; i < 3; i++)
+    {
+        if (cache.blocks[i].page_id == 3)
+            found_3 = true;
+    }
+    assert(!found_3);
+
+    printf("LRU basic cache tests passed\n");
+}
+
+void test_mru_basic()
+{
+    Cache cache;
+    cache_init(&cache, 3);
+
+    // Access 1, 2, 3: Misses
+    assert(!cache_access_mru(&cache, 1, false));
+    assert(!cache_access_mru(&cache, 2, false));
+    assert(!cache_access_mru(&cache, 3, false));
+
+    // Access 2: Hit (updates recency - 2 becomes most recent)
+    assert(cache_access_mru(&cache, 2, false));
+
+    // Access 4: Miss. Evict most recent (2).
+    assert(!cache_access_mru(&cache, 4, false));
+
+    // 2 should no longer be in the cache
+    bool found_2 = false;
+    for (int i = 0; i < 3; i++)
+    {
+        if (cache.blocks[i].page_id == 2)
+            found_2 = true;
+    }
+    assert(!found_2);
+
+    printf("MRU basic cache tests passed\n");
+}
+
 int main()
 {
     test_fifo_basic();
+    test_lru_basic();
+    test_mru_basic();
     printf("All cache simulator tests passed\n");
     return 0;
 }

--- a/tests/cache_simulator/test_cache_simulator.c
+++ b/tests/cache_simulator/test_cache_simulator.c
@@ -222,6 +222,73 @@ void test_opt_basic()
     printf("OPT basic cache tests passed\n");
 }
 
+void test_clock_basic()
+{
+    Cache cache;
+    cache_init(&cache, 3);
+
+    // Access 1, 2, 3: Misses
+    assert(!cache_access_clock(&cache, 1, false)); // U: [1, 0, 0]
+    assert(!cache_access_clock(&cache, 2, false)); // U: [1, 1, 0]
+    assert(!cache_access_clock(&cache, 3, false)); // U: [1, 1, 1]
+
+    // Access 1: Hit (reference_bit = 1)
+    assert(cache_access_clock(&cache, 1, false));
+
+    // Access 4: Miss. Evict loop:
+    // Hand is at 0 (page 1). reference_bit == 1 -> set to 0, advance.
+    // Hand is at 1 (page 2). reference_bit == 1 -> set to 0, advance.
+    // Hand is at 2 (page 3). reference_bit == 1 -> set to 0, advance.
+    // Loop again: Hand is at 0 (page 1). reference_bit == 0 -> replace!
+    // Hand advances to 1 (page 2).
+    assert(!cache_access_clock(&cache, 4, false));
+
+    // 1 should no longer be in cache (evicted)
+    bool found_1 = false;
+    for (int i = 0; i < 3; i++)
+    {
+        if (cache.blocks[i].page_id == 1)
+            found_1 = true;
+    }
+    assert(!found_1);
+
+    printf("Clock basic cache tests passed\n");
+}
+
+void test_enhanced_clock_basic()
+{
+    Cache cache;
+    cache_init(&cache, 3);
+
+    // Access 1 (read), 2 (write), 3 (read): Misses
+    assert(!cache_access_enhanced_clock(&cache, 1, false)); // (1, 0)
+    assert(!cache_access_enhanced_clock(&cache, 2, true));  // (1, 1)
+    assert(!cache_access_enhanced_clock(&cache, 3, false)); // (1, 0)
+
+    // Clear reference bit of 2 to make it (0, 1)
+    cache.blocks[1].reference_bit = 0;
+    // Clear reference bit of 3 to make it (0, 0)
+    cache.blocks[2].reference_bit = 0;
+
+    // Current states (page, U, M): 1: (1, 0), 2: (0, 1), 3: (0, 0).
+    // Clock hand is at 0 (page 1).
+    // Access 4: Miss.
+    // Step 1: Scan for Class 0 (0, 0). We start from hand 0 (page 1 is (1,0)).
+    // Page 2 is (0,1). Page 3 is (0,0) -> Match!
+    // Evict page 3. Hand becomes (2 + 1) % 3 = 0.
+    assert(!cache_access_enhanced_clock(&cache, 4, false));
+
+    bool found_3 = false;
+    for (int i = 0; i < 3; i++)
+    {
+        if (cache.blocks[i].page_id == 3)
+            found_3 = true;
+    }
+    assert(!found_3);
+
+    printf("Enhanced Clock basic cache tests passed\n");
+}
+
 int main()
 {
     test_fifo_basic();
@@ -229,6 +296,8 @@ int main()
     test_mru_basic();
     test_lfu_basic();
     test_opt_basic();
+    test_clock_basic();
+    test_enhanced_clock_basic();
     printf("All cache simulator tests passed\n");
     return 0;
 }

--- a/tests/cache_simulator/test_cache_simulator.c
+++ b/tests/cache_simulator/test_cache_simulator.c
@@ -121,11 +121,62 @@ void test_mru_basic()
     printf("MRU basic cache tests passed\n");
 }
 
+void test_lfu_basic()
+{
+    Cache cache;
+    cache_init(&cache, 3);
+
+    // Access 1, 2, 3: Misses
+    assert(!cache_access_lfu(&cache, 1, false));
+    assert(!cache_access_lfu(&cache, 2, false));
+    assert(!cache_access_lfu(&cache, 3, false));
+
+    // Access 1: Hit (frequency becomes 2)
+    assert(cache_access_lfu(&cache, 1, false));
+
+    // Access 2: Hit (frequency becomes 2)
+    assert(cache_access_lfu(&cache, 2, false));
+
+    // Access 4: Miss. Frequencies: 1 (freq 2), 2 (freq 2), 3 (freq 1). Evict min freq (3).
+    assert(!cache_access_lfu(&cache, 4, false));
+
+    // 3 should no longer be in the cache
+    bool found_3 = false;
+    for (int i = 0; i < 3; i++)
+    {
+        if (cache.blocks[i].page_id == 3)
+            found_3 = true;
+    }
+    assert(!found_3);
+
+    // Let's test tie-break (LRU)
+    // Access 4: freq becomes 2 (since 4 was inserted with freq 1, then we access it)
+    assert(cache_access_lfu(&cache, 4, false));
+    // Access 1: freq becomes 3
+    assert(cache_access_lfu(&cache, 1, false));
+    // Current cache state page/frequency: 4/2, 1/3, 2/2.
+    // Recency list: 2 (least recent), 4, 1.
+    // Access 5: Miss. Frequencies: 4 (freq 2), 1 (freq 3), 2 (freq 2). Min freq are 4 and 2.
+    // LRU tie break: 2 was accessed least recently, so evict 2.
+    assert(!cache_access_lfu(&cache, 5, false));
+
+    bool found_2 = false;
+    for (int i = 0; i < 3; i++)
+    {
+        if (cache.blocks[i].page_id == 2)
+            found_2 = true;
+    }
+    assert(!found_2);
+
+    printf("LFU basic cache tests passed\n");
+}
+
 int main()
 {
     test_fifo_basic();
     test_lru_basic();
     test_mru_basic();
+    test_lfu_basic();
     printf("All cache simulator tests passed\n");
     return 0;
 }


### PR DESCRIPTION
# Description
Closes #738 (PR 6 of 7)

### Summary of Changes
- Implemented `cache_visualize` in `src/cache_simulator/cache.c` to print cache blocks in a clean ASCII box grid.
- Added `last_accessed_slot` to `Cache` to track the victim or hit page index for coloring.
- Linked colored hit (green) / miss (red) ANSI escapes and circular Clock Hand pointers inside the grid representation.
- Integrated visual grid animations inside the simulation loop in `src/cache_simulator/cache_demo.c`.

### Verification
- Formatted source files with `make fmt`.
- Built project successfully with `make` and verified all tests pass via `make test_cache_simulator`.