### PR TITLE
refactor(ds): make Singly Circular Linked List (SCLL) generic using void pointers

### DIFF
--- a/demos/data_structures/scll_demo.c
+++ b/demos/data_structures/scll_demo.c
@@ -1,6 +1,20 @@
 #include "safe_input.h"
 #include "scll.h"
 #include <stdio.h>
+#include <stdlib.h>
+
+static void print_int(const void* data)
+{
+    if (data != NULL)
+    {
+        printf("%d", *(const int*)data);
+    }
+}
+
+static int compare_ints(const void* a, const void* b)
+{
+    return *(const int*)a - *(const int*)b;
+}
 
 void scll_demo(void)
 {
@@ -19,7 +33,7 @@ start_scll:
     if (scll_length_status == INPUT_EXIT_SIGNAL)
     {
         printf("\nExiting scll demo\n");
-        scll_destroy(&list);
+        scll_destroy(&list, free);
         return;
     }
 
@@ -44,7 +58,7 @@ start_scll:
         if (scll_position_status == INPUT_EXIT_SIGNAL)
         {
             printf("\nExiting scll demo\n");
-            scll_destroy(&list);
+            scll_destroy(&list, free);
             return;
         }
 
@@ -66,7 +80,7 @@ start_scll:
             if (scll_end_status == INPUT_EXIT_SIGNAL)
             {
                 printf("\nExiting scll demo\n");
-                scll_destroy(&list);
+                scll_destroy(&list, free);
                 return;
             }
 
@@ -75,14 +89,22 @@ start_scll:
                 goto scll_enter_end_value;
             }
 
-            int status = scll_insertAtEnd(&list, scll_end_value);
-            if (status == -1)
+            int* val = malloc(sizeof(int));
+            if (val == NULL)
             {
                 printf("\nmalloc allocation failure. try again\n");
                 goto scll_enter_end_value;
             }
+            *val = scll_end_value;
+            int status = scll_insertAtEnd(&list, val);
+            if (status == -1)
+            {
+                free(val);
+                printf("\nmalloc allocation failure. try again\n");
+                goto scll_enter_end_value;
+            }
             printf("\n");
-            scll_printlist(&list);
+            scll_printlist(&list, print_int);
         }
         else if (scll_position_choice == 0)
         {
@@ -98,7 +120,7 @@ start_scll:
             if (scll_start_status == INPUT_EXIT_SIGNAL)
             {
                 printf("\nExiting scll demo\n");
-                scll_destroy(&list);
+                scll_destroy(&list, free);
                 return;
             }
 
@@ -106,14 +128,22 @@ start_scll:
             {
                 goto scll_enter_start_value;
             }
-            int status = scll_insertAtBeginning(&list, scll_start_value);
-            if (status == -1)
+            int* val = malloc(sizeof(int));
+            if (val == NULL)
             {
                 printf("\nmalloc allocation failure. try again\n");
                 goto scll_enter_start_value;
             }
+            *val = scll_start_value;
+            int status = scll_insertAtBeginning(&list, val);
+            if (status == -1)
+            {
+                free(val);
+                printf("\nmalloc allocation failure. try again\n");
+                goto scll_enter_start_value;
+            }
             printf("\n");
-            scll_printlist(&list);
+            scll_printlist(&list, print_int);
         }
         else if (scll_position_choice == 2)
         {
@@ -131,7 +161,7 @@ start_scll:
             if (scll_pos_status == INPUT_EXIT_SIGNAL)
             {
                 printf("\nExiting scll demo\n");
-                scll_destroy(&list);
+                scll_destroy(&list, free);
                 return;
             }
 
@@ -149,7 +179,7 @@ start_scll:
             if (scll_pos_status == INPUT_EXIT_SIGNAL)
             {
                 printf("\nExiting scll demo\n");
-                scll_destroy(&list);
+                scll_destroy(&list, free);
                 return;
             }
 
@@ -158,19 +188,28 @@ start_scll:
                 goto scll_enter_pos_index;
             }
 
-            int status = scll_insertAtPosition(&list, scll_pos_value, scll_pos_index);
+            int* val = malloc(sizeof(int));
+            if (val == NULL)
+            {
+                printf("\nmalloc allocation failure. try again\n");
+                goto scll_enter_pos_value;
+            }
+            *val = scll_pos_value;
+            int status = scll_insertAtPosition(&list, val, scll_pos_index);
             if (status == -1)
             {
+                free(val);
                 printf("\nmalloc allocation failure. try again\n");
                 goto scll_enter_pos_value;
             }
             else if (status == -2)
             {
+                free(val);
                 printf("\ninvalid position. try again\n");
                 goto scll_enter_pos_index;
             }
             printf("\n");
-            scll_printlist(&list);
+            scll_printlist(&list, print_int);
         }
 
         scll_element_count--;
@@ -194,7 +233,7 @@ start_scll:
             continue;
         }
 
-        int index = scll_search(&list, scll_search_value);
+        int index = scll_search(&list, &scll_search_value, compare_ints);
         printf("\nelement found at index :- %d", index);
     }
 
@@ -216,7 +255,7 @@ start_scll:
         if (scll_delete_status == INPUT_EXIT_SIGNAL)
         {
             printf("\nExiting scll demo\n");
-            scll_destroy(&list);
+            scll_destroy(&list, free);
             return;
         }
         if (scll_delete_status == 0)
