### PR TITLE
refactor(parser): standardise error handling and validation (PR 4)

### DIFF
--- a/src/expression_evaluation/expression.h
+++ b/src/expression_evaluation/expression.h
@@ -1,6 +1,19 @@
 #ifndef EXPRESSION_H
 #define EXPRESSION_H
 #include "stack.h"
+#include <stddef.h>
+
+typedef enum
+{
+    EXPR_SUCCESS = 0,
+    EXPR_ERROR_EMPTY = -1,
+    EXPR_ERROR_INVALID_CHAR = -2,
+    EXPR_ERROR_UNMATCHED_PARENTHESES = -3,
+    EXPR_ERROR_DIVIDE_BY_ZERO = -4,
+    EXPR_ERROR_STACK_UNDERFLOW = -5,
+    EXPR_ERROR_MALFORMED = -6,
+    EXPR_ERROR_INVALID_OPERATOR = -7
+} ExpressionResult;
 
 void infix_to_postfix_demo(void);
 void postfix_evaluation_demo(void);
@@ -9,5 +22,12 @@ void parantheses_checker_demo(void);
 void infix_to_prefix_demo(void);
 int precedence(char ch);
 int isOperator(char ch);
+
+ExpressionResult check_parantheses(char* s);
+ExpressionResult evaluate_postfix_expr(const char* postfix_expr, int* final_result);
+ExpressionResult infix_to_postfix_convert(const char* infix_expr, char* postfix_expr,
+                                          size_t max_size);
+ExpressionResult infix_to_prefix_convert(const char* infix_expr, char* prefix_expr,
+                                         size_t max_size);
 
 #endif

--- a/src/expression_evaluation/expression.h
+++ b/src/expression_evaluation/expression.h
@@ -3,17 +3,14 @@
 #include "stack.h"
 #include <stddef.h>
 
-typedef enum
-{
-    EXPR_SUCCESS = 0,
-    EXPR_ERROR_EMPTY = -1,
-    EXPR_ERROR_INVALID_CHAR = -2,
-    EXPR_ERROR_UNMATCHED_PARENTHESES = -3,
-    EXPR_ERROR_DIVIDE_BY_ZERO = -4,
-    EXPR_ERROR_STACK_UNDERFLOW = -5,
-    EXPR_ERROR_MALFORMED = -6,
-    EXPR_ERROR_INVALID_OPERATOR = -7
-} ExpressionResult;
+#define EXPR_SUCCESS 0
+#define EXPR_ERROR_EMPTY -1
+#define EXPR_ERROR_INVALID_CHAR -2
+#define EXPR_ERROR_UNMATCHED_PARENTHESES -3
+#define EXPR_ERROR_DIVIDE_BY_ZERO -4
+#define EXPR_ERROR_STACK_UNDERFLOW -5
+#define EXPR_ERROR_MALFORMED -6
+#define EXPR_ERROR_INVALID_OPERATOR -7
 
 void infix_to_postfix_demo(void);
 void postfix_evaluation_demo(void);
@@ -23,11 +20,9 @@ void infix_to_prefix_demo(void);
 int precedence(char ch);
 int isOperator(char ch);
 
-ExpressionResult check_parantheses(char* s);
-ExpressionResult evaluate_postfix_expr(const char* postfix_expr, int* final_result);
-ExpressionResult infix_to_postfix_convert(const char* infix_expr, char* postfix_expr,
-                                          size_t max_size);
-ExpressionResult infix_to_prefix_convert(const char* infix_expr, char* prefix_expr,
-                                         size_t max_size);
+int check_parantheses(char* s);
+int evaluate_postfix_expr(const char* postfix_expr, int* final_result);
+int infix_to_postfix_convert(const char* infix_expr, char* postfix_expr, size_t max_size);
+int infix_to_prefix_convert(const char* infix_expr, char* prefix_expr, size_t max_size);
 
 #endif

--- a/src/expression_evaluation/infix_to_postfix.c
+++ b/src/expression_evaluation/infix_to_postfix.c
@@ -28,16 +28,168 @@ int isOperator(char ch)
     return 0;
 }
 
