### PR TITLE
refactor(memory-safety): standardise allocation checking and cleanups in compression

### DIFF
--- a/src/compression/huffman.c
+++ b/src/compression/huffman.c
@@ -80,6 +80,14 @@ HuffmanNode* build_huffman_tree(const char* input)
         if (freq[i] > 0)
         {
             HuffmanNode* node = malloc(sizeof(HuffmanNode));
+            if (node == NULL)
+            {
+                for (int j = 0; j < heap.size; j++)
+                {
+                    free(heap.nodes[j]);
+                }
+                return NULL;
+            }
             node->ch = (char)i;
             node->freq = freq[i];
             node->left = NULL;
@@ -98,6 +106,11 @@ HuffmanNode* build_huffman_tree(const char* input)
     {
         HuffmanNode* leaf = heap_pop(&heap);
         HuffmanNode* parent = malloc(sizeof(HuffmanNode));
+        if (parent == NULL)
+        {
+            free(leaf);
+            return NULL;
+        }
         parent->ch = '\0';
         parent->freq = leaf->freq;
         parent->left = leaf;
@@ -111,6 +124,16 @@ HuffmanNode* build_huffman_tree(const char* input)
         HuffmanNode* right = heap_pop(&heap);
 
         HuffmanNode* parent = malloc(sizeof(HuffmanNode));
+        if (parent == NULL)
+        {
+            free_huffman_tree(left);
+            free_huffman_tree(right);
+            for (int j = 0; j < heap.size; j++)
+            {
+                free_huffman_tree(heap.nodes[j]);
+            }
+            return NULL;
+        }
         parent->ch = '\0';
         parent->freq = left->freq + right->freq;
         parent->left = left;


### PR DESCRIPTION
### Description
Standardize memory allocation verification and recovery in compression algorithms (primarily Huffman tree creation) to prevent Null Pointer Dereference crashes and memory leaks under memory pressure.

Closes #806

### Proposed Changes
- **Huffman Tree Builder Memory Safety**:
  - In `build_huffman_tree` within `huffman.c`, added safety verification checks for all `malloc` calls.
  - Added cleanups to free previously allocated nodes in the MinHeap or subtrees recursively if any allocation fails.

### Verification Plan
- Built and ran all compression tests successfully:
  ```bash
  ./test_binaries/test_compression