### PR TITLE
refactor(ds): make Doubly Linked List (DLL) generic using void pointers

### DIFF
--- a/demos/data_structures/dll_demo.c
+++ b/demos/data_structures/dll_demo.c
@@ -1,6 +1,20 @@
 #include "dll.h"
 #include "safe_input.h"
 #include <stdio.h>
+#include <stdlib.h>
+
+static void print_int(const void* data)
+{
+    if (data != NULL)
+    {
+        printf("%d", *(const int*)data);
+    }
+}
+
+static int compare_ints(const void* a, const void* b)
+{
+    return *(const int*)a - *(const int*)b;
+}
 
 void dll_demo(void)
 {
@@ -16,7 +30,7 @@ start_dll:
     if (dll_length_status == INPUT_EXIT_SIGNAL)
     {
         printf("\nExiting dll demo.\n");
-        delete_dll(head);
+        delete_dll(head, free);
         return;
     }
     if (dll_length_status == 0)
@@ -41,7 +55,7 @@ start_dll:
         if (dll_position_status == INPUT_EXIT_SIGNAL)
         {
             printf("\nExiting dll demo.\n");
-            delete_dll(head);
+            delete_dll(head, free);
             return;
         }
         if (dll_position_status == 0)
@@ -63,20 +77,28 @@ start_dll:
             if (dll_end_status == INPUT_EXIT_SIGNAL)
             {
                 printf("\nExiting dll demo.\n");
-                delete_dll(head);
+                delete_dll(head, free);
                 return;
             }
             if (dll_end_status == 0)
             {
                 goto dll_enter_end_value;
             }
-            int status = dll_insertAtBeginning(&head, dll_end_value);
-            if (status == -1)
+            int* val = malloc(sizeof(int));
+            if (val == NULL)
             {
                 printf("\nmalloc allocation failure. try again\n");
                 goto dll_enter_end_value;
             }
-            dll_printlist(head);
+            *val = dll_end_value;
+            int status = dll_insertAtBeginning(&head, val);
+            if (status == -1)
+            {
+                free(val);
+                printf("\nmalloc allocation failure. try again\n");
+                goto dll_enter_end_value;
+            }
+            dll_printlist(head, print_int);
         }
         else if (dll_position_choice == 1)
         { // enter element at end
@@ -92,20 +114,28 @@ start_dll:
             if (dll_start_status == INPUT_EXIT_SIGNAL)
             {
                 printf("\nExiting dll demo.\n");
-                delete_dll(head);
+                delete_dll(head, free);
                 return;
             }
             if (dll_start_status == 0)
             {
                 goto dll_enter_start_value;
             }
-            int status = dll_insertAtEnd(&head, dll_start_value);
-            if (status == -1)
+            int* val = malloc(sizeof(int));
+            if (val == NULL)
             {
                 printf("\nmalloc allocation failure. try again\n");
                 goto dll_enter_start_value;
             }
-            dll_printlist(head);
+            *val = dll_start_value;
+            int status = dll_insertAtEnd(&head, val);
+            if (status == -1)
+            {
+                free(val);
+                printf("\nmalloc allocation failure. try again\n");
+                goto dll_enter_start_value;
+            }
+            dll_printlist(head, print_int);
         }
         else if (dll_position_choice == 2)
         {
@@ -123,7 +153,7 @@ start_dll:
             if (dll_pos_status == INPUT_EXIT_SIGNAL)
             {
                 printf("\nExiting dll demo.\n");
-                delete_dll(head);
+                delete_dll(head, free);
                 return;
             }
 
@@ -142,7 +172,7 @@ start_dll:
             if (dll_pos_status == INPUT_EXIT_SIGNAL)
             {
                 printf("\nExiting dll demo.\n");
-                delete_dll(head);
+                delete_dll(head, free);
                 return;
             }
 
@@ -151,18 +181,27 @@ start_dll:
                 goto dll_enter_pos_index;
             }
 