+ExpressionResult infix_to_postfix_convert(const char* infix_expr, char* postfix_expr,
+                                          size_t max_size)
+{
+    if (infix_expr == NULL || infix_expr[0] == '\0')
+    {
+        return EXPR_ERROR_EMPTY;
+    }
+
+    stack* operators = createStack();
+    int i = 0;
+    int pf_idx = 0;
+    int step = 1;
+    postfix_expr[0] = '\0';
+
+    while (infix_expr[i] != '\0')
+    {
+        if (!is_instant())
+        {
+            clear_screen();
+        }
+        char ch = infix_expr[i];
+        const char* action_msg = NULL;
+        char op;
+        char opbuf[100];
+
+        if (isalnum((unsigned char)ch))
+        {
+            if ((size_t)pf_idx + 1 >= max_size)
+            {
+                destroyStack(operators);
+                return EXPR_ERROR_MALFORMED;
+            }
+            postfix_expr[pf_idx++] = ch;
+            postfix_expr[pf_idx] = '\0';
+
+            snprintf(opbuf, sizeof(opbuf), "Added operand '%c' to postfix expression", ch);
+            action_msg = opbuf;
+        }
+        else if (ch == '(')
+        {
+            push(operators, ch);
+            action_msg = "Pushed '(' onto stack";
+        }
+        else if (ch == ')')
+        {
+            action_msg = "Popped operators until matching '(' was found";
+
+            while (!isEmpty(operators) && peek(operators) != '(')
+            {
+                op = pop(operators);
+                if ((size_t)pf_idx + 1 >= max_size)
+                {
+                    destroyStack(operators);
+                    return EXPR_ERROR_MALFORMED;
+                }
+                postfix_expr[pf_idx++] = op;
+                postfix_expr[pf_idx] = '\0';
+            }
+
+            if (isEmpty(operators))
+            {
+                destroyStack(operators);
+                return EXPR_ERROR_UNMATCHED_PARENTHESES;
+            }
+            pop(operators); // Remove '('
+        }
+        else if (isOperator(ch))
+        {
+            if (isEmpty(operators))
+            {
+                push(operators, ch);
+                snprintf(opbuf, sizeof(opbuf), "Pushed operator '%c' onto stack", ch);
+                action_msg = opbuf;
+            }
+            else if (precedence(ch) > precedence(peek(operators)))
+            {
+                push(operators, ch);
+                snprintf(opbuf, sizeof(opbuf), "Pushed operator '%c' onto stack", ch);
+                action_msg = opbuf;
+            }
+            else if (precedence(ch) <= precedence(peek(operators)))
+            {
+                int prec_lower = precedence(ch);
+
+                while (!isEmpty(operators) && peek(operators) != '(' &&
+                       precedence(peek(operators)) >= prec_lower)
+                {
+                    op = pop(operators);
+                    if ((size_t)pf_idx + 1 >= max_size)
+                    {
+                        destroyStack(operators);
+                        return EXPR_ERROR_MALFORMED;
+                    }
+                    postfix_expr[pf_idx++] = op;
+                    postfix_expr[pf_idx] = '\0';
+                }
+
+                push(operators, ch);
+                snprintf(opbuf, sizeof(opbuf),
+                         "Popped operators with higher/equal precedence, then pushed '%c'", ch);
+                action_msg = opbuf;
+            }
+        }
+        else
+        {
+            destroyStack(operators);
+            return EXPR_ERROR_INVALID_CHAR;
+        }
+
+        printf("\nStep %d\n", step++);
+        printf("Character : %c\n", ch);
+        printf("Action    : %s\n", action_msg ? action_msg : "(none)");
+        printf("Postfix   : %s\n", postfix_expr);
+        printf("Stack     : ");
+        printStack(operators);
+        printf("----------------------------------\n");
+
+        i++;
+        dynamic_sleep();
+    }
+
+    while (!isEmpty(operators))
+    {
+        if (!is_instant())
+        {
+            clear_screen();
+        }
+        char op = pop(operators);
+        if (op == '(')
+        {
+            destroyStack(operators);
+            return EXPR_ERROR_UNMATCHED_PARENTHESES;
+        }
+
+        if ((size_t)pf_idx + 1 >= max_size)
+        {
+            destroyStack(operators);
+            return EXPR_ERROR_MALFORMED;
+        }
+        postfix_expr[pf_idx++] = op;
+        postfix_expr[pf_idx] = '\0';
+
+        printf("\nStep %d\n", step++);
+        printf("Character : End\n");
+        printf("Action    : Popped remaining operator '%c' from stack\n", op);
+        printf("Postfix   : %s\n", postfix_expr);
+        printf("Stack     : ");
+        printStack(operators);
+        printf("----------------------------------\n");
+    }
+
+    destroyStack(operators);
+    return EXPR_SUCCESS;
+}
+
 void infix_to_postfix_demo(void)
 {
     char infix_expr[50];
     char postfix_expr[100];
-    int step;
 
     while (1)
     {
-        stack* operators = createStack();
-
         printf("\nInfix to Postfix Demo\n");
 
         int infix_expr_status =
@@ -47,148 +199,33 @@ void infix_to_postfix_demo(void)
 
         if (infix_expr_status == INPUT_EXIT_SIGNAL)
         {
-            destroyStack(operators);
             printf("\nExiting infix to postfix demo...\n");
             return;
         }
 
         if (infix_expr_status != 1)
         {
-            destroyStack(operators);
             continue;
         }
 
-        int i = 0;
-        int pf_idx = 0;
+        ExpressionResult result =
+            infix_to_postfix_convert(infix_expr, postfix_expr, sizeof(postfix_expr));
 
-        postfix_expr[0] = '\0';
-        step = 1;
-
-        while (infix_expr[i] != '\0')
+        if (result == EXPR_SUCCESS)
         {
-            if (!is_instant())
-            {
-                clear_screen();
-            }
-            char ch = infix_expr[i];
-            const char* action_msg = NULL;
-            char op;
-            char opbuf[100];
-
-            if (isalnum((unsigned char)ch))
-            {
-                postfix_expr[pf_idx++] = ch;
-                postfix_expr[pf_idx] = '\0';
-
-                snprintf(opbuf, sizeof(opbuf), "Added operand '%c' to postfix expression", ch);
-
-                action_msg = opbuf;
-            }
-            else if (ch == '(')
-            {
-                push(operators, ch);
-                action_msg = "Pushed '(' onto stack";
-            }
-            else if (ch == ')')
-            {
-                action_msg = "Popped operators until matching '(' was found";
-
-                while (!isEmpty(operators) && peek(operators) != '(')
-                {
-                    op = pop(operators);
-
-                    postfix_expr[pf_idx++] = op;
-                    postfix_expr[pf_idx] = '\0';
-                }
-
-                pop(operators); // Remove '('
-            }
-            else if (isOperator(ch))
-            {
-                if (isEmpty(operators))
-                {
-                    push(operators, ch);
-
-                    snprintf(opbuf, sizeof(opbuf), "Pushed operator '%c' onto stack", ch);
-
-                    action_msg = opbuf;
-                }
-                else if (precedence(ch) > precedence(peek(operators)))
-                {
-                    push(operators, ch);
-
-                    snprintf(opbuf, sizeof(opbuf), "Pushed operator '%c' onto stack", ch);
-
-                    action_msg = opbuf;
-                }
-                else if (precedence(ch) <= precedence(peek(operators)))
-                {
-                    int prec_lower = precedence(ch);
-
-                    while (!isEmpty(operators) && peek(operators) != '(' &&
-                           precedence(peek(operators)) >= prec_lower)
-                    {
-                        op = pop(operators);
-
-                        postfix_expr[pf_idx++] = op;
-                        postfix_expr[pf_idx] = '\0';
-                    }
-
-                    push(operators, ch);
-
-                    snprintf(opbuf, sizeof(opbuf),
-                             "Popped operators with higher/equal precedence, "
-                             "then pushed '%c'",
-                             ch);
-
-                    action_msg = opbuf;
-                }
-            }
-
-            printf("\nStep %d\n", step++);
-            printf("Character : %c\n", ch);
-            printf("Action    : %s\n", action_msg ? action_msg : "(none)");
-            printf("Postfix   : %s\n", postfix_expr);
-            printf("Stack     : ");
-
-            printStack(operators);
-
-            printf("----------------------------------\n");
-
-            i++;
-            dynamic_sleep();
+            printf("\n==================================\n");
+            printf("Conversion Complete\n");
+            printf("Final Postfix Expression : %s\n", postfix_expr);
+            printf("==================================\n\n");
         }
-
-        while (!isEmpty(operators))
+        else if (result == EXPR_ERROR_UNMATCHED_PARENTHESES)
         {
-            if (!is_instant())
-            {
-                clear_screen();
-            }
-            char op = pop(operators);
-
-            postfix_expr[pf_idx++] = op;
-            postfix_expr[pf_idx] = '\0';
-
-            printf("\nStep %d\n", step++);
-            printf("Character : End\n");
-            printf("Action    : Popped remaining operator '%c' "
-                   "from stack\n",
-                   op);
-            printf("Postfix   : %s\n", postfix_expr);
-            printf("Stack     : ");
-
-            printStack(operators);
-
-            printf("----------------------------------\n");
+            printf("\n[Error] Conversion failed: Unmatched parentheses.\n");
         }
-
-        destroyStack(operators);
-
-        printf("\n==================================\n");
-        printf("Conversion Complete\n");
-        printf("Final Postfix Expression : %s\n", postfix_expr);
-        printf("==================================\n\n");
+        else
+        {
+            printf("\n[Error] Conversion failed: Code %d.\n", result);
+        }
 
         dynamic_sleep();
     }

--- a/src/expression_evaluation/infix_to_postfix.c
+++ b/src/expression_evaluation/infix_to_postfix.c
@@ -28,8 +28,7 @@ int isOperator(char ch)
     return 0;
 }
 
