### PR TITLE
test(job_scheduling): add test coverage for empty Gantt segments / zero burst times (PR for #719)

### DIFF
--- a/tests/job_scheduling/test_fcfs.c
+++ b/tests/job_scheduling/test_fcfs.c
@@ -102,9 +102,31 @@ void test_fcfs_basic()
     printf("FCFS basic test passed\n");
 }
 
+void test_fcfs_zero_burst()
+{
+    // Initialize input processes
+    g_input_count = 1;
+
+    g_input_procs[0].id = 1;
+    g_input_procs[0].arrival = 0;
+    g_input_procs[0].burst = 0;
+    g_input_procs[0].priority = 0;
+
+    // Run the scheduler demo
+    fcfs_demo();
+
+    // Assert results
+    assert(g_output_count == 1);
+    assert(g_output_procs[0].completion == 0);
+    assert(g_output_procs[0].turnaround == 0);
+    assert(g_output_procs[0].waiting == 0);
+    printf("FCFS zero burst test passed\n");
+}
+
 int main()
 {
     test_fcfs_basic();
+    test_fcfs_zero_burst();
     printf("All FCFS tests passed\n");
     return 0;
 }


### PR DESCRIPTION
# Description
Closes #719

### Summary of Changes
- Added a new unit test `test_fcfs_zero_burst()` in `tests/job_scheduling/test_fcfs.c` that configures a scheduling run where all processes have zero burst times.
- This exercises the recently added guard clause in `js_print_gantt()` (checking if segment count is 0) to guarantee the Gantt chart rendering engine handles empty segments gracefully without segfaulting or regressing.

### Verification
- Formatted with `clang-format`.
- Ran the test suite locally; `test_fcfs` completed and passed successfully.