-            int status = dll_insertAtPosition(&head, dll_pos_value, dll_pos_index);
+            int* val = malloc(sizeof(int));
+            if (val == NULL)
+            {
+                printf("\nmalloc allocation failure. try again\n");
+                goto dll_enter_pos_value;
+            }
+            *val = dll_pos_value;
+            int status = dll_insertAtPosition(&head, val, dll_pos_index);
             if (status == -1)
             {
+                free(val);
                 printf("\nmalloc allocation failure. try again\n");
                 goto dll_enter_pos_value;
             }
             else if (status == -2)
             {
+                free(val);
                 printf("\ninvalid position. try again\n");
                 goto dll_enter_pos_index;
             }
-            dll_printlist(head);
+            dll_printlist(head, print_int);
         }
         dll_element_count--;
     }
@@ -180,10 +219,10 @@ start_dll:
             break;
         case 1:
             printf("\nreversed list is:- ");
-            dll_printlist(head);
+            dll_printlist(head, print_int);
             printf("\nthe restored list is:- ");
             dll_reverselist(&head);
-            dll_printlist(head);
+            dll_printlist(head, print_int);
     }
 
     // searching elements in the dll
@@ -207,7 +246,7 @@ start_dll:
             continue;
         }
 
-        int index = dll_search(head, dll_search_value);
+        int index = dll_search(head, &dll_search_value, compare_ints);
         printf("\nentered number found at index %d", index);
     }
 
@@ -227,7 +266,7 @@ start_dll:
         if (dll_delete_status == INPUT_EXIT_SIGNAL)
         {
             printf("\nExiting dll demo.\n");
-            delete_dll(head);
+            delete_dll(head, free);
             return;
         }
         if (dll_delete_status == 0)
@@ -246,7 +285,7 @@ start_dll:
             if (dll_delete_status == INPUT_EXIT_SIGNAL)
             {
                 printf("\nExiting dll demo.\n");
-                delete_dll(head);
+                delete_dll(head, free);
                 return;
             }
             if (dll_delete_status == 0)
@@ -254,11 +293,11 @@ start_dll:
                 continue;
             }
 
-            int status = dll_deleteByValue(&head, dll_delete_value);
+            int status = dll_deleteByValue(&head, &dll_delete_value, compare_ints, free);
             if (status == 1)
             {
                 printf("\ndll after deletion - ");
-                dll_printlist(head);
+                dll_printlist(head, print_int);
             }
             else if (status == -1)
             {
@@ -285,7 +324,7 @@ start_dll:
             if (dll_pos_delete_status == INPUT_EXIT_SIGNAL)
             {
                 printf("\nExiting dll demo.\n");
-                delete_dll(head);
+                delete_dll(head, free);
                 return;
             }
 
@@ -294,7 +333,7 @@ start_dll:
                 goto dll_delete_pos_input;
             }
 
-            int status = dll_deleteAtPosition(&head, dll_pos_delete_index);
+            int status = dll_deleteAtPosition(&head, dll_pos_delete_index, free);
             if (status == -1)
             {
                 printf("\nList is empty\n");
@@ -306,7 +345,7 @@ start_dll:
             else
             {
                 printf("\ndll after deletion - ");
-                dll_printlist(head);
+                dll_printlist(head, print_int);
             }
         }
     }

--- a/src/data_structures/dll.c
+++ b/src/data_structures/dll.c
@@ -7,7 +7,7 @@
 // methods implemented are - insertAtBeginning, insertAtEnd, printlist, search, deleteAtBeginning,
 // deleteAtEnd, deleteByValue, insertAtPosition, deleteAtPosition and reverselist
 
-int dll_insertAtBeginning(doubly_ll_Node** head_ref, int value)
+int dll_insertAtBeginning(doubly_ll_Node** head_ref, void* value)
 {
     doubly_ll_Node* newnode = malloc(sizeof(doubly_ll_Node));
     if (newnode == NULL)
@@ -27,7 +27,7 @@ int dll_insertAtBeginning(doubly_ll_Node** head_ref, int value)
     return 1;
 }
 
-int dll_insertAtEnd(doubly_ll_Node** head_ref, int value)
+int dll_insertAtEnd(doubly_ll_Node** head_ref, void* value)
 {
     doubly_ll_Node* newnode = malloc(sizeof(doubly_ll_Node));
     if (newnode == NULL)
@@ -51,25 +51,43 @@ int dll_insertAtEnd(doubly_ll_Node** head_ref, int value)
     return 1;
 }
 
