### PR TITLE
test(tui): add automated regression tests for TUI menu structure (PR 6)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,8 +33,8 @@ CFLAGS = -Wall -Wextra -Werror -std=c11 -g \
 	-Isrc/compression \
 	-Idemos/data_structures \
 	-Idemos/trees \
-	-Idemos/sorting_algorithms_n2
-	# -Itui
+	-Idemos/sorting_algorithms_n2 \
+	-Itui
 
 # LDFLAGS = -lncurses
 
@@ -221,6 +221,10 @@ endif
 
 ifneq ($(wildcard tests/debugger/test_step_debugger.c),)
 TEST_BINS += test_step_debugger
+endif
+
+ifneq ($(wildcard tests/tui/test_tui.c),)
+TEST_BINS += test_tui
 endif
 
 ifneq ($(wildcard tests/memory_profiler/test_memory_tracker.c),)
@@ -806,6 +810,13 @@ test_step_debugger: $(TEST_DIR)/test_step_debugger$(EXE)
 	$(TEST_DIR)/test_step_debugger$(EXE)
 
 $(TEST_DIR)/test_step_debugger$(EXE): $(OBJS) tests/debugger/test_step_debugger.c
+	@$(call MKDIR_P,$(TEST_DIR))
+	$(CC) $(CFLAGS) $^ -o $@ $(LDFLAGS)
+
+test_tui: $(TEST_DIR)/test_tui$(EXE)
+	$(TEST_DIR)/test_tui$(EXE)
+
+$(TEST_DIR)/test_tui$(EXE): $(filter-out $(OBJ_DIR)/tui/tui.o,$(OBJS)) tests/tui/test_tui.c
 	@$(call MKDIR_P,$(TEST_DIR))
 	$(CC) $(CFLAGS) $^ -o $@ $(LDFLAGS)
 

--- a/tests/tui/test_tui.c
+++ b/tests/tui/test_tui.c
@@ -1,0 +1,36 @@
+#include <assert.h>
+#include <stdio.h>
+
+#define main tui_main_unused
+#include "../../tui/tui.c"
+#undef main
+
+void test_build_visible(void)
+{
+    printf("Running test_build_visible...\n");
+    int visible[256];
+    int count = build_visible(visible, 256);
+    assert(count > 0);
+    // Make sure we have "Animation speed (s)" as first visible category
+    assert(visible[0] == 0);
+    printf("--> test_build_visible PASSED! (%d visible items)\n", count);
+}
+
+void test_find_parent(void)
+{
+    printf("Running test_find_parent...\n");
+    // Find parent of first item
+    int parent =
+        find_parent(1); // Set Animation Speed parent should be "Animation speed (s)" (idx 0)
+    assert(parent == 0);
+    printf("--> test_find_parent PASSED!\n");
+}
+
+int main(void)
+{
+    printf("Starting TUI unit tests...\n");
+    test_build_visible();
+    test_find_parent();
+    printf("All TUI unit tests passed successfully!\n");
+    return 0;
+}


### PR DESCRIPTION
### Description
This PR addresses **PR 6 — TUI and Debugger Regression Tests** under issue #836. It implements automated regression tests validating TUI visible list builders and menu hierarchical traversal logic.

### Changes
- **TUI Tests ([test_tui.c](file:///Users/akshatshukla/Downloads/Work/open/C_DSA_interactive_suite.git/tests/tui/test_tui.c))**: Implemented automated unit tests verifying structural behaviors of the categories registry and directory depth indexing.
- **Makefile ([Makefile](file:///Users/akshatshukla/Downloads/Work/open/C_DSA_interactive_suite.git/Makefile))**: Added `-Itui` to path flags and registered `test_tui` inside the test pipeline execution sequence.

### Verification
Ran and passed all test binaries successfully:
- `make test`