-ExpressionResult infix_to_postfix_convert(const char* infix_expr, char* postfix_expr,
-                                          size_t max_size)
+int infix_to_postfix_convert(const char* infix_expr, char* postfix_expr, size_t max_size)
 {
     if (infix_expr == NULL || infix_expr[0] == '\0')
     {
@@ -208,8 +207,7 @@ void infix_to_postfix_demo(void)
             continue;
         }
 
-        ExpressionResult result =
-            infix_to_postfix_convert(infix_expr, postfix_expr, sizeof(postfix_expr));
+        int result = infix_to_postfix_convert(infix_expr, postfix_expr, sizeof(postfix_expr));
 
         if (result == EXPR_SUCCESS)
         {

--- a/src/expression_evaluation/infix_to_prefix.c
+++ b/src/expression_evaluation/infix_to_prefix.c
@@ -39,22 +39,175 @@ static void swap_parentheses(char* str)
     }
 }
 
+ExpressionResult infix_to_prefix_convert(const char* infix_expr, char* prefix_expr, size_t max_size)
+{
+    if (infix_expr == NULL || infix_expr[0] == '\0')
+    {
+        return EXPR_ERROR_EMPTY;
+    }
+
+    char reversed_expr[50];
+    char postfix_expr[100];
+    stack* operators = createStack();
+
+    int step = 1;
+    postfix_expr[0] = '\0';
+    prefix_expr[0] = '\0';
+
+    if (strlen(infix_expr) >= sizeof(reversed_expr))
+    {
+        destroyStack(operators);
+        return EXPR_ERROR_MALFORMED;
+    }
+
+    strcpy(reversed_expr, infix_expr);
+    reverse_string(reversed_expr);
+    swap_parentheses(reversed_expr);
+
+    dynamic_sleep();
+
+    int i = 0;
+    int pf_idx = 0;
+
+    while (reversed_expr[i] != '\0')
+    {
+        if (!is_instant())
+        {
+            clear_screen();
+        }
+
+        char ch = reversed_expr[i];
+        const char* action_msg = NULL;
+        char opbuf[100];
+
+        if (isalnum((unsigned char)ch))
+        {
+            if ((size_t)pf_idx + 1 >= sizeof(postfix_expr))
+            {
+                destroyStack(operators);
+                return EXPR_ERROR_MALFORMED;
+            }
+            postfix_expr[pf_idx++] = ch;
+            postfix_expr[pf_idx] = '\0';
+
+            snprintf(opbuf, sizeof(opbuf), "Added operand '%c' to postfix expression", ch);
+            action_msg = opbuf;
+        }
+        else if (ch == '(')
+        {
+            push(operators, ch);
+            action_msg = "Pushed '(' onto stack";
+        }
+        else if (ch == ')')
+        {
+            while (!isEmpty(operators) && peek(operators) != '(')
+            {
+                if ((size_t)pf_idx + 1 >= sizeof(postfix_expr))
+                {
+                    destroyStack(operators);
+                    return EXPR_ERROR_MALFORMED;
+                }
+                postfix_expr[pf_idx++] = pop(operators);
+                postfix_expr[pf_idx] = '\0';
+            }
+
+            if (isEmpty(operators))
+            {
+                destroyStack(operators);
+                return EXPR_ERROR_UNMATCHED_PARENTHESES;
+            }
+            pop(operators);
+            action_msg = "Popped operators until matching '('";
+        }
+        else if (isOperator(ch))
+        {
+            while (!isEmpty(operators) && peek(operators) != '(' &&
+                   precedence(peek(operators)) > precedence(ch))
+            {
+                if ((size_t)pf_idx + 1 >= sizeof(postfix_expr))
+                {
+                    destroyStack(operators);
+                    return EXPR_ERROR_MALFORMED;
+                }
+                postfix_expr[pf_idx++] = pop(operators);
+                postfix_expr[pf_idx] = '\0';
+            }
+
+            push(operators, ch);
+            snprintf(opbuf, sizeof(opbuf), "Processed operator '%c'", ch);
+            action_msg = opbuf;
+        }
+        else
+        {
+            destroyStack(operators);
+            return EXPR_ERROR_INVALID_CHAR;
+        }
+
+        printf("\nStep %d\n", step++);
+        printf("Character : %c\n", ch);
+        printf("Action    : %s\n", action_msg);
+        printf("Postfix   : %s\n", postfix_expr);
+        printf("Stack     : ");
+        printStack(operators);
+        printf("----------------------------------\n");
+
+        i++;
+        dynamic_sleep();
+    }
+
+    while (!isEmpty(operators))
+    {
+        if (!is_instant())
+        {
+            clear_screen();
+        }
+
+        char op = pop(operators);
+        if (op == '(')
+        {
+            destroyStack(operators);
+            return EXPR_ERROR_UNMATCHED_PARENTHESES;
+        }
+
+        if ((size_t)pf_idx + 1 >= sizeof(postfix_expr))
+        {
+            destroyStack(operators);
+            return EXPR_ERROR_MALFORMED;
+        }
+        postfix_expr[pf_idx++] = op;
+        postfix_expr[pf_idx] = '\0';
+
+        printf("\nStep %d\n", step++);
+        printf("Character : End\n");
+        printf("Action    : Popped remaining operator '%c' from stack\n", op);
+        printf("Postfix   : %s\n", postfix_expr);
+        printf("Stack     : ");
+        printStack(operators);
+        printf("----------------------------------\n");
+
+        dynamic_sleep();
+    }
+
+    if (strlen(postfix_expr) >= max_size)
+    {
+        destroyStack(operators);
+        return EXPR_ERROR_MALFORMED;
+    }
+
+    strcpy(prefix_expr, postfix_expr);
+    reverse_string(prefix_expr);
+
+    destroyStack(operators);
+    return EXPR_SUCCESS;
+}
+
 void infix_to_prefix_demo(void)
 {
     char infix_expr[50];
-    char reversed_expr[50];
-    char postfix_expr[100];
     char prefix_expr[100];
 
     while (1)
     {
-        stack* operators = createStack();
-
-        int step = 1;
-
-        postfix_expr[0] = '\0';
-        prefix_expr[0] = '\0';
-
         printf("\nInfix to Prefix Demo\n");
 
         int infix_expr_status =
@@ -64,134 +217,34 @@ void infix_to_prefix_demo(void)
 
         if (infix_expr_status == INPUT_EXIT_SIGNAL)
         {
-            destroyStack(operators);
             printf("\nExiting infix to prefix demo...\n");
             return;
         }
 
         if (infix_expr_status != 1)
         {
-            destroyStack(operators);
             continue;
         }
 
-        strcpy(reversed_expr, infix_expr);
+        ExpressionResult result =
+            infix_to_prefix_convert(infix_expr, prefix_expr, sizeof(prefix_expr));
 
-        reverse_string(reversed_expr);
-        swap_parentheses(reversed_expr);
-
-        dynamic_sleep();
-
-        int i = 0;
-        int pf_idx = 0;
-
-        while (reversed_expr[i] != '\0')
+        if (result == EXPR_SUCCESS)
         {
-            if (!is_instant())
-            {
-                clear_screen();
-            }
-
-            char ch = reversed_expr[i];
-            const char* action_msg = NULL;
-            char opbuf[100];
-
-            if (isalnum((unsigned char)ch))
-            {
-                postfix_expr[pf_idx++] = ch;
-                postfix_expr[pf_idx] = '\0';
-
-                snprintf(opbuf, sizeof(opbuf), "Added operand '%c' to postfix expression", ch);
-
-                action_msg = opbuf;
-            }
-            else if (ch == '(')
-            {
-                push(operators, ch);
-                action_msg = "Pushed '(' onto stack";
-            }
-            else if (ch == ')')
-            {
-                while (!isEmpty(operators) && peek(operators) != '(')
-                {
-                    postfix_expr[pf_idx++] = pop(operators);
-                    postfix_expr[pf_idx] = '\0';
-                }
-
-                if (!isEmpty(operators))
-                {
-                    pop(operators);
-                }
-
-                action_msg = "Popped operators until matching '('";
-            }
-            else if (isOperator(ch))
-            {
-                while (!isEmpty(operators) && peek(operators) != '(' &&
-                       precedence(peek(operators)) > precedence(ch))
-                {
-                    postfix_expr[pf_idx++] = pop(operators);
-                    postfix_expr[pf_idx] = '\0';
-                }
-
-                push(operators, ch);
-
-                snprintf(opbuf, sizeof(opbuf), "Processed operator '%c'", ch);
-
-                action_msg = opbuf;
-            }
-
-            printf("\nStep %d\n", step++);
-            printf("Character : %c\n", ch);
-            printf("Action    : %s\n", action_msg);
-            printf("Postfix   : %s\n", postfix_expr);
-            printf("Stack     : ");
-
-            printStack(operators);
-
-            printf("----------------------------------\n");
-
-            i++;
-
-            dynamic_sleep();
+            printf("\n==================================\n");
+            printf("Conversion Complete\n");
+            printf("Final Prefix      : %s\n", prefix_expr);
+            printf("==================================\n\n");
+        }
+        else if (result == EXPR_ERROR_UNMATCHED_PARENTHESES)
+        {
+            printf("\n[Error] Conversion failed: Unmatched parentheses.\n");
+        }
+        else
+        {
+            printf("\n[Error] Conversion failed: Code %d.\n", result);
         }
 
-        while (!isEmpty(operators))
-        {
-            if (!is_instant())
-            {
-                clear_screen();
-            }
-
-            char op = pop(operators);
-
-            postfix_expr[pf_idx++] = op;
-            postfix_expr[pf_idx] = '\0';
-
-            printf("\nStep %d\n", step++);
-            printf("Character : End\n");
-            printf("Action    : Popped remaining operator '%c' from stack\n", op);
-            printf("Postfix   : %s\n", postfix_expr);
-            printf("Stack     : ");
-
-            printStack(operators);
-
-            printf("----------------------------------\n");
-
-            dynamic_sleep();
-        }
-
-        strcpy(prefix_expr, postfix_expr);
-        reverse_string(prefix_expr);
-
-        printf("\n==================================\n");
-        printf("Conversion Complete\n");
-        printf("Intermediate : %s\n", postfix_expr);
-        printf("Final Prefix      : %s\n", prefix_expr);
-        printf("==================================\n\n");
-
         dynamic_sleep();
-
-        destroyStack(operators);
     }
 }

