### PR TITLE
Fix EOF handling in safe_input_int using fgets

### DIFF
--- a/src/utils/safe_input_int.c
+++ b/src/utils/safe_input_int.c
@@ -21,6 +21,10 @@ int safe_input_int(int* input, const char* prompt, int min_val, int max_val)
         // Read input safely and detect EOF
         if (fgets(buffer, sizeof(buffer), stdin) == NULL)
         {
+            if (feof(stdin))
+            {
+                clearerr(stdin);
+            }
             printf("input ended unexpectedly\n");
             return 0;
         }

--- a/src/utils/safe_input_int.c
+++ b/src/utils/safe_input_int.c
@@ -18,14 +18,15 @@ int safe_input_int(int* input, const char* prompt, int min_val, int max_val)
         }
 
         // Read input as a string safely
-        if (scanf("%99s", buffer) != 1)
+        // Read input safely and detect EOF
+        if (fgets(buffer, sizeof(buffer), stdin) == NULL)
         {
-            goto clear_buffer;
+            printf("input ended unexpectedly\n");
+            return 0;
         }
 
-        // Clear the rest of the line from input buffer
-        while ((c = getchar()) != '\n' && c != EOF)
-            ;
+        // Remove trailing newline, if present
+        buffer[strcspn(buffer, "\n")] = '\0';
 
         // 1. Intercept "help" command
         if (strcmp(buffer, "help") == 0)
@@ -70,14 +71,4 @@ int safe_input_int(int* input, const char* prompt, int min_val, int max_val)
         return 1; // Successful insertion
     }
 
-clear_buffer:
-    while ((c = getchar()) != '\n' && c != EOF)
-        ;
-    if (c == EOF)
-    {
-        clearerr(stdin);
-        printf("input ended unexpectedly\n");
-        return 0;
-    }
-    return 0;
 }

--- a/src/utils/safe_input_int.c
+++ b/src/utils/safe_input_int.c
@@ -17,7 +17,6 @@ int safe_input_int(int* input, const char* prompt, int min_val, int max_val)
             fflush(stdout);
         }
 
-        // Read input as a string safely
         // Read input safely and detect EOF
         if (fgets(buffer, sizeof(buffer), stdin) == NULL)
         {
@@ -74,5 +73,4 @@ int safe_input_int(int* input, const char* prompt, int min_val, int max_val)
         *input = value;
         return 1; // Successful insertion
     }
-
 }


### PR DESCRIPTION
Summary

This PR fixes EOF handling in `safe_input_int()` by replacing `scanf()` with `fgets()` for input reading.

Changes
- Replaced `scanf()` with `fgets()` to detect EOF correctly.
- Removed the obsolete `clear_buffer` logic.
- Trimmed the trailing newline before parsing input.
- Preserved the existing integer parsing and validation flow.

Closes #749