### PR TITLE
refactor(memory-safety): standardise allocation checking and cascading cleanups in advanced graph algorithms (PR 1)

### DIFF
--- a/src/advanced_graph_algorithms/bipartite_matching.c
+++ b/src/advanced_graph_algorithms/bipartite_matching.c
@@ -277,6 +277,11 @@ void bipartite_matching_demo(void)
         return;
 
     graph = create_graph(vertices);
+    if (graph == NULL)
+    {
+        printf("\nError: Memory allocation failed for graph.\n");
+        return;
+    }
     int edge_status = safe_input_int(&edges, "Enter number of edges (1-100): ", 1, 100);
     if (edge_status == INPUT_EXIT_SIGNAL)
     {

--- a/src/advanced_graph_algorithms/eulerian_path.c
+++ b/src/advanced_graph_algorithms/eulerian_path.c
@@ -207,6 +207,11 @@ void eulerian_path_demo(void)
         return;
 
     graph = create_graph(vertices);
+    if (graph == NULL)
+    {
+        printf("\nError: Memory allocation failed for graph.\n");
+        return;
+    }
     int edge_status = safe_input_int(&edges, "Enter number of edges (1-100): ", 1, 100);
     if (edge_status == INPUT_EXIT_SIGNAL)
     {

--- a/src/advanced_graph_algorithms/scc.c
+++ b/src/advanced_graph_algorithms/scc.c
@@ -4,8 +4,11 @@
 #include <string.h>
 
 static void tarjan_dfs(Graph* graph, int u, int* disc, int* low, bool* on_stack, stack* st,
-                       int* time, int*** sccs, int** sizes, int* count)
+                       int* time, int*** sccs, int** sizes, int* count, bool* success)
 {
+    if (!*success)
+        return;
+
     disc[u] = low[u] = ++(*time);
     push(st, u);
     on_stack[u] = true;
@@ -16,7 +19,9 @@ static void tarjan_dfs(Graph* graph, int u, int* disc, int* low, bool* on_stack,
         int v = temp->data;
         if (disc[v] == -1)
         {
-            tarjan_dfs(graph, v, disc, low, on_stack, st, time, sccs, sizes, count);
+            tarjan_dfs(graph, v, disc, low, on_stack, st, time, sccs, sizes, count, success);
+            if (!*success)
+                return;
             if (low[v] < low[u])
             {
                 low[u] = low[v];
@@ -46,6 +51,7 @@ static void tarjan_dfs(Graph* graph, int u, int* disc, int* low, bool* on_stack,
             if (new_comp == NULL)
             {
                 free(comp);
+                *success = false;
                 return;
             }
             comp = new_comp;
@@ -57,6 +63,7 @@ static void tarjan_dfs(Graph* graph, int u, int* disc, int* low, bool* on_stack,
         if (new_sccs == NULL)
         {
             free(comp);
+            *success = false;
             return;
         }
         *sccs = new_sccs;
@@ -65,6 +72,7 @@ static void tarjan_dfs(Graph* graph, int u, int* disc, int* low, bool* on_stack,
         if (new_sizes == NULL)
         {
             free(comp);
+            *success = false;
             return;
         }
         *sizes = new_sizes;
@@ -110,12 +118,22 @@ int** find_scc_tarjan(Graph* graph, int* scc_count, int** scc_sizes)
     int** sccs = NULL;
     int* sizes = NULL;
     int count = 0;
+    bool success = true;
 
     for (int i = 0; i < V; i++)
     {
         if (disc[i] == -1)
         {
-            tarjan_dfs(graph, i, disc, low, on_stack, st, &time, &sccs, &sizes, &count);
+            tarjan_dfs(graph, i, disc, low, on_stack, st, &time, &sccs, &sizes, &count, &success);
+            if (!success)
+            {
+                free_scc_result(sccs, sizes, count);
+                destroyStack(st);
+                free(disc);
+                free(low);
+                free(on_stack);
+                return NULL;
+            }
         }
     }
 

--- a/src/advanced_graph_algorithms/scc_visualize.c
+++ b/src/advanced_graph_algorithms/scc_visualize.c
@@ -89,8 +89,11 @@ static void print_graph_state(Graph* graph, int active_node, int* disc, int* low
 }
 
 static void tarjan_dfs_vis(Graph* graph, int u, int* disc, int* low, bool* on_stack, stack* st,
-                           int* time, int*** sccs, int** sizes, int* count)
+                           int* time, int*** sccs, int** sizes, int* count, bool* success)
 {
+    if (!*success)
+        return;
+
     disc[u] = low[u] = ++(*time);
     push(st, u);
     on_stack[u] = true;
@@ -103,7 +106,9 @@ static void tarjan_dfs_vis(Graph* graph, int u, int* disc, int* low, bool* on_st
         int v = temp->data;
         if (disc[v] == -1)
         {
-            tarjan_dfs_vis(graph, v, disc, low, on_stack, st, time, sccs, sizes, count);
+            tarjan_dfs_vis(graph, v, disc, low, on_stack, st, time, sccs, sizes, count, success);
+            if (!*success)
+                return;
             if (low[v] < low[u])
             {
                 low[u] = low[v];
@@ -138,6 +143,7 @@ static void tarjan_dfs_vis(Graph* graph, int u, int* disc, int* low, bool* on_st
             if (new_comp == NULL)
             {
                 free(comp);
+                *success = false;
                 return;
             }
             comp = new_comp;
@@ -153,6 +159,7 @@ static void tarjan_dfs_vis(Graph* graph, int u, int* disc, int* low, bool* on_st
         if (new_sccs == NULL)
         {
             free(comp);
+            *success = false;
             return;
         }
         *sccs = new_sccs;
@@ -161,6 +168,7 @@ static void tarjan_dfs_vis(Graph* graph, int u, int* disc, int* low, bool* on_st
         if (new_sizes == NULL)
         {
             free(comp);
+            *success = false;
             return;
         }
         *sizes = new_sizes;
@@ -175,6 +183,13 @@ static void visualize_tarjan(Graph* graph)
     int* disc = malloc(sizeof(int) * V);
     int* low = malloc(sizeof(int) * V);
     bool* on_stack = malloc(sizeof(bool) * V);
+    if (disc == NULL || low == NULL || on_stack == NULL)
+    {
+        free(disc);
+        free(low);
+        free(on_stack);
+        return;
+    }
     for (int i = 0; i < V; i++)
     {
         disc[i] = -1;
@@ -183,16 +198,34 @@ static void visualize_tarjan(Graph* graph)
     }
 
     stack* st = createStack();
+    if (st == NULL)
+    {
+        free(disc);
+        free(low);
+        free(on_stack);
+        return;
+    }
     int time = 0;
     int** sccs = NULL;
     int* sizes = NULL;
     int count = 0;
+    bool success = true;
 
     for (int i = 0; i < V; i++)
     {
         if (disc[i] == -1)
         {
-            tarjan_dfs_vis(graph, i, disc, low, on_stack, st, &time, &sccs, &sizes, &count);
+            tarjan_dfs_vis(graph, i, disc, low, on_stack, st, &time, &sccs, &sizes, &count,
+                           &success);
+            if (!success)
+            {
+                free_scc_result(sccs, sizes, count);
+                destroyStack(st);
+                free(disc);
+                free(low);
+                free(on_stack);
+                return;
+            }
         }
     }
 


### PR DESCRIPTION
# Description
Closes #806 (Part 1)

### Summary of Changes
- Added memory safety verification checks for graph allocation in `eulerian_path.c` and `bipartite_matching.c`.
- Refactored Tarjan's strongly connected components algorithm in `scc.c` and `scc_visualize.c` to use a `success` state flag, allowing recursive DFS routines to gracefully abort and free all heap resources in case of a `realloc` failure.

### Verification
- Formatted with `clang-format`.
- Verified compilation and test suite run successfully (100% tests passed).