### PR TITLE
bugfix(test): resolve animation time delay in make test (Issue #830)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 CC = gcc
 
+export DSA_TEST_MODE=1
+
 OBJ_DIR = object_files
 TEST_DIR = test_binaries
 

--- a/src/utils/cross_platform_timer.c
+++ b/src/utils/cross_platform_timer.c
@@ -7,8 +7,14 @@
 #include <unistd.h>
 #endif
 
+#include <stdlib.h>
+
 void sleep_seconds(float seconds)
 {
+    if (getenv("DSA_TEST_MODE") != NULL)
+    {
+        return;
+    }
 #ifdef _WIN32
     Sleep(seconds * 1000);
 #else

--- a/src/utils/safe_input_int.c
+++ b/src/utils/safe_input_int.c
@@ -1,12 +1,18 @@
 #include "help.h" // Include our help module header
 #include "safe_input.h"
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 // this function return 1 on successful insertion, 0 on failure (invalid input or EOF or number out
 // of range) and -111 on exit signal ie when user gives input as '-1'
 int safe_input_int(int* input, const char* prompt, int min_val, int max_val)
 {
+    if (getenv("DSA_TEST_MODE") != NULL)
+    {
+        return 0;
+    }
+
     int c;
     char buffer[100]; // Buffer to read raw user input as a string first
 

--- a/src/utils/safe_input_string.c
+++ b/src/utils/safe_input_string.c
@@ -1,10 +1,16 @@
 #include "help.h" // Include our new help module header
 #include "safe_input.h"
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 int safe_input_string(char* buffer, const char* prompt)
 {
+    if (getenv("DSA_TEST_MODE") != NULL)
+    {
+        return 0;
+    }
+
     while (1)
     {
         printf("%s", prompt);


### PR DESCRIPTION
### Description
This PR resolves **Issue #830**. It introduces a centralized way to bypass animation time delays and blockages from interactive `stdin` prompts during the execution of automated test binaries via `make test`.
resolves #830 
### Changes
- **Timer Suppression ([cross_platform_timer.c](file:///Users/akshatshukla/Downloads/Work/open/C_DSA_interactive_suite.git/src/utils/cross_platform_timer.c))**: Updated `sleep_seconds()` to verify if `DSA_TEST_MODE` is present in the environment. If it is, any delay or sleep is bypassed immediately.
- **Bypass Stdin Prompts ([safe_input_int.c](file:///Users/akshatshukla/Downloads/Work/open/C_DSA_interactive_suite.git/src/utils/safe_input_int.c) & [safe_input_string.c](file:///Users/akshatshukla/Downloads/Work/open/C_DSA_interactive_suite.git/src/utils/safe_input_string.c))**: Added check for `DSA_TEST_MODE` to return immediately with `0` (failure/default value), ensuring the test binaries do not block waiting for user keyboard inputs.
- **Build System Integration ([Makefile](file:///Users/akshatshukla/Downloads/Work/open/C_DSA_interactive_suite.git/Makefile))**: Exported `DSA_TEST_MODE=1` globally at the top of the Makefile.

### Verification
All tests run in record speed (taking ~50 seconds instead of hanging/taking minutes) and pass without issues:
- `make test`