### PR TITLE
docs: enhance help pages and fix unreachable Infix help option

### DIFF
--- a/help/help_advanced_topics.c
+++ b/help/help_advanced_topics.c
@@ -51,7 +51,14 @@ void help_advanced_topics_menu(void)
             case 2:
                 display_header("Help - Strings & Compression");
                 printf("STRING ALGORITHMS:\n");
-                printf("    Pattern matching algorithms (e.g., KMP, Rabin-Karp, Z-algorithm).\n\n");
+                printf("    • Naive Matching: Checks the pattern at every position of the text. "
+                       "O(N*M).\n");
+                printf("    • KMP (Knuth-Morris-Pratt): Uses a prefix table to skip re-checking "
+                       "characters. O(N+M).\n");
+                printf("    • Rabin-Karp: Uses rolling hashes to compare pattern and text "
+                       "windows.\n");
+                printf("    • Suffix Array: Sorted array of all suffixes, enabling fast substring "
+                       "queries.\n\n");
                 printf("COMPRESSION & ENCODING:\n");
                 printf("    • Huffman Coding: Lossless data compression using variable-length "
                        "prefix codes.\n");

--- a/help/help_expression_evaluation.c
+++ b/help/help_expression_evaluation.c
@@ -14,7 +14,7 @@ void help_expression_evaluation_menu(void)
         printf("2. Infix Expression Evaluation\n");
         int choice;
         int status =
-            safe_input_int(&choice, "\nenter choice (\'-1\' to exit, or \'help\') : ", 1, 1);
+            safe_input_int(&choice, "\nenter choice (\'-1\' to exit, or \'help\') : ", 1, 2);
 
         if (status == INPUT_EXIT_SIGNAL)
         {
@@ -40,7 +40,10 @@ void help_expression_evaluation_menu(void)
                        "binary operators),\n");
                 printf("      evaluate the result, and push the result back onto Stack.\n");
                 printf("    • The final result will be the single value left on Stack.\n\n");
-                getchar();
+                printf("=================================================================\n");
+                printf("Press [ENTER] to return...\n");
+                printf("=================================================================\n");
+                press_enter_to_continue();
                 break;
             case 2:
                 display_header("Help - Infix Expression Evaluation");
@@ -55,10 +58,15 @@ void help_expression_evaluation_menu(void)
                 printf("    • Right parentheses ')' pop operators until '(' is encountered.\n");
                 printf("    • Operators pop higher or equal precedence operators from Stack, then "
                        "push themselves.\n\n");
+                printf("INFIX TO PREFIX CONVERSION:\n");
+                printf("    Similar to infix to postfix, but operators end up before their "
+                       "operands (e.g., + A B).\n");
+                printf("    Achieved by reversing the infix expression, converting it, and "
+                       "reversing the result.\n\n");
                 printf("=================================================================\n");
                 printf("Press [ENTER] to return...\n");
                 printf("=================================================================\n");
-                getchar();
+                press_enter_to_continue();
                 break;
         }
     }

--- a/help/help_graphs_trees.c
+++ b/help/help_graphs_trees.c
@@ -43,6 +43,19 @@ void help_graphs_trees_menu(void)
                 printf("B-TREE & B+ TREE:\n");
                 printf("    Self-balancing search trees optimized for systems that read/write "
                        "large blocks of data.\n\n");
+                printf("RED-BLACK TREE:\n");
+                printf("    Self-balancing BST using node colors (red/black) to guarantee O(log "
+                       "N) operations.\n\n");
+                printf("SPLAY TREE:\n");
+                printf("    Self-adjusting BST that moves recently accessed nodes to the root "
+                       "(splaying).\n\n");
+                printf("SEGMENT TREE & FENWICK TREE (BIT):\n");
+                printf("    Trees for fast range queries (sum, min, max) and point updates in "
+                       "O(log N).\n\n");
+                printf("THREADED BINARY TREE:\n");
+                printf("    Binary tree where NULL child pointers are reused as \"threads\" to "
+                       "in-order neighbors,\n");
+                printf("    allowing traversal without recursion or a stack.\n\n");
                 printf("=================================================================\n");
                 printf("Press [ENTER] to return...\n");
                 printf("=================================================================\n");
