### PR TITLE
refactor(memory-safety): standardise failure propagation in data structures and demos (PR 3)

### DIFF
--- a/demos/data_structures/dll_demo.c
+++ b/demos/data_structures/dll_demo.c
@@ -70,7 +70,12 @@ start_dll:
             {
                 goto dll_enter_end_value;
             }
-            dll_insertAtBeginning(&head, dll_end_value);
+            int status = dll_insertAtBeginning(&head, dll_end_value);
+            if (status == -1)
+            {
+                printf("\nmalloc allocation failure. try again\n");
+                goto dll_enter_end_value;
+            }
             dll_printlist(head);
         }
         else if (dll_position_choice == 1)
@@ -94,7 +99,12 @@ start_dll:
             {
                 goto dll_enter_start_value;
             }
-            dll_insertAtEnd(&head, dll_start_value);
+            int status = dll_insertAtEnd(&head, dll_start_value);
+            if (status == -1)
+            {
+                printf("\nmalloc allocation failure. try again\n");
+                goto dll_enter_start_value;
+            }
             dll_printlist(head);
         }
         else if (dll_position_choice == 2)

--- a/src/data_structures/stack.c
+++ b/src/data_structures/stack.c
@@ -5,7 +5,7 @@
 
 int push(stack* s, int value)
 {
-    if (sll_insertAtBeginning(&(s->top), value))
+    if (sll_insertAtBeginning(&(s->top), value) == 1)
     {
         return 1;
     }


### PR DESCRIPTION
### Description
This PR addresses **PR 3 — Data structures and demos** under issue #827. It hardens failure checking and propagation in `stack.c` and `dll_demo.c` to prevent silent failures and properly handle allocation errors.

### Changes
- **Stack ([stack.c](file:///Users/akshatshukla/Downloads/Work/open/C_DSA_interactive_suite.git/src/data_structures/stack.c))**: Fixed the check for `sll_insertAtBeginning` return value in `push()`. Previously, it checked it simply as a truthy value (`if (sll_insertAtBeginning(...))`), which meant `-1` (failure return value) was incorrectly treated as truthy/success. Modified it to verify `== 1` for success.
- **DLL Demo ([dll_demo.c](file:///Users/akshatshukla/Downloads/Work/open/C_DSA_interactive_suite.git/demos/data_structures/dll_demo.c))**: Checked the returns of `dll_insertAtBeginning` and `dll_insertAtEnd` for allocation failure (`== -1`) and printed a warning message if it occurs.

### Verification
All tests compiled and passed successfully:
- `make test_stack`
- `make test`