### PR TITLE
feat: add help intercept to validate_infix_expr and document infix help(PR1)

### DIFF
--- a/help/help.c
+++ b/help/help.c
@@ -19,12 +19,13 @@ void launch_help_page(void)
 
         printf("Select a module to view its help page:\n\n");
         printf("1. Data Structures Help\n");
-        printf("2. Sorting & Searching Help\n");
-        printf("3. Graphs & Trees Help\n");
-        printf("4. Advanced & Specialized Topics Help\n");
-        printf("5. Navigation, Commands & General Info\n");
+        printf("2. Expression Evaluation Help\n");
+        printf("3. Sorting & Searching Help\n");
+        printf("4. Graphs & Trees Help\n");
+        printf("5. Advanced & Specialized Topics Help\n");
+        printf("6. Navigation, Commands & General Info\n");
         int choice;
-        int status = safe_input_int(&choice, "Enter choice (or -1 to exit help): ", 1, 5);
+        int status = safe_input_int(&choice, "Enter choice (or -1 to exit help): ", 1, 6);
 
         if (status == INPUT_EXIT_SIGNAL)
         {
@@ -42,15 +43,18 @@ void launch_help_page(void)
                 help_data_structures_menu();
                 break;
             case 2:
-                help_sorting_searching_menu();
+                help_expression_evaluation_menu();
                 break;
             case 3:
-                help_graphs_trees_menu();
+                help_sorting_searching_menu();
                 break;
             case 4:
-                help_advanced_topics_menu();
+                help_graphs_trees_menu();
                 break;
             case 5:
+                help_advanced_topics_menu();
+                break;
+            case 6:
                 display_header("General Navigation & Commands");
                 printf("DESCRIPTION\n");
                 printf("    The C DSA Interactive Suite is a terminal-based application\n");

--- a/help/help.h
+++ b/help/help.h
@@ -27,4 +27,9 @@ void help_graphs_trees_menu(void);
  */
 void help_advanced_topics_menu(void);
 
+/**
+ * @brief Sub-menu for Expression Evaluation help.
+ */
+void help_expression_evaluation_menu(void);
+
 #endif // HELP_H

--- a/help/help_expression_evaluation.c
+++ b/help/help_expression_evaluation.c
@@ -1,0 +1,47 @@
+#include "help.h"
+#include "display_header.h"
+#include "safe_input.h"
+#include <stdio.h>
+
+void help_expression_evaluation_menu(void)
+{
+    while (1)
+    {
+        display_header("Help - Expression Evaluation");
+
+        printf("Select a sub-topic:\n\n");
+        printf("1. Infix Expression Evaluation\n");
+        int choice;
+        int status = safe_input_int(&choice, "Enter choice (or -1 to go back): ", 1, 1);
+
+        if (status == INPUT_EXIT_SIGNAL)
+        {
+            break;
+        }
+
+        if (status == 0)
+        {
+            continue;
+        }
+
+        switch (choice)
+        {
+            case 1:
+                display_header("Help - Infix Expression Evaluation");
+                printf("INFIX EXPRESSION:\n");
+                printf("    Operators are written in-between operands (e.g., A + B).\n");
+                printf("    Requires operator precedence and parentheses rules to evaluate.\n\n");
+                printf("INFIX TO POSTFIX CONVERSION:\n");
+                printf("    Uses a Stack to store operators and enforce precedence. When parsing:\n");
+                printf("    • Operands are output immediately.\n");
+                printf("    • Left parentheses '(' are pushed onto the Stack.\n");
+                printf("    • Right parentheses ')' pop operators until '(' is encountered.\n");
+                printf("    • Operators pop higher or equal precedence operators from Stack, then push themselves.\n\n");
+                printf("=================================================================\n");
+                printf("Press [ENTER] to return...\n");
+                printf("=================================================================\n");
+                getchar();
+                break;
+        }
+    }
+}

--- a/help/help_expression_evaluation.c
+++ b/help/help_expression_evaluation.c
@@ -1,5 +1,5 @@
-#include "help.h"
 #include "display_header.h"
+#include "help.h"
 #include "safe_input.h"
 #include <stdio.h>
 
@@ -32,11 +32,13 @@ void help_expression_evaluation_menu(void)
                 printf("    Operators are written in-between operands (e.g., A + B).\n");
                 printf("    Requires operator precedence and parentheses rules to evaluate.\n\n");
                 printf("INFIX TO POSTFIX CONVERSION:\n");
-                printf("    Uses a Stack to store operators and enforce precedence. When parsing:\n");
+                printf(
+                    "    Uses a Stack to store operators and enforce precedence. When parsing:\n");
                 printf("    • Operands are output immediately.\n");
                 printf("    • Left parentheses '(' are pushed onto the Stack.\n");
                 printf("    • Right parentheses ')' pop operators until '(' is encountered.\n");
-                printf("    • Operators pop higher or equal precedence operators from Stack, then push themselves.\n\n");
+                printf("    • Operators pop higher or equal precedence operators from Stack, then "
+                       "push themselves.\n\n");
                 printf("=================================================================\n");
                 printf("Press [ENTER] to return...\n");
                 printf("=================================================================\n");

--- a/src/expression_evaluation/safe_input_infix.c
+++ b/src/expression_evaluation/safe_input_infix.c
@@ -1,3 +1,4 @@
+#include "help.h"
 #include "safe_input.h"
 #include "string.h"
 #include <ctype.h>
@@ -8,67 +9,78 @@
 
 int validate_infix_expr(char* buff, size_t size, const char* prompt)
 {
-
-    if (prompt)
+    while (1)
     {
-        printf("%s", prompt);
-        fflush(stdout);
-    }
-    if (!fgets(buff, size, stdin))
-    { // return code 0 represents EOF
-        clearerr(stdin);
-        printf("\ninput ended unexpectedly\n");
-        return 0;
-    }
-    trim_newline(buff);
-    if (buff[0] == 'X' && buff[1] == '\0')
-    { // when user enters 'X'
-        return INPUT_EXIT_SIGNAL;
-    }
-    size_t i = 0;
-    int balance = 0;
-
-    while (buff[i] != '\0')
-    { // main while loop which does the infix expression validation
-        char c = buff[i];
-        if (isalnum((unsigned char)c) || c == '(' || c == ')' || c == '+' || c == '-' || c == '*' ||
-            c == '/')
+        if (prompt)
         {
-            if (c == '(')
-            {
-                balance++;
-                i++;
-                continue;
-            }
-            if (c == ')')
-            {
-                balance--;
-                if (balance < 0)
-                {
-                    printf("\ninvalid: ')' before '('\n");
-                    return 0;
-                }
-                i++;
-                continue;
-            }
+            printf("%s", prompt);
+            fflush(stdout);
         }
-
-        else
-        {
-            printf("\ninvalid character: %c\n", c);
-            printf("\nonly alphanumeric character, parantheses, +,-,*,/ operators are "
-                   "supported.\neg - A+B-C*D/E+(F-G) is a valid"
-                   " infix expression where alphabets can be any alphanumeric character - A,b,1,2 "
-                   "etc");
-
+        if (!fgets(buff, size, stdin))
+        { // return code 0 represents EOF
+            clearerr(stdin);
+            printf("\ninput ended unexpectedly\n");
             return 0;
         }
-        i++;
-    } // end of main while loop which performs validation
-    if (balance != 0)
-    {
-        printf("\ninvalid: '(' without ')'\n");
-        return 0;
+        trim_newline(buff);
+
+        // Intercept help command
+        if (strcmp(buff, "help") == 0)
+        {
+            launch_help_page();
+            continue;
+        }
+
+        if (buff[0] == 'X' && buff[1] == '\0')
+        { // when user enters 'X'
+            return INPUT_EXIT_SIGNAL;
+        }
+        size_t i = 0;
+        int balance = 0;
+
+        while (buff[i] != '\0')
+        { // main while loop which does the infix expression validation
+            char c = buff[i];
+            if (isalnum((unsigned char)c) || c == '(' || c == ')' || c == '+' || c == '-' ||
+                c == '*' || c == '/')
+            {
+                if (c == '(')
+                {
+                    balance++;
+                    i++;
+                    continue;
+                }
+                if (c == ')')
+                {
+                    balance--;
+                    if (balance < 0)
+                    {
+                        printf("\ninvalid: ')' before '('\n");
+                        return 0;
+                    }
+                    i++;
+                    continue;
+                }
+            }
+
+            else
+            {
+                printf("\ninvalid character: %c\n", c);
+                printf(
+                    "\nonly alphanumeric character, parantheses, +,-,*,/ operators are "
+                    "supported.\neg - A+B-C*D/E+(F-G) is a valid"
+                    " infix expression where alphabets can be any alphanumeric character - A,b,1,2 "
+                    "etc");
+
+                return 0;
+            }
+            i++;
+        } // end of main while loop which performs validation
+        if (balance != 0)
+        {
+            printf("\ninvalid: '(' without ')'\n");
+            return 0;
+        }
+        return 1; // return code 1 represents valid string input
     }
-    return 1; // return code 1 represents valid string input
 }


### PR DESCRIPTION
closes #808 

Changes Made
Header Updates: Added declaration of help_expression_evaluation_menu() in help.h
.Router Updates: Added "Expression Evaluation Help" as Option 2 in the main help menu loop in 
help.c and routed it correctly.
Dedicated Help File: Created help_expression_evaluation.c  containing the submenu loop and help text strictly for Infix Expression Evaluation (Postfix documentation is omitted).
Input Validator Interception: Wrapped validate_infix_expr in 
safe_input_infix.c in a while (1) loop to intercept the "help" command and launch the help manual.