-void dll_printlist(const doubly_ll_Node* head)
+void dll_printlist(const doubly_ll_Node* head, void (*print_element)(const void*))
 {
     printf("\nHEAD<-> ");
     while (head != NULL)
     {
-        printf("%d <->", head->data);
+        if (print_element != NULL)
+        {
+            print_element(head->data);
+        }
+        else
+        {
+            printf("%p", head->data);
+        }
+        printf(" <->");
         head = head->next;
     }
     printf("NULL");
 }
 
-int dll_search(const doubly_ll_Node* head, int key)
+int dll_search(const doubly_ll_Node* head, const void* key, int (*compare)(const void*, const void*))
 {
     int index = 0;
     while (head != NULL)
     {
-        if (head->data == key)
+        if (compare != NULL)
         {
-            return index; // if value found returns index number
+            if (compare(head->data, key) == 0)
+            {
+                return index; // if value found returns index number
+            }
+        }
+        else
+        {
+            if (head->data == key)
+            {
+                return index;
+            }
         }
         head = head->next;
         index++;
@@ -77,66 +95,94 @@ int dll_search(const doubly_ll_Node* head, int key)
     return -1; // otherwise returns -1
 }
 
-int dll_deleteAtBeginning(doubly_ll_Node** head_ref)
+int dll_deleteAtBeginning(doubly_ll_Node** head_ref, void (*free_data)(void*))
 {
     if (*head_ref == NULL)
         return -1;
-    if ((*head_ref)->next == NULL)
+    doubly_ll_Node* temp = *head_ref;
+    if (temp->next == NULL)
     {
-        free(*head_ref);
+        if (free_data != NULL)
+        {
+            free_data(temp->data);
+        }
+        free(temp);
         *head_ref = NULL;
         return 1;
     }
-    doubly_ll_Node* secondnode = (*head_ref)->next;
-    free(*head_ref);
+    doubly_ll_Node* secondnode = temp->next;
+    if (free_data != NULL)
+    {
+        free_data(temp->data);
+    }
+    free(temp);
     secondnode->prev = NULL;
     *head_ref = secondnode;
     return 1;
 }
 
-int dll_deleteAtEnd(doubly_ll_Node** head_ref)
+int dll_deleteAtEnd(doubly_ll_Node** head_ref, void (*free_data)(void*))
 {
     if (*head_ref == NULL)
         return -1;
-    if ((*head_ref)->next == NULL)
+    doubly_ll_Node* temp = *head_ref;
+    if (temp->next == NULL)
     {
-        free(*head_ref);
+        if (free_data != NULL)
+        {
+            free_data(temp->data);
+        }
+        free(temp);
         *head_ref = NULL;
         return 1;
     }
-    doubly_ll_Node* temp = *head_ref;
     while (temp->next != NULL)
     {
         temp = temp->next;
     }
     doubly_ll_Node* secondlast = temp->prev;
+    if (free_data != NULL)
+    {
+        free_data(temp->data);
+    }
     free(temp);
     secondlast->next = NULL;
     return 1;
 }
 
-int dll_deleteByValue(doubly_ll_Node** head_ref, int key)
+int dll_deleteByValue(doubly_ll_Node** head_ref, const void* key, int (*compare)(const void*, const void*), void (*free_data)(void*))
 {
     if (*head_ref == NULL)
         return -2;
 
-    if ((*head_ref)->next == NULL && (*head_ref)->data == key)
-    {
-        free(*head_ref);
-        *head_ref = NULL;
-        return 1;
-    }
     doubly_ll_Node* temp = *head_ref;
     while (temp != NULL)
     {
-        if (temp->data == key)
+        int match = 0;
+        if (compare != NULL)
+        {
+            match = (compare(temp->data, key) == 0);
+        }
+        else
+        {
+            match = (temp->data == key);
+        }
+
+        if (match)
         {
             doubly_ll_Node* beforekey = temp->prev;
             doubly_ll_Node* afterkey = temp->next;
             if (beforekey == NULL)
             {
                 *head_ref = temp->next;
-                (*head_ref)->prev = NULL;
+                if (*head_ref != NULL)
+                {
+                    (*head_ref)->prev = NULL;
+                }
+                if (free_data != NULL)
+                {
+                    free_data(temp->data);
+                }
                 free(temp);
                 return 1;
             }
@@ -144,6 +190,10 @@ int dll_deleteByValue(doubly_ll_Node** head_ref, int key)
             if (afterkey != NULL)
             {
                 afterkey->prev = beforekey;
+            }
+            if (free_data != NULL)
+            {
+                free_data(temp->data);
             }
             free(temp);
             return 1;
@@ -154,11 +204,15 @@ int dll_deleteByValue(doubly_ll_Node** head_ref, int key)
     return -1;
 }
 
-void delete_dll(doubly_ll_Node* head)
+void delete_dll(doubly_ll_Node* head, void (*free_data)(void*))
 {
     while (head != NULL)
     {
         doubly_ll_Node* upcoming = head->next;
+        if (free_data != NULL)
+        {
+            free_data(head->data);
+        }
         free(head);
         head = upcoming;
     }
@@ -209,7 +263,7 @@ int dll_getLength(const doubly_ll_Node* head)
 
 // Insert at a specific position (0-indexed)
 // Returns 1 on success, -1 on malloc failure, -2 on invalid position
-int dll_insertAtPosition(doubly_ll_Node** head_ref, int value, int position)
+int dll_insertAtPosition(doubly_ll_Node** head_ref, void* value, int position)
 {
     int length = dll_getLength(*head_ref);
 
@@ -260,7 +314,7 @@ int dll_insertAtPosition(doubly_ll_Node** head_ref, int value, int position)
 
 // Delete at a specific position (0-indexed)
 // Returns 1 on success, -1 on empty list, -2 on invalid position
-int dll_deleteAtPosition(doubly_ll_Node** head_ref, int position)
+int dll_deleteAtPosition(doubly_ll_Node** head_ref, int position, void (*free_data)(void*))
 {
     if (*head_ref == NULL)
     {
@@ -287,6 +341,10 @@ int dll_deleteAtPosition(doubly_ll_Node** head_ref, int position)
         {
             *head_ref = NULL;
         }
+        if (free_data != NULL)
+        {
+            free_data(temp->data);
+        }
         free(temp);
         return 1;
     }
@@ -302,6 +360,10 @@ int dll_deleteAtPosition(doubly_ll_Node** head_ref, int position)
         temp->next->prev = prevnode;
     }
     prevnode->next = temp->next;
+    if (free_data != NULL)
+    {
+        free_data(temp->data);
+    }
     free(temp);
     return 1;
 }

--- a/src/data_structures/dll.c
+++ b/src/data_structures/dll.c
@@ -70,7 +70,8 @@ void dll_printlist(const doubly_ll_Node* head, void (*print_element)(const void*
     printf("NULL");
 }
 
-int dll_search(const doubly_ll_Node* head, const void* key, int (*compare)(const void*, const void*))
+int dll_search(const doubly_ll_Node* head, const void* key,
+               int (*compare)(const void*, const void*))
 {
     int index = 0;
     while (head != NULL)
@@ -150,7 +151,8 @@ int dll_deleteAtEnd(doubly_ll_Node** head_ref, void (*free_data)(void*))
     return 1;
 }
 
-int dll_deleteByValue(doubly_ll_Node** head_ref, const void* key, int (*compare)(const void*, const void*), void (*free_data)(void*))
+int dll_deleteByValue(doubly_ll_Node** head_ref, const void* key,
+                      int (*compare)(const void*, const void*), void (*free_data)(void*))
 {
     if (*head_ref == NULL)
         return -2;

--- a/src/data_structures/dll.h
+++ b/src/data_structures/dll.h
@@ -20,7 +20,8 @@ int dll_insertAtEnd(doubly_ll_Node** head_ref, void* value);
 void dll_printlist(const doubly_ll_Node* head, void (*print_element)(const void*));
 
 // Search for a key in a doubly linked list. Returns The index of the key or -1 if not found.
-int dll_search(const doubly_ll_Node* head, const void* key, int (*compare)(const void*, const void*));
+int dll_search(const doubly_ll_Node* head, const void* key,
+               int (*compare)(const void*, const void*));
 
 // Delete the first element from a doubly linked list. Returns 1 on success, -1 if the list is
 // empty.
@@ -31,7 +32,8 @@ int dll_deleteAtEnd(doubly_ll_Node** head_ref, void (*free_data)(void*));
 
 // Delete the first occurrence of a key from a doubly linked list. Returns 1 on success, -1 if not
 // found, -2 if empty list.
-int dll_deleteByValue(doubly_ll_Node** head_ref, const void* key, int (*compare)(const void*, const void*), void (*free_data)(void*));
+int dll_deleteByValue(doubly_ll_Node** head_ref, const void* key,
+                      int (*compare)(const void*, const void*), void (*free_data)(void*));
 
 // Free all nodes in a doubly linked list.
 void delete_dll(doubly_ll_Node* head, void (*free_data)(void*));

--- a/src/data_structures/dll.h
+++ b/src/data_structures/dll.h
@@ -3,38 +3,38 @@
 
 typedef struct doubly_ll_Node
 {
-    int data;
+    void* data;
     struct doubly_ll_Node* prev;
     struct doubly_ll_Node* next;
 } doubly_ll_Node;
 
 // Insert a value at the beginning of a doubly linked list. Returns 1 on success, -1 on allocation
 // failure.
-int dll_insertAtBeginning(doubly_ll_Node** head_ref, int value);
+int dll_insertAtBeginning(doubly_ll_Node** head_ref, void* value);
 
 // Insert a value at the end of a doubly linked list. Returns 1 on success, -1 on allocation
 // failure.
-int dll_insertAtEnd(doubly_ll_Node** head_ref, int value);
+int dll_insertAtEnd(doubly_ll_Node** head_ref, void* value);
 
 // Print the elements of a doubly linked list.
-void dll_printlist(const doubly_ll_Node* head);
+void dll_printlist(const doubly_ll_Node* head, void (*print_element)(const void*));
 
 // Search for a key in a doubly linked list. Returns The index of the key or -1 if not found.
-int dll_search(const doubly_ll_Node* head, int key);
+int dll_search(const doubly_ll_Node* head, const void* key, int (*compare)(const void*, const void*));
 
 // Delete the first element from a doubly linked list. Returns 1 on success, -1 if the list is
 // empty.
-int dll_deleteAtBeginning(doubly_ll_Node** head_ref);
+int dll_deleteAtBeginning(doubly_ll_Node** head_ref, void (*free_data)(void*));
 
 // Delete the last element from a doubly linked list. Returns 1 on success, -1 if the list is empty.
-int dll_deleteAtEnd(doubly_ll_Node** head_ref);
+int dll_deleteAtEnd(doubly_ll_Node** head_ref, void (*free_data)(void*));
 
 // Delete the first occurrence of a key from a doubly linked list. Returns 1 on success, -1 if not
-// found.
-int dll_deleteByValue(doubly_ll_Node** head_ref, int key);
+// found, -2 if empty list.
+int dll_deleteByValue(doubly_ll_Node** head_ref, const void* key, int (*compare)(const void*, const void*), void (*free_data)(void*));
 
 // Free all nodes in a doubly linked list.
-void delete_dll(doubly_ll_Node* head);
+void delete_dll(doubly_ll_Node* head, void (*free_data)(void*));
 
 // Run the doubly linked list demonstration module.
 void dll_demo(void);
@@ -47,10 +47,10 @@ int dll_getLength(const doubly_ll_Node* head);
 
 // Insert a value at a specific position in a doubly linked list. Returns 1 on success, -1 on
 // allocation failure, -2 on invalid position.
-int dll_insertAtPosition(doubly_ll_Node** head_ref, int value, int position);
+int dll_insertAtPosition(doubly_ll_Node** head_ref, void* value, int position);
 
 // Delete a node at a specific position in a doubly linked list. Returns 1 on success, -1 if the
 // list is empty, -2 on invalid position.
-int dll_deleteAtPosition(doubly_ll_Node** head_ref, int position);
+int dll_deleteAtPosition(doubly_ll_Node** head_ref, int position, void (*free_data)(void*));
 
 #endif

--- a/tests/data_structures/test_dll.c
+++ b/tests/data_structures/test_dll.c
@@ -1,6 +1,12 @@
 #include "dll.h"
 #include <assert.h>
 #include <stdio.h>
+#include <stdlib.h>
+
+static int compare_ints(const void* a, const void* b)
+{
+    return *(const int*)a - *(const int*)b;
+}
 
 /* Helper: build list */
 static doubly_ll_Node* build_list(int arr[], int n)
@@ -8,7 +14,10 @@ static doubly_ll_Node* build_list(int arr[], int n)
     doubly_ll_Node* head = NULL;
     for (int i = 0; i < n; i++)
     {
-        assert(dll_insertAtEnd(&head, arr[i]) == 1);
+        int* val = malloc(sizeof(int));
+        assert(val != NULL);
+        *val = arr[i];
+        assert(dll_insertAtEnd(&head, val) == 1);
     }
     return head;
 }
@@ -19,7 +28,7 @@ static int list_to_array(doubly_ll_Node* head, int arr[], int max)
     int i = 0;
     while (head != NULL && i < max)
     {
-        arr[i++] = head->data;
+        arr[i++] = *(int*)(head->data);
         head = head->next;
     }
     return i;
@@ -30,13 +39,19 @@ void test_insert()
 {
     doubly_ll_Node* head = NULL;
 
-    assert(dll_insertAtBeginning(&head, 10) == 1);
-    assert(head->data == 10);
+    int* val10 = malloc(sizeof(int));
+    *val10 = 10;
+    assert(dll_insertAtBeginning(&head, val10) == 1);
+    assert(*(int*)(head->data) == 10);
 
-    assert(dll_insertAtBeginning(&head, 5) == 1);
-    assert(head->data == 5);
+    int* val5 = malloc(sizeof(int));
+    *val5 = 5;
+    assert(dll_insertAtBeginning(&head, val5) == 1);
+    assert(*(int*)(head->data) == 5);
 
-    assert(dll_insertAtEnd(&head, 20) == 1);
+    int* val20 = malloc(sizeof(int));
+    *val20 = 20;
+    assert(dll_insertAtEnd(&head, val20) == 1);
 
     int out[3];
     int n = list_to_array(head, out, 3);
@@ -44,7 +59,7 @@ void test_insert()
     assert(n == 3);
     assert(out[0] == 5 && out[1] == 10 && out[2] == 20);
 
-    delete_dll(head);
+    delete_dll(head, free);
 
     printf("DLL insert tests passed\n");
 }
@@ -55,7 +70,7 @@ void test_delete_begin()
     int arr[] = {1, 2, 3};
     doubly_ll_Node* head = build_list(arr, 3);
 
-    assert(dll_deleteAtBeginning(&head) == 1);
+    assert(dll_deleteAtBeginning(&head, free) == 1);
 
     int out[3];
     int n = list_to_array(head, out, 3);
@@ -63,7 +78,7 @@ void test_delete_begin()
     assert(n == 2);
     assert(out[0] == 2 && out[1] == 3);
 
-    delete_dll(head);
+    delete_dll(head, free);
 
     printf("DLL delete beginning tests passed\n");
 }
@@ -74,7 +89,7 @@ void test_delete_end()
     int arr[] = {1, 2, 3};
     doubly_ll_Node* head = build_list(arr, 3);
 
-    assert(dll_deleteAtEnd(&head) == 1);
+    assert(dll_deleteAtEnd(&head, free) == 1);
 
     int out[3];
     int n = list_to_array(head, out, 3);
@@ -82,7 +97,7 @@ void test_delete_end()
     assert(n == 2);
     assert(out[0] == 1 && out[1] == 2);
 
-    delete_dll(head);
+    delete_dll(head, free);
 
     printf("DLL delete end tests passed\n");
 }
@@ -93,7 +108,8 @@ void test_delete_by_value()
     int arr[] = {1, 2, 3, 4};
     doubly_ll_Node* head = build_list(arr, 4);
 
-    assert(dll_deleteByValue(&head, 4) == 1);
+    int key = 4;
+    assert(dll_deleteByValue(&head, &key, compare_ints, free) == 1);
 
     int out[4];
     int n = list_to_array(head, out, 4);
@@ -101,7 +117,7 @@ void test_delete_by_value()
     assert(n == 3);
     assert(out[0] == 1 && out[1] == 2 && out[2] == 3);
 
-    delete_dll(head);
+    delete_dll(head, free);
 
     printf("DLL delete by value tests passed\n");
 }
@@ -112,11 +128,15 @@ void test_search()
     int arr[] = {5, 10, 15};
     doubly_ll_Node* head = build_list(arr, 3);
 
-    assert(dll_search(head, 5) == 0);
-    assert(dll_search(head, 15) == 2);
-    assert(dll_search(head, 99) == -1);
+    int key5 = 5;
+    int key15 = 15;
+    int key99 = 99;
 
-    delete_dll(head);
+    assert(dll_search(head, &key5, compare_ints) == 0);
+    assert(dll_search(head, &key15, compare_ints) == 2);
+    assert(dll_search(head, &key99, compare_ints) == -1);
+
+    delete_dll(head, free);
 
     printf("DLL search tests passed\n");
 }
@@ -135,7 +155,7 @@ void test_reverse()
     assert(n == 3);
     assert(out[0] == 5 && out[1] == 2 && out[2] == 1);
 
-    delete_dll(head);
+    delete_dll(head, free);
 
     printf("DLL reverse tests passed\n");
 }
