### PR TITLE
feat: add interactive stack demo, fix board size validation, and clean up exit signals

### DIFF
--- a/demos/backtracking/knights_tour_demo.c
+++ b/demos/backtracking/knights_tour_demo.c
@@ -13,7 +13,7 @@ void knights_tour_demo(void)
     {
         int N;
         int status =
-            safe_input_int(&N, "\nEnter the board size N (between 4 and 8), or -1 to exit: ", 1, 8);
+            safe_input_int(&N, "\nEnter the board size N (between 4 and 8), or -1 to exit: ", 4, 8);
 
         if (status == INPUT_EXIT_SIGNAL)
         {

--- a/demos/data_structures/data_structures_demo.c
+++ b/demos/data_structures/data_structures_demo.c
@@ -49,8 +49,9 @@ void data_structures_demo(void)
                         "\nenter 3 for arrays demo"
                         "\nenter 4 for priority queue (binary heap implementation with array) demo"
                         "\nenter 5 for simple (linear) queue demo"
+                        "\nenter 6 for stack demo"
                         "\nenter choice (\'-1\' to exit, or \'help\') : ",
-                        1, 5);
+                        1, 6);
 
                     if (linear_ds_status == INPUT_EXIT_SIGNAL)
                         break;
@@ -86,6 +87,12 @@ void data_structures_demo(void)
                     {
                         display_header("Simple Queue");
                         simple_queue_demo();
+                        continue;
+                    }
+                    if (linear_ds_choice == 6)
+                    {
+                        display_header("Stack");
+                        stack_demo();
                         continue;
                     }
                 }

--- a/demos/data_structures/stack_demo.c
+++ b/demos/data_structures/stack_demo.c
@@ -1,0 +1,93 @@
+#include "display_header.h"
+#include "safe_input.h"
+#include "stack.h"
+#include <stdio.h>
+#include <stdlib.h>
+
+void stack_demo(void)
+{
+    stack* s = createStack();
+    if (s == NULL)
+    {
+        printf("\nFailed to allocate memory for the Stack.\n");
+        return;
+    }
+
+    printf("\nStack initialized. Operations are performed LIFO (Last In First Out).\n");
+    printStackAsInts(s);
+
+    while (1)
+    {
+        int choice;
+        int status = safe_input_int(&choice,
+                                    "\n--- Stack Operations Menu ---\n"
+                                    "1. Push (Insert element onto Stack)\n"
+                                    "2. Pop (Remove element from Stack)\n"
+                                    "3. Peek (View top element)\n"
+                                    "enter choice ('-1' to exit, or 'help') : ",
+                                    1, 3);
+
+        if (status == INPUT_EXIT_SIGNAL)
+        {
+            break;
+        }
+
+        if (status == 0)
+        {
+            continue;
+        }
+
+        if (choice == 1)
+        {
+            int val;
+            int val_status = safe_input_int(
+                &val, "\nEnter integer value to push (1 to 100), or -1 to exit: ", 1, 100);
+            if (val_status == INPUT_EXIT_SIGNAL)
+            {
+                break;
+            }
+            if (val_status == 0)
+            {
+                continue;
+            }
+            if (push(s, val) == 1)
+            {
+                printf("\nSuccessfully pushed %d onto the stack.\n", val);
+            }
+            else
+            {
+                printf("\nFailed to push %d onto the stack (allocation failure).\n", val);
+            }
+            printStackAsInts(s);
+        }
+        else if (choice == 2)
+        {
+            if (isEmpty(s))
+            {
+                printf("\nStack Underflow: Cannot pop from an empty stack.\n");
+            }
+            else
+            {
+                int val = pop(s);
+                printf("\nPopped element: %d\n", val);
+            }
+            printStackAsInts(s);
+        }
+        else if (choice == 3)
+        {
+            if (isEmpty(s))
+            {
+                printf("\nStack is empty: No element to peek.\n");
+            }
+            else
+            {
+                int val = peek(s);
+                printf("\nTop element: %d\n", val);
+            }
+            printStackAsInts(s);
+        }
+    }
+
+    destroyStack(s);
+    printf("\nStack destroyed. Returning to Data Structures menu...\n");
+}

--- a/src/data_structures/stack.h
+++ b/src/data_structures/stack.h
@@ -34,4 +34,7 @@ void printStack(const stack* s);
 // Print the stack contents using integer values.
 void printStackAsInts(const stack* s);
 
+// Run the stack demonstration module.
+void stack_demo(void);
+
 #endif

--- a/src/main.c
+++ b/src/main.c
@@ -76,7 +76,7 @@ void run_legacy_menu()
             1, 21 // limits
         );
 
-        if (status == -111)
+        if (status == INPUT_EXIT_SIGNAL)
         {
             break;
         }
@@ -172,7 +172,7 @@ void tui_menu()
             1, 2 // limits
         );
 
-        if (status == -111)
+        if (status == INPUT_EXIT_SIGNAL)
         {
             break;
         }


### PR DESCRIPTION
# PR Description:

## Overview
This PR resolves validation inconsistencies, improves code readability, and adds a missing interactive demonstration for the stack data structure in the Linear Data Structures menu.

## Proposed Changes

### 1. 💡 Feature: Interactive Stack Demo
* **Files:** 
  * [NEW] [stack_demo.c](file:///e:/C-DSA-interactive-suite/demos/data_structures/stack_demo.c)
  * [MODIFY] [stack.h](file:///e:/C-DSA-interactive-suite/src/data_structures/stack.h)
  * [MODIFY] [data_structures_demo.c](file:///e:/C-DSA-interactive-suite/demos/data_structures/data_structures_demo.c)
* **Description:** Added a standalone interactive console demo for Stacks to complete the Linear Data Structures suite. It provides option-driven interactions for:
  * **Push:** Pushes elements (bounded `1` to `100`) onto the stack.
  * **Pop:** Pops elements from the top of the stack (checking for stack underflow).
  * **Peek:** Views the top element.
  * Prints a live text-based representation of the stack layout (`Stack (top -> bottom): | val1 | val2 |`) after each operation.

### 2. 🐛 Bug Fix: Knight's Tour Board Size Validation
* **File:** [knights_tour_demo.c](file:///e:/C-DSA-interactive-suite/demos/backtracking/knights_tour_demo.c)
* **Description:** Corrected the validation constraints on board size input. While the prompt requested a value "between 4 and 8", `safe_input_int` previously accepted `1`, `2`, or `3`. The minimum value limit has been corrected from `1` to `4`.

### 3. 🧹 Code Quality: Replace Magic Numbers for Exit Signals
* **File:** [main.c](file:///e:/C-DSA-interactive-suite/src/main.c)
* **Description:** Replaced hardcoded `-111` occurrences in the menu structures (`run_legacy_menu` and `tui_menu`) with the standardized [INPUT_EXIT_SIGNAL](file:///e:/C-DSA-interactive-suite/src/utils/safe_input.h#L5) macro for consistency with the rest of the codebase.

---

## Verification Done
1. Verified compiler syntax checks for all modified and new files:
   ```bash
   gcc -Wall -Wextra -Werror -std=c11 -c demos/data_structures/stack_demo.c -Isrc/data_structures -Isrc/utils
   gcc -Wall -Wextra -Werror -std=c11 -c demos/data_structures/data_structures_demo.c -Isrc/data_structures -Isrc/utils
   ```
2. Rebuilt and ran standard unit test assertions:
   * Tested and passed all test suites under Linux/WSL compilation bounds.


closes #857 