--- a/src/expression_evaluation/infix_to_prefix.c
+++ b/src/expression_evaluation/infix_to_prefix.c
@@ -39,7 +39,7 @@ static void swap_parentheses(char* str)
     }
 }
 
-ExpressionResult infix_to_prefix_convert(const char* infix_expr, char* prefix_expr, size_t max_size)
+int infix_to_prefix_convert(const char* infix_expr, char* prefix_expr, size_t max_size)
 {
     if (infix_expr == NULL || infix_expr[0] == '\0')
     {
@@ -226,8 +226,7 @@ void infix_to_prefix_demo(void)
             continue;
         }
 
-        ExpressionResult result =
-            infix_to_prefix_convert(infix_expr, prefix_expr, sizeof(prefix_expr));
+        int result = infix_to_prefix_convert(infix_expr, prefix_expr, sizeof(prefix_expr));
 
         if (result == EXPR_SUCCESS)
         {

--- a/src/expression_evaluation/parantheses_checker.c
+++ b/src/expression_evaluation/parantheses_checker.c
@@ -7,7 +7,7 @@
 #include <stdio.h>
 #include <string.h>
 
-ExpressionResult check_parantheses(char* s)
+int check_parantheses(char* s)
 {
     int i = 0;
     int step = 1;
@@ -169,7 +169,7 @@ void parantheses_checker_demo(void)
         if (status != 1)
             continue;
 
-        ExpressionResult result = check_parantheses(parantheses_expression);
+        int result = check_parantheses(parantheses_expression);
         printf("\n===================================\n");
         if (result == EXPR_SUCCESS)
             printf("Result  : Valid Expression\n");

--- a/src/expression_evaluation/parantheses_checker.c
+++ b/src/expression_evaluation/parantheses_checker.c
@@ -1,13 +1,13 @@
 #include "../utils/config.h"
 #include "clear_screen.h"
 #include "cross_platform_timer.h"
+#include "expression.h"
 #include "safe_input.h"
 #include "stack.h"
 #include <stdio.h>
-
 #include <string.h>
 
-int check_parantheses(char* s)
+ExpressionResult check_parantheses(char* s)
 {
     int i = 0;
     int step = 1;
@@ -39,7 +39,7 @@ int check_parantheses(char* s)
                 printf("Action  : No matching opening bracket found for '%c'\n", s[i]);
                 printf("Stack   : Empty\n");
                 destroyStack(parantheses);
-                return 0;
+                return EXPR_ERROR_UNMATCHED_PARENTHESES;
             }
             int top = pop(parantheses);
 
@@ -56,7 +56,7 @@ int check_parantheses(char* s)
                         printStack(parantheses);
 
                     destroyStack(parantheses);
-                    return 0;
+                    return EXPR_ERROR_UNMATCHED_PARENTHESES;
                 }
                 printf("Action  : Matched '(' with ')'\n");
             }
@@ -73,7 +73,7 @@ int check_parantheses(char* s)
                         printStack(parantheses);
 
                     destroyStack(parantheses);
-                    return 0;
+                    return EXPR_ERROR_UNMATCHED_PARENTHESES;
                 }
                 printf("Action  : Matched '[' with ']'\n");
             }
