### PR TITLE
fix(dijkstra): add NULL pointer check for heap allocation in init_pq_graph

### DIFF
--- a/src/graph_traversals/dijkstra.c
+++ b/src/graph_traversals/dijkstra.c
@@ -26,6 +26,11 @@ void init_pq_graph(PQ_graph* pq, int initial_capacity)
     pq->size = 0;
     pq->capacity = initial_capacity > 0 ? initial_capacity : 10;
     pq->heap = malloc(pq->capacity * sizeof(PQ_graph_node));
+    if (pq->heap == NULL)
+    {
+        pq->capacity = 0;
+        return;
+    }
 }
 
 void PQ_Destroy(PQ_graph* pq)


### PR DESCRIPTION
# Description
Closes #785

### Summary of Changes
- Added a safety check after allocating `pq->heap` in `init_pq_graph`.
- Prevents segmentation faults under memory exhaustion by resetting `pq->capacity` to `0` and exiting early.

### Verification
- Built the project and ran `./build/test_dijkstra`. All Dijkstra tests passed successfully.