### PR TITLE
refactor(windows): remove Windows compatibility from debugger, memory profiler, and TUI (PR 2)

### DIFF
--- a/features/debugger/step_debugger.c
+++ b/features/debugger/step_debugger.c
@@ -2,19 +2,14 @@
 #include <stdio.h>
 #include <string.h>
 
-#ifndef _WIN32
 #include <ncurses.h>
 #include <sys/select.h>
 #include <termios.h>
 #include <unistd.h>
-#else
-#include <conio.h>
-#endif
 static char event_log[5][128];
 static int event_count = 0;
 
-#ifndef _WIN32
-static int get_keypress_unix(int block)
+static int get_keypress(int block)
 {
     if (stdscr != NULL && !isendwin())
     {
@@ -56,32 +51,6 @@ static int get_keypress_unix(int block)
         tcsetattr(STDIN_FILENO, TCSANOW, &oldt);
     }
     return ch;
-}
-#else
-static int get_keypress_windows(int block)
-{
-    if (block)
-    {
-        return _getch();
-    }
-    else
-    {
-        if (_kbhit())
-        {
-            return _getch();
-        }
-    }
-    return -1;
-}
-#endif
-
-static int get_keypress(int block)
-{
-#ifdef _WIN32
-    return get_keypress_windows(block);
-#else
-    return get_keypress_unix(block);
-#endif
 }
 
 void algorithm_step_hook(const char* event_msg)

--- a/features/memory_profiler/memory_tracker.c
+++ b/features/memory_profiler/memory_tracker.c
@@ -5,11 +5,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#ifndef _WIN32
 #include <execinfo.h>
-#else
-#include <windows.h>
-#endif
 
 #define MAX_BACKTRACE_FRAMES 10
 
@@ -44,12 +40,7 @@ static void add_block(void* addr, size_t size, const char* file, int line)
     block->filename = file;
     block->line = line;
 
-#ifndef _WIN32
     block->backtrace_size = backtrace(block->backtrace_buffer, MAX_BACKTRACE_FRAMES);
-#else
-    block->backtrace_size =
-        CaptureStackBackTrace(1, MAX_BACKTRACE_FRAMES, block->backtrace_buffer, NULL);
-#endif
 
     block->next = head;
     head = block;
@@ -292,7 +283,6 @@ void print_memory_leak_report(void)
     while (curr != NULL)
     {
         printf("%-20p %-10zu %s:%d\n", curr->address, curr->size, curr->filename, curr->line);
-#ifndef _WIN32
         if (curr->backtrace_size > 0)
         {
             char** symbols = backtrace_symbols(curr->backtrace_buffer, curr->backtrace_size);
@@ -306,16 +296,6 @@ void print_memory_leak_report(void)
                 free(symbols);
             }
         }
-#else
-        if (curr->backtrace_size > 0)
-        {
-            printf("  Call Stack (Hex Addresses):\n");
-            for (int j = 0; j < curr->backtrace_size; j++)
-            {
-                printf("    [%d] %p\n", j, curr->backtrace_buffer[j]);
-            }
-        }
-#endif
 
         total_leaked += curr->size;
         leak_count++;

--- a/tui/tui.h
+++ b/tui/tui.h
@@ -1,10 +1,6 @@
 #ifndef TUI_H
 #define TUI_H
 
-#ifndef _WIN32
 void tui_run(void);
-#else
-static inline void tui_run(void) {}
-#endif
 
 #endif


### PR DESCRIPTION
### Description
Addresses PR 2 of issue #844. Removes Windows compatibility preprocessors (`_WIN32`, `WIN32`) and header includes from the stepping debugger, memory profiler, and TUI module.

Resolves #844

### Changes
- **step_debugger.c**: Removed Windows-specific `conio.h` header and keypress capturing functions. Simplified logic to use POSIX/ncurses standard functions.
- **memory_tracker.c**: Removed `windows.h` and the hex call-stack fallback, unconditionally using standard POSIX `backtrace` and `backtrace_symbols` from `<execinfo.h>`.
- **tui.h**: Unconditionally declares `tui_run()`.

### Verification
- All tests pass successfully via `make test`.