@@ -90,7 +90,7 @@ int check_parantheses(char* s)
                         printStack(parantheses);
 
                     destroyStack(parantheses);
-                    return 0;
+                    return EXPR_ERROR_UNMATCHED_PARENTHESES;
                 }
                 printf("Action  : Matched '{' with '}'\n");
             }
@@ -117,7 +117,7 @@ int check_parantheses(char* s)
         printStack(parantheses);
     }
     destroyStack(parantheses);
-    return result;
+    return result ? EXPR_SUCCESS : EXPR_ERROR_UNMATCHED_PARENTHESES;
 }
 int get_validated_input_parantheses(char* buff, size_t size, const char* prompt)
 {
@@ -169,9 +169,9 @@ void parantheses_checker_demo(void)
         if (status != 1)
             continue;
 
-        int result = check_parantheses(parantheses_expression);
+        ExpressionResult result = check_parantheses(parantheses_expression);
         printf("\n===================================\n");
-        if (result)
+        if (result == EXPR_SUCCESS)
             printf("Result  : Valid Expression\n");
         else
             printf("Result  : Invalid Expression\n");

--- a/src/expression_evaluation/postfix_evaluation.c
+++ b/src/expression_evaluation/postfix_evaluation.c
@@ -10,7 +10,7 @@
 // main while loop, it indicates malformed postfix expression and program exits with error code '-1'
 // and on succesful evaluation returns '0' maximum expression length is 50 characters
 
-ExpressionResult evaluate_postfix_expr(const char* postfix_expr, int* final_result)
+int evaluate_postfix_expr(const char* postfix_expr, int* final_result)
 {
     if (postfix_expr == NULL || postfix_expr[0] == '\0')
     {
@@ -167,7 +167,7 @@ void postfix_evaluation_demo(void)
         }
 
         int final_result = 0;
-        ExpressionResult result = evaluate_postfix_expr(postfix_expr, &final_result);
+        int result = evaluate_postfix_expr(postfix_expr, &final_result);
 
         if (result == EXPR_SUCCESS)
         {

--- a/src/expression_evaluation/postfix_evaluation.c
+++ b/src/expression_evaluation/postfix_evaluation.c
@@ -10,13 +10,146 @@
 // main while loop, it indicates malformed postfix expression and program exits with error code '-1'
 // and on succesful evaluation returns '0' maximum expression length is 50 characters
 
+ExpressionResult evaluate_postfix_expr(const char* postfix_expr, int* final_result)
+{
+    if (postfix_expr == NULL || postfix_expr[0] == '\0')
+    {
+        return EXPR_ERROR_EMPTY;
+    }
+
+    stack* operands = createStack();
+    int i = 0;
+    int step = 1;
+    char action_msg[200];
+    int current_result = 0;
+
+    while (postfix_expr[i] != '\0')
+    {
+        if (!is_instant())
+        {
+            clear_screen();
+        }
+        action_msg[0] = '\0';
+        char ch = postfix_expr[i];
+        if (isdigit((unsigned char)ch))
+        {
+            push(operands, ch - '0');
+            snprintf(action_msg, sizeof(action_msg), "Pushed operand '%c' onto stack", ch);
+            current_result = ch - '0';
+
+            printf("Step    : %d\n", step);
+            printf("Char    : %c\n", ch);
+            printf("Action  : %s\n", action_msg);
+            printf("Stack   : ");
+            printStackAsInts(operands);
+            printf("Result  : %d\n", current_result);
+            printf("-----------------------------------\n\n");
+            step++;
+        }
+        else if (isOperator(ch))
+        {
+            if (isEmpty(operands))
+            {
+                printf("\n[Error] Invalid expression: Stack underflow (missing operands for "
+                       "operator '%c')\n",
+                       ch);
+                destroyStack(operands);
+                return EXPR_ERROR_STACK_UNDERFLOW;
+            }
+            int right_operand = pop(operands);
+            if (isEmpty(operands))
+            {
+                printf("\n[Error] Invalid expression: Stack underflow (missing operands for "
+                       "operator '%c')\n",
+                       ch);
+                destroyStack(operands);
+                return EXPR_ERROR_STACK_UNDERFLOW;
+            }
+            int left_operand = pop(operands);
+            int result = 0;
+            if (ch == '+')
+            {
+                result = left_operand + right_operand;
+                snprintf(action_msg, sizeof(action_msg),
+                         "Popped operands %d and %d, evaluated %d + %d = %d, pushed result back "
+                         "onto stack",
+                         left_operand, right_operand, left_operand, right_operand, result);
+            }
+            else if (ch == '-')
+            {
+                result = left_operand - right_operand;
+                snprintf(action_msg, sizeof(action_msg),
+                         "Popped operands %d and %d, evaluated %d - %d = %d, pushed result back "
+                         "onto stack",
+                         left_operand, right_operand, left_operand, right_operand, result);
+            }
+            else if (ch == '*')
+            {
+                result = left_operand * right_operand;
+                snprintf(action_msg, sizeof(action_msg),
+                         "Popped operands %d and %d, evaluated %d * %d = %d, pushed result back "
+                         "onto stack",
+                         left_operand, right_operand, left_operand, right_operand, result);
+            }
+            else if (ch == '/')
+            {
+                if (right_operand == 0)
+                {
+                    printf("\n[Error] Division by zero encountered.\n");
+                    destroyStack(operands);
+                    return EXPR_ERROR_DIVIDE_BY_ZERO;
+                }
+                result = left_operand / right_operand;
+                snprintf(action_msg, sizeof(action_msg),
+                         "Popped operands %d and %d, evaluated %d / %d = %d, pushed result back "
+                         "onto stack",
+                         left_operand, right_operand, left_operand, right_operand, result);
+            }
+            push(operands, result);
+            current_result = result;
+
+            printf("Step    : %d\n", step);
+            printf("Char    : %c\n", ch);
+            printf("Action  : %s\n", action_msg);
+            printf("Stack   : ");
+            printStackAsInts(operands);
+            printf("Result  : %d\n", current_result);
+            printf("-----------------------------------\n\n");
+            step++;
+        }
+        else
+        {
+            destroyStack(operands);
+            return EXPR_ERROR_INVALID_CHAR;
+        }
+
+        i++;
+        dynamic_sleep();
+    }
+
+    if (isEmpty(operands))
+    {
+        destroyStack(operands);
+        return EXPR_ERROR_EMPTY;
+    }
+
+    *final_result = pop(operands);
+
+    if (!isEmpty(operands))
+    {
+        destroyStack(operands);
+        return EXPR_ERROR_MALFORMED;
+    }
+
+    destroyStack(operands);
+    return EXPR_SUCCESS;
+}
+
 void postfix_evaluation_demo(void)
 {
     char postfix_expr[50];
     while (1)
     {
-        stack* operands = createStack();
-
         printf("\nPostfix Evaluation demo\n");
         int postfix_expr_status = validate_postfix_expr(
             postfix_expr, sizeof(postfix_expr),
@@ -24,149 +157,39 @@ void postfix_evaluation_demo(void)
 
         if (postfix_expr_status == INPUT_EXIT_SIGNAL)
         {
-            destroyStack(operands);
             printf("\nExiting postfix evaluation demo...\n");
             return;
         }
 
         if (postfix_expr_status != 1)
         {
-            destroyStack(operands);
             continue;
         }
 
-        int i = 0;
-        int step = 1;
-        char action_msg[200];
-        int current_result = 0;
-        int error_occurred = 0;
+        int final_result = 0;
+        ExpressionResult result = evaluate_postfix_expr(postfix_expr, &final_result);
 
-        while (postfix_expr[i] != '\0')
+        if (result == EXPR_SUCCESS)
         {
-            if (!is_instant())
-            {
-                clear_screen();
-            }
-            action_msg[0] = '\0';
-            char ch = postfix_expr[i];
-            if (isdigit(ch))
-            {
-                push(operands, ch - '0');
-                snprintf(action_msg, sizeof(action_msg), "Pushed operand '%c' onto stack", ch);
-                current_result = ch - '0';
-
-                printf("Step    : %d\n", step);
-                printf("Char    : %c\n", ch);
-                printf("Action  : %s\n", action_msg);
-                printf("Stack   : ");
-                printStackAsInts(operands);
-                printf("Result  : %d\n", current_result);
-                printf("-----------------------------------\n\n");
-                step++;
-            }
-            else if (isOperator(ch))
-            {
-                if (isEmpty(operands))
-                {
-                    printf("\n[Error] Invalid expression: Stack underflow (missing operands for "
-                           "operator '%c')\n",
-                           ch);
-                    error_occurred = 1;
-                    break;
-                }
-                int right_operand = pop(operands);
-                if (isEmpty(operands))
-                {
-                    printf("\n[Error] Invalid expression: Stack underflow (missing operands for "
-                           "operator '%c')\n",
-                           ch);
-                    error_occurred = 1;
-                    break;
-                }
-                int left_operand = pop(operands);
-                int result = 0;
-                if (ch == '+')
-                {
-                    result = left_operand + right_operand;
-                    snprintf(action_msg, sizeof(action_msg),
-                             "Popped operands %d and %d, evaluated %d + %d = %d, pushed result "
-                             "back onto stack",
-                             left_operand, right_operand, left_operand, right_operand, result);
-                }
-                else if (ch == '-')
-                {
-                    result = left_operand - right_operand;
-                    snprintf(action_msg, sizeof(action_msg),
-                             "Popped operands %d and %d, evaluated %d - %d = %d, pushed result "
-                             "back onto stack",
-                             left_operand, right_operand, left_operand, right_operand, result);
-                }
-                else if (ch == '*')
-                {
-                    result = left_operand * right_operand;
-                    snprintf(action_msg, sizeof(action_msg),
-                             "Popped operands %d and %d, evaluated %d * %d = %d, pushed result "
-                             "back onto stack",
-                             left_operand, right_operand, left_operand, right_operand, result);
-                }
-                else if (ch == '/')
-                {
-                    if (right_operand == 0)
-                    {
-                        printf("\n[Error] Division by zero encountered.\n");
-                        error_occurred = 1;
-                        break;
-                    }
-                    result = left_operand / right_operand;
-                    snprintf(action_msg, sizeof(action_msg),
-                             "Popped operands %d and %d, evaluated %d / %d = %d, pushed result "
-                             "back onto stack",
-                             left_operand, right_operand, left_operand, right_operand, result);
-                }
-                push(operands, result);
-                current_result = result;
-
-                printf("Step    : %d\n", step);
-                printf("Char    : %c\n", ch);
-                printf("Action  : %s\n", action_msg);
-                printf("Stack   : ");
-                printStackAsInts(operands);
-                printf("Result  : %d\n", current_result);
-                printf("-----------------------------------\n\n");
-                step++;
-            }
-
-            i++;
-            dynamic_sleep();
+            printf("\n===================================\n");
+            printf("Final Evaluated Result : %d\n", final_result);
+            printf("===================================\n\n");
         }
-
-        if (error_occurred)
+        else if (result == EXPR_ERROR_DIVIDE_BY_ZERO)
         {
-            destroyStack(operands);
-            continue;
+            printf("\n[Error] Evaluation failed: Division by zero.\n");
         }
-
-        if (isEmpty(operands))
+        else if (result == EXPR_ERROR_STACK_UNDERFLOW)
         {
-            printf("\n[Error] Invalid or empty expression provided.\n");
-            destroyStack(operands);
-            continue;
+            printf("\n[Error] Evaluation failed: Stack underflow (missing operands).\n");
         }
-
-        int final_result = pop(operands);
-
-        if (!isEmpty(operands))
+        else if (result == EXPR_ERROR_MALFORMED)
         {
-            printf("\n[Error] Malformed expression: Too many operands.\n");
-            destroyStack(operands);
-            continue;
+            printf("\n[Error] Evaluation failed: Malformed expression (too many operands).\n");
         }
-
-        destroyStack(operands);
-        printf("\n===================================\n");
-        printf("Final Evaluated Result : %d\n", final_result);
-        printf("===================================\n\n");
+        else
+        {
+            printf("\n[Error] Evaluation failed: Code %d.\n", result);
+        }
     }
-
-    return;
 }


### PR DESCRIPTION
### Description
Addresses PR 4 of issue #836. Refactors expression evaluation modules to use standardized integer error defines and functions, separating core logic into library functions.

### Changes
- **expression.h**: Replaced enum with standard macro defines and declared library functions.
- **parantheses_checker.c**: Refactored `check_parantheses()` to return standardized integer codes.
- **postfix_evaluation.c**: Extracted `evaluate_postfix_expr()` returning explicit error codes.
- **infix_to_postfix.c** & **infix_to_prefix.c**: Extracted core conversion loops into library functions returning integer status codes.

### Verification
- All tests pass successfully via `make test`.