### PR TITLE
refactor(portability): centralize windows console initialization for UTF-8 and ANSI colors (PR 1)

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -199,6 +199,8 @@ void tui_menu()
 
 int main(int argc, char* argv[])
 {
+    init_windows_console();
+
     for (int i = 1; i < argc; i++)
     {
         if (strcmp(argv[i], "--profile") == 0)
@@ -208,11 +210,11 @@ int main(int argc, char* argv[])
         }
     }
 
-#ifdef _WIN32
+    #ifdef _WIN32
     run_legacy_menu();
-#else
+    #else
     tui_menu();
-#endif
+    #endif
 
     return 0;
 }

--- a/src/main.c
+++ b/src/main.c
@@ -210,11 +210,11 @@ int main(int argc, char* argv[])
         }
     }
 
-    #ifdef _WIN32
+#ifdef _WIN32
     run_legacy_menu();
-    #else
+#else
     tui_menu();
-    #endif
+#endif
 
     return 0;
 }

--- a/src/utils/config.c
+++ b/src/utils/config.c
@@ -6,6 +6,10 @@
 
 #ifdef _WIN32
 #include <io.h>
+#include <windows.h>
+#ifndef ENABLE_VIRTUAL_TERMINAL_PROCESSING
+#define ENABLE_VIRTUAL_TERMINAL_PROCESSING 0x0004
+#endif
 #else
 #include <unistd.h>
 #endif
@@ -156,4 +160,22 @@ int is_instant(void)
         return 1;
     }
     return (current_delay_seconds == 0) ? 1 : 0;
+}
+
+void init_windows_console(void)
+{
+#ifdef _WIN32
+    if (!is_terminal_interactive())
+    {
+        return;
+    }
+    HANDLE hOut = GetStdHandle(STD_OUTPUT_HANDLE);
+    DWORD dwMode = 0;
+    if (hOut != INVALID_HANDLE_VALUE && GetConsoleMode(hOut, &dwMode))
+    {
+        dwMode |= ENABLE_VIRTUAL_TERMINAL_PROCESSING;
+        SetConsoleMode(hOut, dwMode);
+    }
+    SetConsoleOutputCP(CP_UTF8);
+#endif
 }

--- a/src/utils/config.h
+++ b/src/utils/config.h
@@ -19,4 +19,7 @@ int is_instant(void);
 // Checks if the output is a terminal
 int is_terminal_interactive(void);
 
+// Centralized Windows console initialization for UTF-8 and ANSI colors
+void init_windows_console(void);
+
 #endif

--- a/src/utils/sorting_visualizer.c
+++ b/src/utils/sorting_visualizer.c
@@ -2,13 +2,6 @@
 #include "config.h"
 #include <stdio.h>
 
-#ifdef _WIN32
-#include <windows.h>
-#ifndef ENABLE_VIRTUAL_TERMINAL_PROCESSING
-#define ENABLE_VIRTUAL_TERMINAL_PROCESSING 0x0004
-#endif
-#endif
-
 void visualize_sort(const int arr[], int n, int active_idx1, int active_idx2, int pivot_idx,
                     const char* status_message)
 {
@@ -16,22 +9,6 @@ void visualize_sort(const int arr[], int n, int active_idx1, int active_idx2, in
     {
         return;
     }
-
-#ifdef _WIN32
-    static int windows_initialized = 0;
-    if (!windows_initialized)
-    {
-        HANDLE hOut = GetStdHandle(STD_OUTPUT_HANDLE);
-        DWORD dwMode = 0;
-        if (hOut != INVALID_HANDLE_VALUE && GetConsoleMode(hOut, &dwMode))
-        {
-            dwMode |= ENABLE_VIRTUAL_TERMINAL_PROCESSING;
-            SetConsoleMode(hOut, dwMode);
-        }
-        SetConsoleOutputCP(CP_UTF8);
-        windows_initialized = 1;
-    }
-#endif
 
     // Find min and max values in the array for dynamic scaling
     int min_val = arr[0];


### PR DESCRIPTION
# Description
Closes #798 (PR 1 of 7)

### Summary of Changes
- Declared and implemented `init_windows_console()` inside `src/utils/config.c`.
- Configured Windows terminal hosts (CMD/PowerShell) to use UTF-8 (`SetConsoleOutputCP(CP_UTF8)`) and enabled ANSI styling (`ENABLE_VIRTUAL_TERMINAL_PROCESSING`) centrally on startup.
- Added call to `init_windows_console()` at the start of `main()` in `src/main.c`.
- Cleaned up duplicate, redundant console setup logic in `sorting_visualizer.c`.

### Verification
- Checked out and successfully compiled locally on macOS.
- Verified that all 71 non-benchmark unit tests pass successfully.