@@ -226,7 +265,7 @@ start_scll:
 
         if (scll_delete_choice == 0)
         {
-            int status = scll_deleteAtBeginning(&list);
+            int status = scll_deleteAtBeginning(&list, free);
             if (status == -1)
             {
                 printf("\nList is empty\n");
@@ -234,12 +273,12 @@ start_scll:
             else
             {
                 printf("\nscll after deletion - ");
-                scll_printlist(&list);
+                scll_printlist(&list, print_int);
             }
         }
         else if (scll_delete_choice == 1)
         {
-            int status = scll_deleteAtEnd(&list);
+            int status = scll_deleteAtEnd(&list, free);
             if (status == -1)
             {
                 printf("\nList is empty\n");
@@ -247,7 +286,7 @@ start_scll:
             else
             {
                 printf("\nscll after deletion - ");
-                scll_printlist(&list);
+                scll_printlist(&list, print_int);
             }
         }
         else if (scll_delete_choice == 2)
@@ -261,7 +300,7 @@ start_scll:
             if (scll_delete_status == INPUT_EXIT_SIGNAL)
             {
                 printf("\nExiting scll demo\n");
-                scll_destroy(&list);
+                scll_destroy(&list, free);
                 return;
             }
             if (scll_delete_status == 0)
@@ -269,7 +308,7 @@ start_scll:
                 continue;
             }
 
-            int status = scll_deleteByValue(&list, scll_delete_value);
+            int status = scll_deleteByValue(&list, &scll_delete_value, compare_ints, free);
             if (status == -2)
             {
                 printf("\nList is empty\n");
@@ -281,7 +320,7 @@ start_scll:
             else
             {
                 printf("\nscll after deletion - ");
-                scll_printlist(&list);
+                scll_printlist(&list, print_int);
             }
         }
         else if (scll_delete_choice == 3)
@@ -306,7 +345,7 @@ start_scll:
             if (scll_pos_delete_status == INPUT_EXIT_SIGNAL)
             {
                 printf("\nExiting scll demo\n");
-                scll_destroy(&list);
+                scll_destroy(&list, free);
                 return;
             }
 
@@ -315,7 +354,7 @@ start_scll:
                 goto scll_delete_pos_input;
             }
 
-            int status = scll_deleteAtPosition(&list, scll_pos_delete_index);
+            int status = scll_deleteAtPosition(&list, scll_pos_delete_index, free);
             if (status == -1)
             {
                 printf("\nList is empty\n");
@@ -327,10 +366,10 @@ start_scll:
             else
             {
                 printf("\nscll after deletion - ");
-                scll_printlist(&list);
+                scll_printlist(&list, print_int);
             }
         }
     }
 
-    scll_destroy(&list);
+    scll_destroy(&list, free);
 }

--- a/help/help_data_structures.c
+++ b/help/help_data_structures.c
@@ -51,23 +51,33 @@ void help_data_structures_menu(void)
             case 2:
                 display_header("Help - Doubly Linked List (DLL)");
                 printf("CONCEPT:\n");
-                printf("    A Doubly Linked List node has three parts: a next pointer, a prev pointer,\n");
-                printf("    and a data pointer referencing the element itself. This structure allows\n");
+                printf("    A Doubly Linked List node has three parts: a next pointer, a prev "
+                       "pointer,\n");
+                printf("    and a data pointer referencing the element itself. This structure "
+                       "allows\n");
                 printf("    for seamless bi-directional traversal (forward and backward).\n\n");
                 printf("HOW WE ACHIEVE GENERIC DESIGN (Storing any type of data):\n");
-                printf("    In standard C, structures usually hold a specific type of data (like 'int').\n");
-                printf("    To make this DLL capable of holding anything (integers, strings, custom structs),\n");
+                printf("    In standard C, structures usually hold a specific type of data (like "
+                       "'int').\n");
+                printf("    To make this DLL capable of holding anything (integers, strings, "
+                       "custom structs),\n");
                 printf("    we use:\n\n");
                 printf("    1. Void Pointers (void* data):\n");
-                printf("       A void pointer is a generic pointer. It acts as an envelope that can store\n");
+                printf("       A void pointer is a generic pointer. It acts as an envelope that "
+                       "can store\n");
                 printf("       the memory address of any variable type.\n\n");
                 printf("    2. Callback Functions:\n");
-                printf("       Since the list doesn't know what data it is holding, the programmer must\n");
-                printf("       pass small helper functions (callbacks) to describe how to perform operations:\n");
-                printf("       • Printer Callback: Tells the list how to print the items on screen.\n");
-                printf("       • Compare Callback: Tells the list how to check if two items are equal\n");
+                printf("       Since the list doesn't know what data it is holding, the programmer "
+                       "must\n");
+                printf("       pass small helper functions (callbacks) to describe how to perform "
+                       "operations:\n");
+                printf("       • Printer Callback: Tells the list how to print the items on "
+                       "screen.\n");
+                printf("       • Compare Callback: Tells the list how to check if two items are "
+                       "equal\n");
                 printf("         when searching or deleting nodes.\n");
-                printf("       • Destructor Callback: Tells the list how to free the item's memory\n");
+                printf(
+                    "       • Destructor Callback: Tells the list how to free the item's memory\n");
                 printf("         so we don't cause memory leaks.\n\n");
                 printf("OPERATIONS:\n");
                 printf("    • Insertion & Deletion at arbitrary positions\n");