@@ -61,7 +74,14 @@ void help_graphs_trees_menu(void)
                        "weights.\n");
                 printf("    • Bellman-Ford: Finds single-source shortest path; handles negative "
                        "weights.\n");
-                printf("    • A* Search: Uses heuristics to speed up shortest-path searches.\n\n");
+                printf("    • A* Search: Uses heuristics to speed up shortest-path searches.\n");
+                printf("    • Greedy Best-First Search: Expands the node closest to the goal "
+                       "according to a heuristic.\n");
+                printf("    • Floyd-Warshall: Computes shortest paths between all pairs of "
+                       "vertices.\n\n");
+                printf("TOPOLOGICAL SORT:\n");
+                printf("    Linear ordering of a DAG's vertices such that every edge (u, v) has u "
+                       "before v (Kahn's algorithm).\n\n");
                 printf("SPANNING TREES:\n");
                 printf("    • Prim's & Kruskal's algorithms to find Minimum Spanning Trees "
                        "(MST).\n\n");

--- a/help/help_sorting_searching.c
+++ b/help/help_sorting_searching.c
@@ -11,7 +11,7 @@ void help_sorting_searching_menu(void)
 
         printf("Select a sub-topic:\n\n");
         printf("1. O(N^2) Sorting Algorithms\n");
-        printf("2. Advanced O(N log N) Sorting Algorithms\n");
+        printf("2. Advanced Sorting Algorithms (Quick, Merge, Heap, Bucket, Radix)\n");
         printf("3. Searching Algorithms\n");
         int choice;
         int status =
@@ -57,6 +57,14 @@ void help_sorting_searching_menu(void)
                 printf("HEAP SORT:\n");
                 printf("    Comparison-based sorting technique based on Binary Heap data "
                        "structure.\n\n");
+                printf("BUCKET SORT:\n");
+                printf("    Distributes elements into buckets, sorts each bucket, and "
+                       "concatenates them.\n");
+                printf("    Average O(N + K) for uniformly distributed input.\n\n");
+                printf("RADIX SORT:\n");
+                printf("    Non-comparison sort that processes digits from least to most "
+                       "significant.\n");
+                printf("    O(D * (N + K)) where D is the number of digits.\n\n");
                 printf("=================================================================\n");
                 printf("Press [ENTER] to return...\n");
                 printf("=================================================================\n");


### PR DESCRIPTION
Closes #848

While exploring the modules and their help pages (as suggested in the issue), I found one functional bug and several accuracy/coverage gaps.

## Bug fix
- The Expression Evaluation help menu lists two options but `safe_input_int` capped input at 1, so the **Infix Expression Evaluation page could never be opened**. Raised the bound to 2.
- Both pages in that menu used bare `getchar()` and the Postfix page lacked the standard footer; switched to `press_enter_to_continue()` + the footer used by every other help page.

## Accuracy
- String algorithms help advertised a **Z-algorithm that isn't implemented**; replaced with the actual set (Naive, KMP, Rabin-Karp, Suffix Array).

## Coverage (all verified against `src/`)
- **Sorting:** added Bucket Sort and Radix Sort.
- **Trees:** added Red-Black, Splay, Segment, Fenwick (BIT), and Threaded Binary Tree.
- **Graphs:** added Greedy Best-First Search, Floyd-Warshall, and Topological Sort.

## Testing
- `make fmt` — no diff
- `make` — clean build under `-Wall -Wextra -Werror -std=c11`
- `make test` — full suite passing
- Manually verified the Infix help page is now reachable via option 2

Happy to follow up with a second PR adding help pages for the currently undocumented Hashing, Error Correction, Advanced Heaps, and Benchmark modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)