@@ -146,16 +166,22 @@ void test_insert_at_position()
     doubly_ll_Node* head = NULL;
 
     /* Insert at position 0 in empty list */
-    assert(dll_insertAtPosition(&head, 10, 0) == 1);
-    assert(head->data == 10);
+    int* val10 = malloc(sizeof(int));
+    *val10 = 10;
+    assert(dll_insertAtPosition(&head, val10, 0) == 1);
+    assert(*(int*)(head->data) == 10);
 
     /* Insert at position 1 (end) */
-    assert(dll_insertAtPosition(&head, 20, 1) == 1);
-    assert(head->next->data == 20);
-    assert(head->next->prev->data == 10);
+    int* val20 = malloc(sizeof(int));
+    *val20 = 20;
+    assert(dll_insertAtPosition(&head, val20, 1) == 1);
+    assert(*(int*)(head->next->data) == 20);
+    assert(*(int*)(head->next->prev->data) == 10);
 
     /* Insert at position 1 (middle) */
-    assert(dll_insertAtPosition(&head, 15, 1) == 1);
+    int* val15 = malloc(sizeof(int));
+    *val15 = 15;
+    assert(dll_insertAtPosition(&head, val15, 1) == 1);
 
     int out[3];
     int n = list_to_array(head, out, 3);
