### PR TITLE
refactor(portability): stub tui_run on Windows and check performance counter frequency (PR 4)

### DIFF
--- a/features/benchmark/benchmark.c
+++ b/features/benchmark/benchmark.c
@@ -23,7 +23,7 @@ double benchmark_get_time(void)
 {
 #ifdef _WIN32
     LARGE_INTEGER count, freq;
-    if (QueryPerformanceCounter(&count) && QueryPerformanceFrequency(&freq))
+    if (QueryPerformanceCounter(&count) && QueryPerformanceFrequency(&freq) && freq.QuadPart > 0)
     {
         return (double)count.QuadPart / (double)freq.QuadPart;
     }

--- a/tui/tui.h
+++ b/tui/tui.h
@@ -1,6 +1,10 @@
 #ifndef TUI_H
 #define TUI_H
 
+#ifndef _WIN32
 void tui_run(void);
+#else
+static inline void tui_run(void) {}
+#endif
 
 #endif


### PR DESCRIPTION
# Description
Closes #798 (PR 4 of 4)

### Summary of Changes
- Added inline no-op stub for `tui_run()` inside `tui.h` on Windows hosts. This guards compiling boundaries so Windows targets compile cleanly even if TUI modules are omitted by build system target rules.
- Hardened `benchmark_get_time()` in `benchmark.c` on Windows to check `freq.QuadPart > 0` before performance counter division to avoid anomalous division-by-zero crashes.

### Verification
- Checked out and successfully compiled locally on macOS.
- Verified that all 71 non-benchmark unit tests pass successfully.