### PR TITLE
refactor(portability): remove unused unistd.h headers and implement Windows backtrace capture (PR 2)

### DIFF
--- a/features/memory_profiler/memory_tracker.c
+++ b/features/memory_profiler/memory_tracker.c
@@ -47,7 +47,8 @@ static void add_block(void* addr, size_t size, const char* file, int line)
 #ifndef _WIN32
     block->backtrace_size = backtrace(block->backtrace_buffer, MAX_BACKTRACE_FRAMES);
 #else
-    block->backtrace_size = CaptureStackBackTrace(1, MAX_BACKTRACE_FRAMES, block->backtrace_buffer, NULL);
+    block->backtrace_size =
+        CaptureStackBackTrace(1, MAX_BACKTRACE_FRAMES, block->backtrace_buffer, NULL);
 #endif
 
     block->next = head;

--- a/features/memory_profiler/memory_tracker.c
+++ b/features/memory_profiler/memory_tracker.c
@@ -7,6 +7,8 @@
 
 #ifndef _WIN32
 #include <execinfo.h>
+#else
+#include <windows.h>
 #endif
 
 #define MAX_BACKTRACE_FRAMES 10
@@ -45,7 +47,7 @@ static void add_block(void* addr, size_t size, const char* file, int line)
 #ifndef _WIN32
     block->backtrace_size = backtrace(block->backtrace_buffer, MAX_BACKTRACE_FRAMES);
 #else
-    block->backtrace_size = 0;
+    block->backtrace_size = CaptureStackBackTrace(1, MAX_BACKTRACE_FRAMES, block->backtrace_buffer, NULL);
 #endif
 
     block->next = head;
@@ -301,6 +303,15 @@ void print_memory_leak_report(void)
                     printf("    %s\n", symbols[j]);
                 }
                 free(symbols);
+            }
+        }
+#else
+        if (curr->backtrace_size > 0)
+        {
+            printf("  Call Stack (Hex Addresses):\n");
+            for (int j = 0; j < curr->backtrace_size; j++)
+            {
+                printf("    [%d] %p\n", j, curr->backtrace_buffer[j]);
             }
         }
 #endif

--- a/src/sorting_algorithms_n2/bubble_sort.c
+++ b/src/sorting_algorithms_n2/bubble_sort.c
@@ -4,7 +4,6 @@
 #include "step_debugger.h"
 #include <stdio.h>
 #include <time.h>
-#include <unistd.h>
 
 void bubble_sort_optimized(int arr[], int length_of_array);
 

--- a/src/sorting_algorithms_n2/insertion_sort.c
+++ b/src/sorting_algorithms_n2/insertion_sort.c
@@ -4,7 +4,6 @@
 #include "step_debugger.h"
 #include <stdio.h>
 #include <time.h>
-#include <unistd.h>
 
 void insertion_sort(int arr[], int length_of_array);
 

--- a/src/sorting_algorithms_n2/selection_sort.c
+++ b/src/sorting_algorithms_n2/selection_sort.c
@@ -4,7 +4,6 @@
 #include "step_debugger.h"
 #include <stdio.h>
 #include <time.h>
-#include <unistd.h>
 
 void selection_sort(int arr[], int length_of_array);
 

--- a/src/sorting_algorithms_n2/shell_sort.c
+++ b/src/sorting_algorithms_n2/shell_sort.c
@@ -3,7 +3,6 @@
 #include "sorting_visualizer.h"
 #include <stdio.h>
 #include <time.h>
-#include <unistd.h>
 
 void shell_sort(int arr[], int length_of_array);
 


### PR DESCRIPTION
# Description
Closes #798 (Combines PR 2 & 3 of 7)

### Summary of Changes
1. **Unused POSIX Header Removal**: Removed unused `#include <unistd.h>` from bubble_sort, insertion_sort, selection_sort, and shell_sort to prevent compilation failures on non-POSIX standard compiler environments like MSVC.
2. **Windows Stack backtraces**: Integrated `<windows.h>` and used `CaptureStackBackTrace` inside `memory_tracker.c` to capture native backtraces during memory profiling.
3. **leak report format**: Implemented Windows-compatible hexadecimal call stack output printing in memory leak reports.

### Verification
- Checked out and successfully compiled locally on macOS.
- Verified that all 71 unit tests pass.