### PR TITLE
Refactor: Update ci.yml to use CMake

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,19 +15,31 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install build tools
-        run: sudo apt update && sudo apt install -y build-essential valgrind libncurses-dev clang-format
+        run: sudo apt update && sudo apt install -y build-essential cmake valgrind libncurses-dev clang-format
+
+      - name: Configure project
+        run: cmake -S . -B build
+
+      - name: Build project
+        run: cmake --build build --parallel
 
       - name: Format the code
-        run: make fmt
+        run: cmake --build build --target fmt
 
       - name: Check formatting
         run: git diff --exit-code
         
       - name: Run tests
-        run: make test
+        run: ctest --test-dir build --output-on-failure --verbose
 
       - name: Memory check with valgrind
-        run: make valgrind
+        run: cmake --build build --target valgrind
 
-      - name: Build and test with AddressSanitizer + UBSan
-        run: make asan
+      - name: Configure ASan build
+        run: cmake -S . -B build-asan -DSANITIZE=ON
+      
+      - name: Build ASan
+        run: cmake --build build-asan --parallel
+      
+      - name: Run ASan tests
+        run: ctest --test-dir build-asan --output-on-failure --verbose


### PR DESCRIPTION
## Closes #752 

Replaced the Makefile-based CI workflow with a CMake-based workflow. The CI now configures and builds the project using CMake, runs formatting, executes tests with CTest, performs Valgrind checks, and validates the project with an AddressSanitizer/UBSan build.