@@ -163,10 +189,13 @@ void test_insert_at_position()
     assert(out[0] == 10 && out[1] == 15 && out[2] == 20);
 
     /* Test invalid position */
-    assert(dll_insertAtPosition(&head, 99, 10) == -2);
-    assert(dll_insertAtPosition(&head, 99, -1) == -2);
+    int* val99 = malloc(sizeof(int));
+    *val99 = 99;
+    assert(dll_insertAtPosition(&head, val99, 10) == -2);
+    assert(dll_insertAtPosition(&head, val99, -1) == -2);
+    free(val99);
 
-    delete_dll(head);
+    delete_dll(head, free);
     printf("DLL insert at position tests passed\n");
 }
 
@@ -177,7 +206,7 @@ void test_delete_at_position()
     doubly_ll_Node* head = build_list(arr, 4);
 
     /* Delete at position 0 */
-    assert(dll_deleteAtPosition(&head, 0) == 1);
+    assert(dll_deleteAtPosition(&head, 0, free) == 1);
 
     int out[3];
     int n = list_to_array(head, out, 3);
@@ -185,17 +214,17 @@ void test_delete_at_position()
     assert(out[0] == 2 && out[1] == 3 && out[2] == 4);
 
     /* Delete at position 1 (middle) */
-    assert(dll_deleteAtPosition(&head, 1) == 1);
+    assert(dll_deleteAtPosition(&head, 1, free) == 1);
 
     n = list_to_array(head, out, 3);
     assert(n == 2);
     assert(out[0] == 2 && out[1] == 4);
 
     /* Test invalid position */
