### PR TITLE
fix(kmp): add NULL check for lps allocation in kmp_visualization

### DIFF
--- a/src/string_algorithms/kmp.c
+++ b/src/string_algorithms/kmp.c
@@ -159,6 +159,11 @@ void kmp_visualization(char* text, char* pattern)
     }
 
     int* lps = (int*)malloc(m * sizeof(int));
+    if (lps == NULL)
+    {
+        printf("Error: Memory allocation failed.\n");
+        return;
+    }
     compute_lps_array_visual(pattern, m, lps);
     dynamic_sleep();
 


### PR DESCRIPTION

# Description
Closes #787

### Summary of Changes
- Added a NULL check guard for the `lps` array allocation inside the `kmp_visualization` function.
- Prevents segfaults under memory pressure during interactive KMP visualization runs.

### Verification
- Built the project and ran `./build/test_string_algorithms`. All string algorithms tests passed successfully.