### PR TITLE
Fix raw format specifiers in benchmarking settings prompt (#853)

### DIFF
--- a/features/benchmark/benchmark_demo.c
+++ b/features/benchmark/benchmark_demo.c
@@ -52,12 +52,18 @@ void benchmark_menu_demo(void)
         if (choice == 0)
         {
             int opt;
-            int opt_status = safe_input_int(&opt,
-                                            "\n--- Configure Benchmarking Settings ---\n"
-                                            "1. Change Number of Iterations (currently: %d)\n"
-                                            "2. Change Export Reporting Format (currently: %s)\n"
-                                            "Enter option (1 or 2): ",
-                                            1, 2);
+            char opt_msg[256];
+            snprintf(opt_msg, sizeof(opt_msg),
+                     "\n--- Configure Benchmarking Settings ---\n"
+                     "1. Change Number of Iterations (currently: %d)\n"
+                     "2. Change Export Reporting Format (currently: %s)\n"
+                     "Enter option (1 or 2): ",
+                     benchmark_iterations,
+                     benchmark_output_format == FORMAT_CSV
+                         ? "CSV"
+                         : (benchmark_output_format == FORMAT_MARKDOWN ? "Markdown" : "JSON"));
+
+            int opt_status = safe_input_int(&opt, opt_msg, 1, 2);
             if (opt_status != 1)
                 continue;
 


### PR DESCRIPTION
### Description
This PR resolves issue #853, where the Benchmarking Settings configuration menu prompt displayed raw `%d` and `%s` format specifiers instead of the active/current values for iterations and report format.

resolves #853 

### Changes
* Updated [benchmark_demo.c](file:///Users/akshatshukla/Library/Mobile%20Documents/com~apple~CloudDocs/Work/open/C_DSA_interactive_suite.git/features/benchmark/benchmark_demo.c) to format the settings prompt dynamically using `snprintf` with the current configurations before passing it to `safe_input_int`.

### Verification & Testing
* Compiled successfully without warnings/errors using `make`.
* Ran all automated unit tests (`make test`), and verified that all existing tests pass successfully.