-    assert(dll_deleteAtPosition(&head, 10) == -2);
-    assert(dll_deleteAtPosition(&head, -1) == -2);
+    assert(dll_deleteAtPosition(&head, 10, free) == -2);
+    assert(dll_deleteAtPosition(&head, -1, free) == -2);
 
-    delete_dll(head);
+    delete_dll(head, free);
     printf("DLL delete at position tests passed\n");
 }
 
@@ -204,21 +233,22 @@ void test_edge_cases()
 {
     doubly_ll_Node* head = NULL;
 
-    assert(dll_deleteAtBeginning(&head) == -1);
-    assert(dll_deleteAtEnd(&head) == -1);
+    assert(dll_deleteAtBeginning(&head, free) == -1);
+    assert(dll_deleteAtEnd(&head, free) == -1);
 
-    assert(dll_insertAtEnd(&head, 42) == 1);
+    int* val42 = malloc(sizeof(int));
+    *val42 = 42;
+    assert(dll_insertAtEnd(&head, val42) == 1);
 
     dll_reverselist(&head); // single node
 
-    delete_dll(head);
+    delete_dll(head, free);
 
     printf("DLL edge case tests passed\n");
 }
 
 int main()
 {
-
     test_insert();
     test_delete_begin();
     test_delete_end();


### PR DESCRIPTION
# PR Description:

## Overview
This PR implements **PR 1** of the generic linked list refactoring roadmap (Issue #859). It converts the Doubly Linked List (DLL) structures, library logic, demo menus, and unit tests to support generic `void*` pointers and customizable callbacks. 

---

## Proposed Changes

### 1. ⚙️ Generic Node Structure & Function Prototypes
* **File:** [dll.h](file:///e:/C-DSA-interactive-suite/src/data_structures/dll.h)
* Changed the `data` field of `doubly_ll_Node` from `int` to `void*`.
* Modified function signatures to accept generic pointers and callback handlers:
  * **Element Display:** `void dll_printlist(const doubly_ll_Node* head, void (*print_element)(const void*))`
  * **Key Search:** `int dll_search(const doubly_ll_Node* head, const void* key, int (*compare)(const void*, const void*))`
  * **Value Deletion:** `int dll_deleteByValue(doubly_ll_Node** head_ref, const void* key, int (*compare)(const void*, const void*), void (*free_data)(void*))`
  * **Destruction/Deletion:** Added `void (*free_data)(void*)` callback parameters to all list deletion functions and the main destructor `delete_dll` to ensure no memory is leaked when discarding heap-allocated node data.

### 2. 🧠 Generic DLL Core Implementations
* **File:** [dll.c](file:///e:/C-DSA-interactive-suite/src/data_structures/dll.c)
* Updated all pointer logic across SLL-equivalent operations to support generic data traversal.
* Integrated comparator fallback logic (reverting to raw pointer address checking `node->data == key` if the comparator parameter is `NULL`).
* Ensured data destructor callbacks are executed on the node payload before freeing the wrapper node memory.

### 3. 🖥️ Interactive Demo Adaptations
* **File:** [dll_demo.c](file:///e:/C-DSA-interactive-suite/demos/data_structures/dll_demo.c)
* Defined integer printing (`print_int`) and comparison (`compare_ints`) callbacks.
* Updated options flow to heap-allocate test values (`malloc(sizeof(int))`) on insertion.
* Passed `free` as the cleanup callback during list modifications/menu exit.

### 4. 🧪 Unit Test Enhancements
* **File:** [test_dll.c](file:///e:/C-DSA-interactive-suite/tests/data_structures/test_dll.c)
* Refactored helper utilities (`build_list` and `list_to_array`) to correctly handle allocated test structures.
* Adjusted assertions to cover all generic operations (passing search comparators and memory freeing callbacks).

---

## Verification Done
1. Verified compiler syntax checks:
   ```bash
   gcc -Wall -Wextra -Werror -std=c11 -o test_dll src/data_structures/dll.c tests/data_structures/test_dll.c -Isrc/data_structures -Isrc/utils
   ```
   Compilation completed with zero warnings or errors.
2. Ran the unit test binary:
   ```bash
   ./test_dll
   ```
   **Result:**
   ```text
   DLL insert tests passed
   DLL delete beginning tests passed
   DLL delete end tests passed
   DLL delete by value tests passed
   DLL search tests passed
   DLL reverse tests passed
   DLL insert at position tests passed
   DLL delete at position tests passed
   DLL edge case tests passed
   All DLL tests passed
   ```