### PR TITLE
feature(concurrency): add Animated and Step-by-Step playback to process synchronization (PR 3)

### DIFF
--- a/src/process_synchronization/dining_philosophers.c
+++ b/src/process_synchronization/dining_philosophers.c
@@ -427,6 +427,25 @@ void dining_philosophers_demo(void)
             if (step_status != 1)
                 continue;
 
+            int step_mode = 1; // Default to Animated Playback
+            if (!is_instant())
+            {
+                int mode_choice;
+                int mode_status = safe_input_int(
+                    &mode_choice,
+                    "\nSelect Simulation Playback Mode:\n1. Animated Playback (Automatic)\n2. "
+                    "Step-by-Step (Manual)\nEnter choice (1 or 2), or '-1' to exit: ",
+                    1, 2);
+                if (mode_status == INPUT_EXIT_SIGNAL)
+                {
+                    continue;
+                }
+                if (mode_status == 1)
+                {
+                    step_mode = mode_choice;
+                }
+            }
+
             srand((unsigned int)time(NULL));
 
             for (int s = 0; s < steps; s++)
@@ -478,10 +497,22 @@ void dining_philosophers_demo(void)
                 int p_id = rand() % 5;
                 trigger_philosopher(p_id, strategy, chopsticks, phil_states);
 
-                sleep_seconds(1.2f);
+                if (step_mode == 2)
+                {
+                    printf("\nPress [ENTER] to step to next action...");
+                    int ch;
+                    while ((ch = getchar()) != '\n' && ch != EOF)
+                        ;
+                }
+                else if (!is_instant())
+                {
+                    sleep_seconds(1.2f);
+                }
             }
             printf("\nAuto-simulation finished. Press Enter to continue...");
-            getchar();
+            int ch;
+            while ((ch = getchar()) != '\n' && ch != EOF)
+                ;
         }
         else if (choice == 3)
         {

--- a/src/process_synchronization/petersons_algorithm.c
+++ b/src/process_synchronization/petersons_algorithm.c
@@ -275,6 +275,25 @@ void petersons_algorithm_demo(void)
             if (step_status != 1)
                 continue;
 
+            int step_mode = 1; // Default to Animated Playback
+            if (!is_instant())
+            {
+                int mode_choice;
+                int mode_status = safe_input_int(
+                    &mode_choice,
+                    "\nSelect Simulation Playback Mode:\n1. Animated Playback (Automatic)\n2. "
+                    "Step-by-Step (Manual)\nEnter choice (1 or 2), or '-1' to exit: ",
+                    1, 2);
+                if (mode_status == INPUT_EXIT_SIGNAL)
+                {
+                    continue;
+                }
+                if (mode_status == 1)
+                {
+                    step_mode = mode_choice;
+                }
+            }
+
             srand((unsigned int)time(NULL));
 
             for (int s = 0; s < steps; s++)
@@ -301,10 +320,22 @@ void petersons_algorithm_demo(void)
                 int p_id = rand() % 2;
                 step_process(p_id, flag, &turn, pc);
 
-                sleep_seconds(1.2f);
+                if (step_mode == 2)
+                {
+                    printf("\nPress [ENTER] to step to next action...");
+                    int ch;
+                    while ((ch = getchar()) != '\n' && ch != EOF)
+                        ;
+                }
+                else if (!is_instant())
+                {
+                    sleep_seconds(1.2f);
+                }
             }
             printf("\nAuto-simulation finished. Press Enter to continue...");
-            getchar();
+            int ch;
+            while ((ch = getchar()) != '\n' && ch != EOF)
+                ;
         }
         else if (choice == 4)
         {

--- a/src/process_synchronization/producer_consumer.c
+++ b/src/process_synchronization/producer_consumer.c
@@ -186,6 +186,25 @@ void producer_consumer_demo(void)
             if (step_status != 1)
                 continue;
 
+            int step_mode = 1; // Default to Animated Playback
+            if (!is_instant())
+            {
+                int mode_choice;
+                int mode_status = safe_input_int(
+                    &mode_choice,
+                    "\nSelect Simulation Playback Mode:\n1. Animated Playback (Automatic)\n2. "
+                    "Step-by-Step (Manual)\nEnter choice (1 or 2), or '-1' to exit: ",
+                    1, 2);
+                if (mode_status == INPUT_EXIT_SIGNAL)
+                {
+                    continue;
+                }
+                if (mode_status == 1)
+                {
+                    step_mode = mode_choice;
+                }
+            }
+
             srand((unsigned int)time(NULL));
 
             for (int s = 0; s < steps; s++)
@@ -250,10 +269,22 @@ void producer_consumer_demo(void)
                     }
                 }
 
-                sleep_seconds(1.2f);
+                if (step_mode == 2)
+                {
+                    printf("\nPress [ENTER] to step to next action...");
+                    int ch;
+                    while ((ch = getchar()) != '\n' && ch != EOF)
+                        ;
+                }
+                else if (!is_instant())
+                {
+                    sleep_seconds(1.2f);
+                }
             }
             printf("\nAuto-simulation finished. Press Enter to continue...");
-            getchar();
+            int ch;
+            while ((ch = getchar()) != '\n' && ch != EOF)
+                ;
         }
         else if (choice == 4)
         {


### PR DESCRIPTION
### Description
This PR addresses **PR 3 — Concurrency Stepping Mode** under issue #836. It adds an option for users to toggle between **Animated Playback** and manual **Step-by-Step** mode in the process synchronization simulations.

### Changes
- **Dining Philosophers ([dining_philosophers.c](file:///Users/akshatshukla/Downloads/Work/open/C_DSA_interactive_suite.git/src/process_synchronization/dining_philosophers.c))**: Prompt for simulation mode in the auto-simulation loop, pausing on `ENTER` when step-by-step is selected.
- **Producer Consumer ([producer_consumer.c](file:///Users/akshatshukla/Downloads/Work/open/C_DSA_interactive_suite.git/src/process_synchronization/producer_consumer.c))**: Prompt for simulation mode in the auto-simulation loop, pausing on `ENTER` when step-by-step is selected.
- **Peterson's Algorithm ([petersons_algorithm.c](file:///Users/akshatshukla/Downloads/Work/open/C_DSA_interactive_suite.git/src/process_synchronization/petersons_algorithm.c))**: Prompt for simulation mode in the auto-simulation loop, pausing on `ENTER` when step-by-step is selected.

### Verification
Ran and passed all test binaries successfully:
- `make test`