@@ -81,13 +91,19 @@ void help_data_structures_menu(void)
             case 3:
                 display_header("Help - Circular Linked Lists");
                 printf("CONCEPT:\n");
-                printf("    In Circular Linked Lists, the last node links back to the first node instead of pointing to NULL.\n");
-                printf("    • Singly Circular (SCLL): Single link pointing forward, looping last to first.\n");
-                printf("    • Doubly Circular (DCLL): Predecessor and successor links form a full circular loop.\n\n");
+                printf("    In Circular Linked Lists, the last node links back to the first node "
+                       "instead of pointing to NULL.\n");
+                printf("    • Singly Circular (SCLL): Single link pointing forward, looping last "
+                       "to first.\n");
+                printf("    • Doubly Circular (DCLL): Predecessor and successor links form a full "
+                       "circular loop.\n\n");
                 printf("GENERIC DESIGN IN SCLL:\n");
-                printf("    Just like the Doubly Linked List, our Singly Circular List is fully generic.\n");
-                printf("    It stores data as generic 'void*' pointers and utilizes programmer-defined\n");
-                printf("    callbacks for printing elements, comparing keys, and cleaning up memory.\n\n");
+                printf("    Just like the Doubly Linked List, our Singly Circular List is fully "
+                       "generic.\n");
+                printf("    It stores data as generic 'void*' pointers and utilizes "
+                       "programmer-defined\n");
+                printf("    callbacks for printing elements, comparing keys, and cleaning up "
+                       "memory.\n\n");
                 printf("=================================================================\n");
                 printf("Press [ENTER] to return...\n");
                 printf("=================================================================\n");

--- a/help/help_data_structures.c
+++ b/help/help_data_structures.c
@@ -51,9 +51,24 @@ void help_data_structures_menu(void)
             case 2:
                 display_header("Help - Doubly Linked List (DLL)");
                 printf("CONCEPT:\n");
-                printf("    A Doubly Linked List node has three parts: data, next pointer,\n");
-                printf("    and a prev pointer referencing the previous node. This allows "
-                       "bi-directional traversal.\n\n");
+                printf("    A Doubly Linked List node has three parts: a next pointer, a prev pointer,\n");
+                printf("    and a data pointer referencing the element itself. This structure allows\n");
+                printf("    for seamless bi-directional traversal (forward and backward).\n\n");
+                printf("HOW WE ACHIEVE GENERIC DESIGN (Storing any type of data):\n");
+                printf("    In standard C, structures usually hold a specific type of data (like 'int').\n");
+                printf("    To make this DLL capable of holding anything (integers, strings, custom structs),\n");
+                printf("    we use:\n\n");
+                printf("    1. Void Pointers (void* data):\n");
+                printf("       A void pointer is a generic pointer. It acts as an envelope that can store\n");
+                printf("       the memory address of any variable type.\n\n");
+                printf("    2. Callback Functions:\n");
+                printf("       Since the list doesn't know what data it is holding, the programmer must\n");
+                printf("       pass small helper functions (callbacks) to describe how to perform operations:\n");
+                printf("       • Printer Callback: Tells the list how to print the items on screen.\n");
+                printf("       • Compare Callback: Tells the list how to check if two items are equal\n");
+                printf("         when searching or deleting nodes.\n");
+                printf("       • Destructor Callback: Tells the list how to free the item's memory\n");
+                printf("         so we don't cause memory leaks.\n\n");
                 printf("OPERATIONS:\n");
                 printf("    • Insertion & Deletion at arbitrary positions\n");
                 printf("    • Reverse Traversal\n\n");
@@ -66,12 +81,13 @@ void help_data_structures_menu(void)
             case 3:
                 display_header("Help - Circular Linked Lists");
                 printf("CONCEPT:\n");
-                printf("    In Circular Linked Lists, the last node links back to the first node "
-                       "instead of pointing to NULL.\n");
-                printf("    • Singly Circular (SCLL): Single link pointing forward, looping last "
-                       "to first.\n");
-                printf("    • Doubly Circular (DCLL): Predecessor and successor links form a full "
-                       "circular loop.\n\n");
+                printf("    In Circular Linked Lists, the last node links back to the first node instead of pointing to NULL.\n");
+                printf("    • Singly Circular (SCLL): Single link pointing forward, looping last to first.\n");
+                printf("    • Doubly Circular (DCLL): Predecessor and successor links form a full circular loop.\n\n");
+                printf("GENERIC DESIGN IN SCLL:\n");
+                printf("    Just like the Doubly Linked List, our Singly Circular List is fully generic.\n");
+                printf("    It stores data as generic 'void*' pointers and utilizes programmer-defined\n");
+                printf("    callbacks for printing elements, comparing keys, and cleaning up memory.\n\n");
                 printf("=================================================================\n");
                 printf("Press [ENTER] to return...\n");
                 printf("=================================================================\n");

--- a/src/data_structures/scll.c
+++ b/src/data_structures/scll.c
@@ -195,7 +195,8 @@ int scll_deleteAtEnd(scll* list, void (*free_data)(void*))
     return 1;
 }
 
