### PR TITLE
refactor(windows): remove Windows compatibility from benchmarking suite (PR 3)

### DIFF
--- a/features/benchmark/benchmark.c
+++ b/features/benchmark/benchmark.c
@@ -10,47 +10,22 @@
 int benchmark_iterations = 5;
 BenchmarkFormat benchmark_output_format = FORMAT_CSV;
 
-#ifdef _WIN32
-#include <direct.h>
-#include <psapi.h>
-#include <windows.h>
-
-#define make_dir(path) _mkdir(path)
-#else
 #include <sys/resource.h>
 #include <sys/stat.h>
 #define make_dir(path) mkdir(path, 0777)
-#endif
 
 double benchmark_get_time(void)
 {
-#ifdef _WIN32
-    LARGE_INTEGER count, freq;
-    if (QueryPerformanceCounter(&count) && QueryPerformanceFrequency(&freq) && freq.QuadPart > 0)
-    {
-        return (double)count.QuadPart / (double)freq.QuadPart;
-    }
-    return 0.0;
-#else
     struct timespec ts;
     if (clock_gettime(CLOCK_MONOTONIC, &ts) == 0)
     {
         return (double)ts.tv_sec + (double)ts.tv_nsec / 1e9;
     }
     return 0.0;
-#endif
 }
 
 size_t benchmark_get_peak_memory(void)
 {
-#ifdef _WIN32
-    PROCESS_MEMORY_COUNTERS pmc;
-    if (GetProcessMemoryInfo(GetCurrentProcess(), &pmc, sizeof(pmc)))
-    {
-        return (size_t)(pmc.PeakWorkingSetSize / 1024);
-    }
-    return 0;
-#else
     struct rusage r_usage;
     if (getrusage(RUSAGE_SELF, &r_usage) == 0)
     {
@@ -63,7 +38,6 @@ size_t benchmark_get_peak_memory(void)
 #endif
     }
     return 0;
-#endif
 }
 
 int benchmark_export_csv(const char* category_name, const char* algo_name, int input_size,

--- a/features/benchmark/benchmark_backtracking.c
+++ b/features/benchmark/benchmark_backtracking.c
@@ -7,14 +7,7 @@
 #include <string.h>
 #include <time.h>
 
-#ifdef _WIN32
-#include <io.h>
-#define dup _dup
-#define dup2 _dup2
-#define fileno _fileno
-#else
 #include <unistd.h>
-#endif
 
 void run_backtracking_benchmark(int n)
 {
@@ -42,11 +35,7 @@ void run_backtracking_benchmark(int n)
         // Redirect stdout
         fflush(stdout);
         int stdout_dup = dup(1);
-#ifdef _WIN32
-        FILE* fnull = fopen("NUL", "w");
-#else
         FILE* fnull = fopen("/dev/null", "w");
-#endif
         if (fnull != NULL && stdout_dup >= 0)
         {
             dup2(fileno(fnull), 1);

--- a/features/benchmark/benchmark_flow.c
+++ b/features/benchmark/benchmark_flow.c
@@ -7,14 +7,7 @@
 #include <string.h>
 #include <time.h>
 
-#ifdef _WIN32
-#include <io.h>
-#define dup _dup
-#define dup2 _dup2
-#define fileno _fileno
-#else
 #include <unistd.h>
-#endif
 
 static weightedGraph* generate_flow_network(int V, double edge_density)
 {
@@ -96,11 +89,7 @@ void run_flow_benchmark(int v)
 
             fflush(stdout);
             int stdout_dup = dup(1);
-#ifdef _WIN32
-            FILE* fnull = fopen("NUL", "w");
-#else
             FILE* fnull = fopen("/dev/null", "w");
-#endif
             if (fnull != NULL && stdout_dup >= 0)
             {
                 dup2(fileno(fnull), 1);

--- a/features/benchmark/benchmark_graphs.c
+++ b/features/benchmark/benchmark_graphs.c
@@ -6,14 +6,7 @@
 #include <string.h>
 #include <time.h>
 
-#ifdef _WIN32
-#include <io.h>
-#define dup _dup
-#define dup2 _dup2
-#define fileno _fileno
-#else
 #include <unistd.h>
-#endif
 
 void run_graphs_benchmark(int v)
 {
@@ -105,11 +98,7 @@ void run_graphs_benchmark(int v)
             // Redirect stdout to suppress prints from algorithm steps
             fflush(stdout);
             int stdout_dup = dup(1);
-#ifdef _WIN32
-            FILE* fnull = fopen("NUL", "w");
-#else
             FILE* fnull = fopen("/dev/null", "w");
-#endif
             if (fnull != NULL && stdout_dup >= 0)
             {
                 dup2(fileno(fnull), 1);

--- a/features/benchmark/benchmark_mst.c
+++ b/features/benchmark/benchmark_mst.c
@@ -6,14 +6,7 @@
 #include <string.h>
 #include <time.h>
 
-#ifdef _WIN32
-#include <io.h>
-#define dup _dup
-#define dup2 _dup2
-#define fileno _fileno
-#else
 #include <unistd.h>
-#endif
 
 void run_mst_benchmark(int v)
 {
@@ -76,11 +69,7 @@ void run_mst_benchmark(int v)
         // Redirect stdout to suppress print logs from algorithm execution
         fflush(stdout);
         int stdout_dup = dup(1);
-#ifdef _WIN32
-        FILE* fnull = fopen("NUL", "w");
-#else
         FILE* fnull = fopen("/dev/null", "w");
-#endif
         if (fnull != NULL && stdout_dup >= 0)
         {
             dup2(fileno(fnull), 1);

--- a/features/benchmark/benchmark_strings.c
+++ b/features/benchmark/benchmark_strings.c
@@ -6,14 +6,7 @@
 #include <string.h>
 #include <time.h>
 
-#ifdef _WIN32
-#include <io.h>
-#define dup _dup
-#define dup2 _dup2
-#define fileno _fileno
-#else
 #include <unistd.h>
-#endif
 
 static void generate_random_string(char* str, int len)
 {
@@ -68,11 +61,7 @@ void run_strings_benchmark(int n)
         // Redirect stdout
         fflush(stdout);
         int stdout_dup = dup(1);
-#ifdef _WIN32
-        FILE* fnull = fopen("NUL", "w");
-#else
         FILE* fnull = fopen("/dev/null", "w");
-#endif
         if (fnull != NULL && stdout_dup >= 0)
         {
             dup2(fileno(fnull), 1);

--- a/features/benchmark/benchmark_trees.c
+++ b/features/benchmark/benchmark_trees.c
@@ -6,16 +6,8 @@
 #include <string.h>
 #include <time.h>
 
-#ifdef _WIN32
-#include <io.h>
-#define dup _dup
-#define dup2 _dup2
-#define fileno _fileno
-#define DEV_NULL "NUL"
-#else
 #include <unistd.h>
 #define DEV_NULL "/dev/null"
-#endif
 
 static int compare_ints(const void* a, const void* b)
 {


### PR DESCRIPTION
### Description
Addresses PR 3 of issue #844. Removes Windows compatibility preprocessors (`_WIN32`, `WIN32`) and header includes from the benchmarking suite core and individual benchmark modules.

Resolves #844

### Changes
- **benchmark.c**: Removed Windows-specific timing/memory dependencies (`direct.h`, `psapi.h`, `windows.h`, `QueryPerformanceCounter`). Unconditionally uses POSIX `mkdir`, `rusage`, and monotonic `clock_gettime`.
- **benchmark_*.c** (backtracking, flow, graphs, mst, strings, trees): Removed `<io.h>`, customized dup macros, and `"NUL"` redirection checks, utilizing POSIX `<unistd.h>` and redirection to `"/dev/null"`.

### Verification
- All tests pass successfully via `make test`.