### PR TITLE
refactor(windows): remove Windows compatibility from backtracking demos, sources, and tests (PR 4)

### DIFF
--- a/demos/backtracking/graph_coloring_demo.c
+++ b/demos/backtracking/graph_coloring_demo.c
@@ -5,17 +5,8 @@
 #include <stdio.h>
 #include <time.h>
 
-#ifdef _WIN32
-#include <windows.h>
-#endif
-
 void graph_coloring_demo(void)
 {
-    // Set console output to UTF-8 on Windows for Unicode support (●)
-#ifdef _WIN32
-    UINT old_cp = GetConsoleOutputCP();
-    SetConsoleOutputCP(CP_UTF8);
-#endif
 
     // Predefined Graph Topologies
     GraphTopology topologies[] = {
@@ -64,9 +55,7 @@ void graph_coloring_demo(void)
 
         if (status == INPUT_EXIT_SIGNAL)
         {
-#ifdef _WIN32
-            SetConsoleOutputCP(old_cp); // restore code page
-#endif
+
             printf("\nReturning to Backtracking menu...\n");
             return;
         }
@@ -81,9 +70,7 @@ void graph_coloring_demo(void)
             &M, "\nEnter the number of colors M (between 1 and 5), or -1 to exit: ", 1, 5);
         if (status == INPUT_EXIT_SIGNAL)
         {
-#ifdef _WIN32
-            SetConsoleOutputCP(old_cp);
-#endif
+
             printf("\nReturning to Backtracking menu...\n");
             return;
         }

--- a/demos/backtracking/knights_tour_demo.c
+++ b/demos/backtracking/knights_tour_demo.c
@@ -4,17 +4,8 @@
 #include <stdio.h>
 #include <time.h>
 
-#ifdef _WIN32
-#include <windows.h>
-#endif
-
 void knights_tour_demo(void)
 {
-    // Set console output to UTF-8 on Windows for Emojis
-#ifdef _WIN32
-    UINT old_cp = GetConsoleOutputCP();
-    SetConsoleOutputCP(CP_UTF8);
-#endif
 
     int board[8][8];
 
@@ -26,9 +17,7 @@ void knights_tour_demo(void)
 
         if (status == INPUT_EXIT_SIGNAL)
         {
-#ifdef _WIN32
-            SetConsoleOutputCP(old_cp); // restore code page
-#endif
+
             printf("\nReturning to Backtracking menu...\n");
             return;
         }

--- a/src/backtracking/graph_coloring.c
+++ b/src/backtracking/graph_coloring.c
@@ -8,9 +8,6 @@
 #include <time.h>
 
 #include "clear_screen.h"
-#ifdef _WIN32
-#include <windows.h>
-#endif
 
 static const char* color_names[] = {"NONE", "RED", "GREEN", "BLUE", "YELLOW", "MAGENTA"};
 static const char* color_ansi[] = {

--- a/src/backtracking/knights_tour.c
+++ b/src/backtracking/knights_tour.c
@@ -8,9 +8,6 @@
 #include <time.h>
 
 #include "clear_screen.h"
-#ifdef _WIN32
-#include <windows.h>
-#endif
 
 // ANSI styles
 #define ANSI_COLOR_RESET "\033[0m"

--- a/tests/string_algorithms/test_string_algorithms.c
+++ b/tests/string_algorithms/test_string_algorithms.c
@@ -4,15 +4,6 @@
 #include <string.h>
 #include <unistd.h>
 
-#ifdef _WIN32
-#include <io.h>
-#define dup _dup
-#define dup2 _dup2
-#ifndef fileno
-#define fileno _fileno
-#endif
-#endif
-
 /* Functions under test (forward-declared, same approach as the other tests).
    The string matchers print their results, so each test captures stdout and
    counts the "found at index" lines to compare against the expected count. */


### PR DESCRIPTION
### Description
Addresses PR 4 of issue #844. Removes Windows compatibility preprocessors (`_WIN32`, `WIN32`) and header includes from backtracking demos, backtracking sources, and unit tests.

Resolves #844

### Changes
- **graph_coloring_demo.c** & **knights_tour_demo.c**: Removed Windows-specific console UTF-8 code page setup and restore mechanisms.
- **graph_coloring.c** & **knights_tour.c**: Removed Windows header imports.
- **test_string_algorithms.c**: Removed `<io.h>` and duplicate macro definitions, using standard POSIX `<unistd.h>`.

### Verification
- All tests pass successfully via `make test`.