### PR TITLE
refactor(memory-safety): harden DP benchmarks (PR 2)

### DIFF
--- a/features/benchmark/benchmark_dp.c
+++ b/features/benchmark/benchmark_dp.c
@@ -47,6 +47,13 @@ static int knapsack_dp(int W, const int wt[], const int val[], int n)
     for (int i = 0; i <= n; i++)
     {
         dp[i] = malloc((W + 1) * sizeof(int));
+        if (!dp[i])
+        {
+            for (int j = 0; j < i; j++)
+                free(dp[j]);
+            free(dp);
+            return 0;
+        }
     }
     for (int i = 0; i <= n; i++)
     {
@@ -93,6 +100,13 @@ static int lcs_dp(const char* X, const char* Y, int m, int n)
     for (int i = 0; i <= m; i++)
     {
         dp[i] = malloc((n + 1) * sizeof(int));
+        if (!dp[i])
+        {
+            for (int j = 0; j < i; j++)
+                free(dp[j]);
+            free(dp);
+            return 0;
+        }
     }
     for (int i = 0; i <= m; i++)
     {
@@ -140,6 +154,13 @@ static int mcm_dp(const int p[], int n)
     for (int i = 0; i < n; i++)
     {
         m[i] = calloc(n, sizeof(int));
+        if (!m[i])
+        {
+            for (int j = 0; j < i; j++)
+                free(m[j]);
+            free(m);
+            return 0;
+        }
     }
     for (int l = 2; l < n; l++)
     {


### PR DESCRIPTION
### Description
This PR addresses **PR 2 — DP and compression benchmarks** under issue #827. It hardens memory allocation-failure paths inside dynamic programming benchmarks to ensure nested DP tables validate inner row allocations and clean up properly.

### Changes
- **DP Benchmarks ([benchmark_dp.c](file:///Users/akshatshukla/Downloads/Work/open/C_DSA_interactive_suite.git/features/benchmark/benchmark_dp.c))**: Added validation checks for nested row allocations inside `knapsack_dp`, `lcs_dp`, and `mcm_dp`. On row allocation failure, all previously allocated rows and the main pointer are released, exiting safely and returning `0`.

### Verification
All tests compiled and passed successfully:
- `make test_benchmark_dp`
- `make test`