### PR TITLE
refactor(memory-safety): harden benchmark foundations (PR 1)

### DIFF
--- a/features/benchmark/benchmark_hashing.c
+++ b/features/benchmark/benchmark_hashing.c
@@ -155,12 +155,24 @@ static void run_separate_chaining(const int* keys, int m, int n)
         int val = keys[i];
         int hash_loc = hash_function(val, n);
         HashNode* node = malloc(sizeof(HashNode));
-        if (node)
+        if (!node)
         {
-            node->key = val;
-            node->next = table[hash_loc];
-            table[hash_loc] = node;
+            for (int j = 0; j < n; j++)
+            {
+                HashNode* curr = table[j];
+                while (curr)
+                {
+                    HashNode* temp = curr;
+                    curr = curr->next;
+                    free(temp);
+                }
+            }
+            free(table);
+            return;
         }
+        node->key = val;
+        node->next = table[hash_loc];
+        table[hash_loc] = node;
     }
 
     // Lookup

--- a/features/benchmark/benchmark_trees.c
+++ b/features/benchmark/benchmark_trees.c
@@ -153,18 +153,21 @@ void run_trees_benchmark(int n)
             else if (i == 3) // Trie
             {
                 TrieNode* root = trie_create_node();
-                char buf[32];
-                for (int k = 0; k < n; k++)
+                if (root)
                 {
-                    sprintf(buf, "%d", keys[k]);
-                    trie_insert(root, buf);
+                    char buf[32];
+                    for (int k = 0; k < n; k++)
+                    {
+                        sprintf(buf, "%d", keys[k]);
+                        trie_insert(root, buf);
+                    }
+                    for (int k = 0; k < n; k++)
+                    {
+                        sprintf(buf, "%d", keys[k]);
+                        trie_search(root, buf);
+                    }
+                    trie_free(root);
                 }
-                for (int k = 0; k < n; k++)
-                {
-                    sprintf(buf, "%d", keys[k]);
-                    trie_search(root, buf);
-                }
-                trie_free(root);
             }
             else if (i == 4) // B-Tree
             {


### PR DESCRIPTION
### Description
This PR addresses **PR 1 — Benchmark foundations** under issue #827. It hardens memory allocation-failure paths across the core benchmark suites to prevent NULL dereferences and ensure proper cleanup.

### Changes
- **Trie Benchmark ([benchmark_trees.c](file:///Users/akshatshukla/Downloads/Work/open/C_DSA_interactive_suite.git/features/benchmark/benchmark_trees.c))**: Added validation check for the Trie root node returned by `trie_create_node()` before starting the lookup and insertion operations.
- **Separate Chaining Benchmark ([benchmark_hashing.c](file:///Users/akshatshukla/Downloads/Work/open/C_DSA_interactive_suite.git/features/benchmark/benchmark_hashing.c))**: Added allocation validation for collision chain nodes and implemented a cascading cleanup to free the entire hash table and all existing nodes if a nested node allocation fails.

### Verification
All tests compiled and passed successfully:
- `make test_benchmark_hashing`
- `make test_benchmark_trees`
- `make test`