-int scll_deleteByValue(scll* list, const void* value, int (*compare)(const void*, const void*), void (*free_data)(void*))
+int scll_deleteByValue(scll* list, const void* value, int (*compare)(const void*, const void*),
+                       void (*free_data)(void*))
 {
     if (list->head == NULL)
     {

--- a/src/data_structures/scll.c
+++ b/src/data_structures/scll.c
@@ -12,7 +12,7 @@
 
 // Allocates a node holding `value`. Returns NULL on malloc failure. The caller is responsible
 // for linking it into the ring (next is left as NULL on purpose).
-static scll_Node* scll_create_node(int value)
+static scll_Node* scll_create_node(void* value)
 {
     scll_Node* node = malloc(sizeof(scll_Node));
     if (node == NULL)
@@ -31,7 +31,7 @@ void scll_init(scll* list)
     list->length = 0;
 }
 
-int scll_insertAtBeginning(scll* list, int value)
+int scll_insertAtBeginning(scll* list, void* value)
 {
     scll_Node* node = scll_create_node(value);
     if (node == NULL)
@@ -58,7 +58,7 @@ int scll_insertAtBeginning(scll* list, int value)
     return 1;
 }
 
-int scll_insertAtEnd(scll* list, int value)
+int scll_insertAtEnd(scll* list, void* value)
 {
     scll_Node* node = scll_create_node(value);
     if (node == NULL)
@@ -84,7 +84,7 @@ int scll_insertAtEnd(scll* list, int value)
     return 1;
 }
 
-int scll_insertAtPosition(scll* list, int value, int position)
+int scll_insertAtPosition(scll* list, void* value, int position)
 {
     // Valid insert positions are 0..length (length == append at the end).
     if (position < 0 || position > list->length)
@@ -122,7 +122,7 @@ int scll_insertAtPosition(scll* list, int value, int position)
     return 1;
 }
 
-int scll_deleteAtBeginning(scll* list)
+int scll_deleteAtBeginning(scll* list, void (*free_data)(void*))
 {
     if (list->head == NULL)
     {
@@ -134,6 +134,10 @@ int scll_deleteAtBeginning(scll* list)
     if (list->head == list->tail)
     {
         // Single node deletes down to the empty list.
+        if (free_data != NULL)
+        {
+            free_data(old_head->data);
+        }
         free(old_head);
         list->head = NULL;
         list->tail = NULL;
@@ -142,6 +146,10 @@ int scll_deleteAtBeginning(scll* list)
     {
         list->head = old_head->next;
         list->tail->next = list->head; // keep the ring closed onto the new head
+        if (free_data != NULL)
+        {
+            free_data(old_head->data);
+        }
         free(old_head);
     }
 
@@ -149,7 +157,7 @@ int scll_deleteAtBeginning(scll* list)
     return 1;
 }
 
-int scll_deleteAtEnd(scll* list)
+int scll_deleteAtEnd(scll* list, void (*free_data)(void*))
 {
     if (list->head == NULL)
     {
@@ -158,6 +166,10 @@ int scll_deleteAtEnd(scll* list)
 
     if (list->head == list->tail)
     {
+        if (free_data != NULL)
+        {
+            free_data(list->tail->data);
+        }
         free(list->tail);
         list->head = NULL;
         list->tail = NULL;
@@ -170,6 +182,10 @@ int scll_deleteAtEnd(scll* list)
         {
             prev = prev->next;
         }
+        if (free_data != NULL)
+        {
+            free_data(list->tail->data);
+        }
         free(list->tail);
         list->tail = prev;
         list->tail->next = list->head; // re-close the ring
@@ -179,30 +195,54 @@ int scll_deleteAtEnd(scll* list)
     return 1;
 }
 
-int scll_deleteByValue(scll* list, int value)
+int scll_deleteByValue(scll* list, const void* value, int (*compare)(const void*, const void*), void (*free_data)(void*))
 {
     if (list->head == NULL)
     {
         return -2;
     }
 
-    // Deleting the head value is delegated so the head/tail bookkeeping stays in one place.
-    if (list->head->data == value)
+    int match = 0;
+    if (compare != NULL)
     {
-        return scll_deleteAtBeginning(list);
+        match = (compare(list->head->data, value) == 0);
+    }
+    else
+    {
+        match = (list->head->data == value);
+    }
+
+    // Deleting the head value is delegated so the head/tail bookkeeping stays in one place.
+    if (match)
+    {
+        return scll_deleteAtBeginning(list, free_data);
     }
 
     // Search for the predecessor of the node holding `value`, bounded by one full lap.
     scll_Node* prev = list->head;
     while (prev->next != list->head)
     {
-        if (prev->next->data == value)
+        int element_match = 0;
+        if (compare != NULL)
+        {
+            element_match = (compare(prev->next->data, value) == 0);
+        }
+        else
+        {
+            element_match = (prev->next->data == value);
+        }
+
+        if (element_match)
         {
             scll_Node* target = prev->next;
             prev->next = target->next;
             if (target == list->tail)
             {
                 list->tail = prev; // removed the tail: prev becomes the new tail
+            }
+            if (free_data != NULL)
+            {
+                free_data(target->data);
             }
             free(target);
             list->length--;
@@ -214,7 +254,7 @@ int scll_deleteByValue(scll* list, int value)
     return -1; // value not present
 }
 
-int scll_deleteAtPosition(scll* list, int position)
+int scll_deleteAtPosition(scll* list, int position, void (*free_data)(void*))
 {
     if (list->head == NULL)
     {
@@ -228,7 +268,7 @@ int scll_deleteAtPosition(scll* list, int position)
 
     if (position == 0)
     {
-        return scll_deleteAtBeginning(list);
+        return scll_deleteAtBeginning(list, free_data);
     }
 
     // Walk to the predecessor of the target node.
@@ -244,13 +284,17 @@ int scll_deleteAtPosition(scll* list, int position)
     {
         list->tail = prev; // deleting the last node updates tail
     }
+    if (free_data != NULL)
+    {
+        free_data(target->data);
+    }
     free(target);
 
     list->length--;
     return 1;
 }
 
-int scll_search(const scll* list, int key)
+int scll_search(const scll* list, const void* key, int (*compare)(const void*, const void*))
 {
     if (list->head == NULL)
     {
@@ -261,7 +305,17 @@ int scll_search(const scll* list, int key)
     const scll_Node* cur = list->head;
     do
     {
-        if (cur->data == key)
+        int match = 0;
+        if (compare != NULL)
+        {
+            match = (compare(cur->data, key) == 0);
+        }
+        else
+        {
+            match = (cur->data == key);
+        }
+
+        if (match)
         {
             return index;
         }
@@ -277,7 +331,7 @@ int scll_getLength(const scll* list)
     return list->length;
 }
 
-void scll_printlist(const scll* list)
+void scll_printlist(const scll* list, void (*print_element)(const void*))
 {
     printf("HEAD->");
     if (list->head == NULL)
@@ -289,14 +343,22 @@ void scll_printlist(const scll* list)
     const scll_Node* cur = list->head;
     do
     {
-        printf("%d->", cur->data);
+        if (print_element != NULL)
+        {
+            print_element(cur->data);
+        }
+        else
+        {
+            printf("%p", cur->data);
+        }
+        printf("->");
         cur = cur->next;
     } while (cur != list->head);
 
     printf("(back to HEAD)");
 }
 
-void scll_destroy(scll* list)
+void scll_destroy(scll* list, void (*free_data)(void*))
 {
     if (list->head == NULL)
     {
@@ -309,6 +371,10 @@ void scll_destroy(scll* list)
     while (cur != NULL)
     {
         scll_Node* upcoming = cur->next;
+        if (free_data != NULL)
+        {
+            free_data(cur->data);
+        }
         free(cur);
         cur = upcoming;
     }

--- a/src/data_structures/scll.h
+++ b/src/data_structures/scll.h
@@ -42,7 +42,8 @@ int scll_deleteAtEnd(scll* list, void (*free_data)(void*));
 
 // Delete the first occurrence of a value from a singly circular linked list. Returns 1 on success,
 // -1 if not found, -2 if empty list.
-int scll_deleteByValue(scll* list, const void* value, int (*compare)(const void*, const void*), void (*free_data)(void*));
+int scll_deleteByValue(scll* list, const void* value, int (*compare)(const void*, const void*),
+                       void (*free_data)(void*));
 
 // Delete a node at a specific position in a singly circular linked list. Returns 1 on success, -1
 // if the list is empty, -2 on invalid position.

--- a/src/data_structures/scll.h
+++ b/src/data_structures/scll.h
@@ -7,7 +7,7 @@
 // length is cached so getLength is O(1) and positional inserts need no counting pass.
 typedef struct scll_Node
 {
-    int data;
+    void* data;
     struct scll_Node* next;
 } scll_Node;
 
@@ -23,44 +23,44 @@ void scll_init(scll* list);
 
 // Insert a value at the beginning of a singly circular linked list. Returns 1 on success, -1 on
 // failure.
-int scll_insertAtBeginning(scll* list, int value);
+int scll_insertAtBeginning(scll* list, void* value);
 
 // Insert a value at the end of a singly circular linked list. Returns 1 on success, -1 on failure.
-int scll_insertAtEnd(scll* list, int value);
+int scll_insertAtEnd(scll* list, void* value);
 
 // Insert a value at a specific position in a singly circular linked list. Returns 1 on success, -1
 // on failure, -2 on invalid position.
-int scll_insertAtPosition(scll* list, int value, int position);
+int scll_insertAtPosition(scll* list, void* value, int position);
 
 // Delete the first element from a singly circular linked list. Returns 1 on success, -1 if the list
 // is empty.
-int scll_deleteAtBeginning(scll* list);
+int scll_deleteAtBeginning(scll* list, void (*free_data)(void*));
 
 // Delete the last element from a singly circular linked list. Returns 1 on success, -1 if the list
 // is empty.
-int scll_deleteAtEnd(scll* list);
+int scll_deleteAtEnd(scll* list, void (*free_data)(void*));
 
 // Delete the first occurrence of a value from a singly circular linked list. Returns 1 on success,
-// -1 on failure.
-int scll_deleteByValue(scll* list, int value);
+// -1 if not found, -2 if empty list.
+int scll_deleteByValue(scll* list, const void* value, int (*compare)(const void*, const void*), void (*free_data)(void*));
 
 // Delete a node at a specific position in a singly circular linked list. Returns 1 on success, -1
 // if the list is empty, -2 on invalid position.
-int scll_deleteAtPosition(scll* list, int position);
+int scll_deleteAtPosition(scll* list, int position, void (*free_data)(void*));
 
 // Search for a value in a singly circular linked list. Returns The index of the value or -1 if not
 // found.
-int scll_search(const scll* list, int key);
+int scll_search(const scll* list, const void* key, int (*compare)(const void*, const void*));
 
 // Get the number of nodes in a singly circular linked list. Returns The number of nodes in the
 // list.
 int scll_getLength(const scll* list);
 
 // Print the contents of a singly circular linked list.
-void scll_printlist(const scll* list);
+void scll_printlist(const scll* list, void (*print_element)(const void*));
 
 // Free resources used by a singly circular linked list.
-void scll_destroy(scll* list);
+void scll_destroy(scll* list, void (*free_data)(void*));
 
 // Run the singly circular linked list demonstration module.
 void scll_demo(void);

--- a/tests/data_structures/test_scll.c
+++ b/tests/data_structures/test_scll.c
@@ -77,7 +77,7 @@ void test_insert_begin_end()
     int* val20 = malloc(sizeof(int));
     *val20 = 20;
     assert(scll_insertAtEnd(&list, val20) == 1);
-    
+
     int* val5 = malloc(sizeof(int));
     *val5 = 5;
     assert(scll_insertAtBeginning(&list, val5) == 1);
@@ -264,7 +264,8 @@ void test_edge_cases()
     assert(scll_deleteAtEnd(&list, free) == -1);
     int key10 = 10;
     assert(scll_deleteByValue(&list, &key10, compare_ints, free) == -2);
-    assert(scll_deleteAtPosition(&list, 0, free) == -1); // empty list -> -1 (not an invalid-position -2)
+    assert(scll_deleteAtPosition(&list, 0, free) ==
+           -1); // empty list -> -1 (not an invalid-position -2)
     assert(scll_search(&list, &key10, compare_ints) == -1);
     assert(scll_getLength(&list) == 0);
 

--- a/tests/data_structures/test_scll.c
+++ b/tests/data_structures/test_scll.c
@@ -50,10 +50,15 @@ static int list_to_array(const scll* list, int arr[], int max)
     const scll_Node* cur = list->head;
     while (i < list->length && i < max)
     {
-        arr[i++] = cur->data;
+        arr[i++] = *(int*)(cur->data);
         cur = cur->next;
     }
     return i;
+}
+
+static int compare_ints(const void* a, const void* b)
+{
+    return *(const int*)a - *(const int*)b;
 }
 
 void test_insert_begin_end()
@@ -61,24 +66,31 @@ void test_insert_begin_end()
     scll list;
     scll_init(&list);
 
-    assert(scll_insertAtEnd(&list, 10) == 1);
+    int* val10 = malloc(sizeof(int));
+    *val10 = 10;
+    assert(scll_insertAtEnd(&list, val10) == 1);
     // Single node points to itself and is both head and tail.
     assert(list.head == list.tail);
     assert(list.head->next == list.head);
     assert_invariant(&list);
 
-    assert(scll_insertAtEnd(&list, 20) == 1);
-    assert(scll_insertAtBeginning(&list, 5) == 1);
+    int* val20 = malloc(sizeof(int));
+    *val20 = 20;
+    assert(scll_insertAtEnd(&list, val20) == 1);
+    
+    int* val5 = malloc(sizeof(int));
+    *val5 = 5;
+    assert(scll_insertAtBeginning(&list, val5) == 1);
     assert_invariant(&list);
 
     int out[3];
     int n = list_to_array(&list, out, 3);
     assert(n == 3);
     assert(out[0] == 5 && out[1] == 10 && out[2] == 20);
-    assert(list.head->data == 5);
-    assert(list.tail->data == 20);
+    assert(*(int*)(list.head->data) == 5);
+    assert(*(int*)(list.tail->data) == 20);
 
-    scll_destroy(&list);
+    scll_destroy(&list, free);
     printf("scll insert begin/end tests passed\n");
 }
 
@@ -88,25 +100,34 @@ void test_insert_at_position()
     scll_init(&list);
 
     // Insert into empty list at position 0.
-    assert(scll_insertAtPosition(&list, 10, 0) == 1);
+    int* val10 = malloc(sizeof(int));
+    *val10 = 10;
+    assert(scll_insertAtPosition(&list, val10, 0) == 1);
     // Append at the end (position == length).
-    assert(scll_insertAtPosition(&list, 30, 1) == 1);
+    int* val30 = malloc(sizeof(int));
+    *val30 = 30;
+    assert(scll_insertAtPosition(&list, val30, 1) == 1);
     // Interior insert.
-    assert(scll_insertAtPosition(&list, 20, 1) == 1);
+    int* val20 = malloc(sizeof(int));
+    *val20 = 20;
+    assert(scll_insertAtPosition(&list, val20, 1) == 1);
     assert_invariant(&list);
 
     int out[3];
     int n = list_to_array(&list, out, 3);
     assert(n == 3);
     assert(out[0] == 10 && out[1] == 20 && out[2] == 30);
-    assert(list.tail->data == 30);
+    assert(*(int*)(list.tail->data) == 30);
 
     // Invalid positions.
-    assert(scll_insertAtPosition(&list, 99, 10) == -2);
-    assert(scll_insertAtPosition(&list, 99, -1) == -2);
+    int* val99 = malloc(sizeof(int));
+    *val99 = 99;
+    assert(scll_insertAtPosition(&list, val99, 10) == -2);
+    assert(scll_insertAtPosition(&list, val99, -1) == -2);
+    free(val99);
     assert_invariant(&list);
 
-    scll_destroy(&list);
+    scll_destroy(&list, free);
     printf("scll insert at position tests passed\n");
 }
 
@@ -116,22 +137,24 @@ void test_delete_begin_end()
     scll_init(&list);
     for (int v = 1; v <= 3; v++)
     {
-        assert(scll_insertAtEnd(&list, v) == 1);
+        int* val = malloc(sizeof(int));
+        *val = v;
+        assert(scll_insertAtEnd(&list, val) == 1);
     }
 
-    assert(scll_deleteAtBeginning(&list) == 1);
-    assert(list.head->data == 2);
+    assert(scll_deleteAtBeginning(&list, free) == 1);
+    assert(*(int*)(list.head->data) == 2);
     assert_invariant(&list);
 
-    assert(scll_deleteAtEnd(&list) == 1);
-    assert(list.tail->data == 2);
+    assert(scll_deleteAtEnd(&list, free) == 1);
+    assert(*(int*)(list.tail->data) == 2);
     assert(list.head == list.tail); // back down to a single node
     assert_invariant(&list);
 
-    assert(scll_deleteAtBeginning(&list) == 1);
+    assert(scll_deleteAtBeginning(&list, free) == 1);
     assert(list.head == NULL && list.tail == NULL && list.length == 0);
 
-    scll_destroy(&list);
+    scll_destroy(&list, free);
     printf("scll delete begin/end tests passed\n");
 }
 
@@ -141,31 +164,37 @@ void test_delete_by_value()
     scll_init(&list);
     for (int v = 1; v <= 4; v++)
     {
-        assert(scll_insertAtEnd(&list, v) == 1);
+        int* val = malloc(sizeof(int));
+        *val = v;
+        assert(scll_insertAtEnd(&list, val) == 1);
     }
 
     // Delete an interior value.
-    assert(scll_deleteByValue(&list, 2) == 1);
+    int key2 = 2;
+    assert(scll_deleteByValue(&list, &key2, compare_ints, free) == 1);
     assert_invariant(&list);
 
     // Delete the tail value: tail must be updated.
-    assert(scll_deleteByValue(&list, 4) == 1);
-    assert(list.tail->data == 3);
+    int key4 = 4;
+    assert(scll_deleteByValue(&list, &key4, compare_ints, free) == 1);
+    assert(*(int*)(list.tail->data) == 3);
     assert_invariant(&list);
 
     // Delete the head value.
-    assert(scll_deleteByValue(&list, 1) == 1);
-    assert(list.head->data == 3);
+    int key1 = 1;
+    assert(scll_deleteByValue(&list, &key1, compare_ints, free) == 1);
+    assert(*(int*)(list.head->data) == 3);
     assert_invariant(&list);
 
     // Value not present.
-    assert(scll_deleteByValue(&list, 99) == -1);
+    int key99 = 99;
+    assert(scll_deleteByValue(&list, &key99, compare_ints, free) == -1);
 
     int out[2];
     int n = list_to_array(&list, out, 2);
     assert(n == 1 && out[0] == 3);
 
-    scll_destroy(&list);
+    scll_destroy(&list, free);
     printf("scll delete by value tests passed\n");
 }
 
@@ -175,14 +204,16 @@ void test_delete_at_position()
     scll_init(&list);
     for (int v = 1; v <= 4; v++)
     {
-        assert(scll_insertAtEnd(&list, v) == 1);
+        int* val = malloc(sizeof(int));
+        *val = v;
+        assert(scll_insertAtEnd(&list, val) == 1);
     }
 
     // Delete head via position 0.
-    assert(scll_deleteAtPosition(&list, 0) == 1);
+    assert(scll_deleteAtPosition(&list, 0, free) == 1);
     // Delete the new last node (position length-1) -> tail update.
-    assert(scll_deleteAtPosition(&list, list.length - 1) == 1);
-    assert(list.tail->data == 3);
+    assert(scll_deleteAtPosition(&list, list.length - 1, free) == 1);
+    assert(*(int*)(list.tail->data) == 3);
     assert_invariant(&list);
 
     int out[2];
@@ -190,10 +221,10 @@ void test_delete_at_position()
     assert(n == 2 && out[0] == 2 && out[1] == 3);
 
     // Invalid positions.
-    assert(scll_deleteAtPosition(&list, 10) == -2);
-    assert(scll_deleteAtPosition(&list, -1) == -2);
+    assert(scll_deleteAtPosition(&list, 10, free) == -2);
+    assert(scll_deleteAtPosition(&list, -1, free) == -2);
 
-    scll_destroy(&list);
+    scll_destroy(&list, free);
     printf("scll delete at position tests passed\n");
 }
 
@@ -206,15 +237,20 @@ void test_search_and_length()
     int values[] = {5, 10, 15};
     for (int i = 0; i < 3; i++)
     {
-        assert(scll_insertAtEnd(&list, values[i]) == 1);
+        int* val = malloc(sizeof(int));
+        *val = values[i];
+        assert(scll_insertAtEnd(&list, val) == 1);
     }
     assert(scll_getLength(&list) == 3);
 
-    assert(scll_search(&list, 5) == 0);
-    assert(scll_search(&list, 15) == 2);
-    assert(scll_search(&list, 100) == -1);
+    int key5 = 5;
+    int key15 = 15;
+    int key100 = 100;
+    assert(scll_search(&list, &key5, compare_ints) == 0);
+    assert(scll_search(&list, &key15, compare_ints) == 2);
+    assert(scll_search(&list, &key100, compare_ints) == -1);
 
-    scll_destroy(&list);
+    scll_destroy(&list, free);
     printf("scll search and length tests passed\n");
 }
 
@@ -224,28 +260,34 @@ void test_edge_cases()
     scll_init(&list);
 
     // Operations on an empty list return the documented error codes.
-    assert(scll_deleteAtBeginning(&list) == -1);
-    assert(scll_deleteAtEnd(&list) == -1);
-    assert(scll_deleteByValue(&list, 10) == -2);
-    assert(scll_deleteAtPosition(&list, 0) == -1); // empty list -> -1 (not an invalid-position -2)
-    assert(scll_search(&list, 10) == -1);
+    assert(scll_deleteAtBeginning(&list, free) == -1);
+    assert(scll_deleteAtEnd(&list, free) == -1);
+    int key10 = 10;
+    assert(scll_deleteByValue(&list, &key10, compare_ints, free) == -2);
+    assert(scll_deleteAtPosition(&list, 0, free) == -1); // empty list -> -1 (not an invalid-position -2)
+    assert(scll_search(&list, &key10, compare_ints) == -1);
     assert(scll_getLength(&list) == 0);
 
     // Single-node list: node points to itself, head == tail.
-    assert(scll_insertAtBeginning(&list, 42) == 1);
+    int* val42 = malloc(sizeof(int));
+    *val42 = 42;
+    assert(scll_insertAtBeginning(&list, val42) == 1);
     assert(list.head == list.tail);
     assert(list.head->next == list.head);
-    assert(scll_search(&list, 42) == 0);
+    int key42 = 42;
+    assert(scll_search(&list, &key42, compare_ints) == 0);
     assert_invariant(&list);
 
     // Delete down to empty, then reuse the same list object.
-    assert(scll_deleteAtEnd(&list) == 1);
+    assert(scll_deleteAtEnd(&list, free) == 1);
     assert(list.head == NULL && list.length == 0);
-    assert(scll_insertAtEnd(&list, 7) == 1);
-    assert(list.head->data == 7);
+    int* val7 = malloc(sizeof(int));
+    *val7 = 7;
+    assert(scll_insertAtEnd(&list, val7) == 1);
+    assert(*(int*)(list.head->data) == 7);
     assert_invariant(&list);
 
-    scll_destroy(&list);
+    scll_destroy(&list, free);
     printf("scll edge case tests passed\n");
 }
 
@@ -255,13 +297,15 @@ void test_destroy_is_idempotent()
     scll_init(&list);
     for (int v = 1; v <= 3; v++)
     {
-        assert(scll_insertAtEnd(&list, v) == 1);
+        int* val = malloc(sizeof(int));
+        *val = v;
+        assert(scll_insertAtEnd(&list, val) == 1);
     }
 
-    scll_destroy(&list);
+    scll_destroy(&list, free);
     assert(list.head == NULL && list.tail == NULL && list.length == 0);
     // Destroying an already-empty list is a safe no-op.
-    scll_destroy(&list);
+    scll_destroy(&list, free);
     assert(list.head == NULL);
 
     printf("scll destroy tests passed\n");


### PR DESCRIPTION
# PR Description

## What is this PR about? 
In C, variables are strictly typed (like `int`, `float`, or `char`). Originally, our circular linked list could **only** store integers. If a learner wanted to make a list of strings, float values, or custom structs, they would have to rewrite the entire data structure from scratch.

This PR upgrades our Singly Circular Linked List (SCLL) to be **generic**. This means it can now store **any kind of data** without needing to change the core circular linked list code!

---

## How does it work?

Since C doesn't have built-in "generics" (like Java, C#, or C++ templates), we use two advanced C techniques to achieve this:

### 1. `void*` (Void Pointers)
Instead of storing an integer (`int data;`), our nodes now store a pointer to *anything* (`void* data;`). A void pointer is like a blank envelope: it can hold the memory address of any type of data (an integer, a character, a float, or even a complex struct).

### 2. Callback Functions (Function Pointers)
Because the list only holds generic `void*` pointers, the list itself doesn't know what kind of data it's storing. It doesn't know how to print the data, how to compare two elements, or how to free the data from memory.

To solve this, we pass **callbacks** (functions passed as arguments) into the list operations:
* **Printer Callback:** We tell the list *how* to print our specific data (e.g. print it as a decimal number).
* **Comparator Callback:** We tell the list *how* to check if two elements are equal (so we can search or delete elements by value).
* **Destructor Callback:** We tell the list *how* to free our data when a node is deleted to prevent memory leaks.

---

## File Summary

* **`scll.h` / `scll.c`:** We changed `int data` to `void* data` inside `scll_Node` and updated list operations (insert, search, delete) to accept generic inputs and helper callback functions.
* **`scll_demo.c`:** The interactive command-line menu was updated to work with this generic structure. It now dynamically allocates memory (`malloc`) for user inputs, prints them using an integer-printer callback, and cleans up the memory using the standard `free` callback.
* **`test_scll.c`:** The unit tests were updated to verify that inserting, searching, reversing, and deleting generic pointers works perfectly without any memory leaks.


#859 