### PR TITLE
Feature: Implement core telemetry exporter engine and configuration (PR 1) (#677)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,7 @@ set(SRC_DIRS
     demos/searching_algorithms
     demos/advanced_graph_algorithms
     demos/string_algorithms
+    features/telemetry
 )
 
 # Header search paths

--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,7 @@ CFLAGS = -Wall -Wextra -Werror -std=c11 -g \
 	-Idemos/searching_algorithms \
 	-Idemos/advanced_graph_algorithms \
 	-Idemos/string_algorithms \
+	-Ifeatures/telemetry \
 	-Itui
 
 # LDFLAGS = -lncurses
@@ -74,7 +75,8 @@ SRC_DIRS = \
 	demos/graph_traversals \
 	demos/searching_algorithms \
 	demos/advanced_graph_algorithms \
-	demos/string_algorithms
+	demos/string_algorithms \
+	features/telemetry
 
 # SRCS = $(foreach dir,$(SRC_DIRS),$(wildcard $(dir)/*.c))
 # OBJS = $(patsubst %.c,$(OBJ_DIR)/%.o,$(SRCS))
@@ -102,7 +104,7 @@ endif
 SRCS = $(foreach dir,$(SRC_DIRS),$(wildcard $(dir)/*.c))
 SRCS := $(filter-out src/utils/io_utility.c,$(SRCS))
 OBJS = $(patsubst %.c,$(OBJ_DIR)/%.o,$(SRCS))
-HELP_OBJS = $(OBJ_DIR)/help/help.o $(OBJ_DIR)/help/help_data_structures.o $(OBJ_DIR)/help/help_sorting_searching.o $(OBJ_DIR)/help/help_graphs_trees.o $(OBJ_DIR)/help/help_advanced_topics.o $(OBJ_DIR)/help/help_expression_evaluation.o $(OBJ_DIR)/help/help_error_correction.o $(OBJ_DIR)/help/help_hashing.o
+HELP_OBJS = $(OBJ_DIR)/help/help.o $(OBJ_DIR)/help/help_data_structures.o $(OBJ_DIR)/help/help_sorting_searching.o $(OBJ_DIR)/help/help_graphs_trees.o $(OBJ_DIR)/help/help_advanced_topics.o $(OBJ_DIR)/help/help_expression_evaluation.o $(OBJ_DIR)/help/help_error_correction.o $(OBJ_DIR)/help/help_hashing.o $(OBJ_DIR)/features/telemetry/telemetry.o
 
 TARGET = dsa
 
@@ -171,7 +173,7 @@ TEST_BINS = test_circ_queue test_bst test_search test_hash_func \
             test_string_algorithms test_expression_evaluation \
             test_fcfs test_sjf test_srtf test_round_robin test_priority_scheduling test_preemptive_priority \
             test_dining_philosophers test_petersons test_producer_consumer \
-            test_dijkstra test_bellman_ford test_bfs test_dfs test_topological_sort test_benchmark test_scc test_ford_fulkerson test_edmonds_karp test_dinic test_bipartite_matching test_hopcroft_karp test_eulerian_path test_cache_simulator test_compression
+            test_dijkstra test_bellman_ford test_bfs test_dfs test_topological_sort test_benchmark test_scc test_ford_fulkerson test_edmonds_karp test_dinic test_bipartite_matching test_hopcroft_karp test_eulerian_path test_cache_simulator test_compression test_telemetry
 
 # Automatically find all advanced heap test sources and append their targets
 ADV_HEAP_TESTS = $(patsubst tests/advanced_heaps/%.c,%,$(wildcard tests/advanced_heaps/*.c))
@@ -848,6 +850,13 @@ test_compression: $(TEST_DIR)/test_compression$(EXE)
 	$(TEST_DIR)/test_compression$(EXE)
 
 $(TEST_DIR)/test_compression$(EXE): $(OBJ_DIR)/src/compression/rle.o $(OBJ_DIR)/src/compression/huffman.o $(OBJ_DIR)/src/compression/huffman_visualizer.o $(OBJ_DIR)/src/compression/lzw.o $(OBJ_DIR)/src/compression/bwt.o tests/compression/test_compression.c
+	@$(call MKDIR_P,$(TEST_DIR))
+	$(CC) $(CFLAGS) $^ -o $@ $(LDFLAGS)
+
+test_telemetry: $(TEST_DIR)/test_telemetry$(EXE)
+	$(TEST_DIR)/test_telemetry$(EXE)
+
+$(TEST_DIR)/test_telemetry$(EXE): $(OBJS) tests/telemetry/test_telemetry.c
 	@$(call MKDIR_P,$(TEST_DIR))
 	$(CC) $(CFLAGS) $^ -o $@ $(LDFLAGS)
 

--- a/features/telemetry/telemetry.c
+++ b/features/telemetry/telemetry.c
@@ -1,0 +1,156 @@
+#include "telemetry.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#ifdef _WIN32
+#include <direct.h>
+#endif
+
+static bool telemetry_enabled = false;
+static char telemetry_filepath[512] = "benchmarks/algo_trace.json";
+static bool is_first_entry = true;
+
+static void ensure_parent_dir_exists(const char* filepath)
+{
+    char temp[512];
+    strncpy(temp, filepath, sizeof(temp) - 1);
+    temp[sizeof(temp) - 1] = '\0';
+
+    char* last_slash = strrchr(temp, '/');
+#ifdef _WIN32
+    char* last_backslash = strrchr(temp, '\\');
+    if (last_backslash > last_slash)
+    {
+        last_slash = last_backslash;
+    }
+#endif
+
+    if (last_slash != NULL)
+    {
+        *last_slash = '\0';
+        if (strlen(temp) > 0)
+        {
+#ifdef _WIN32
+            _mkdir(temp);
+#else
+            struct stat st;
+            if (stat(temp, &st) == -1)
+            {
+                mkdir(temp, 0755);
+            }
+#endif
+        }
+    }
+}
+
+void set_telemetry_enabled(bool enabled)
+{
+    telemetry_enabled = enabled;
+}
+
+bool is_telemetry_enabled(void)
+{
+    return telemetry_enabled;
+}
+
+void set_telemetry_filepath(const char* filepath)
+{
+    if (filepath != NULL && strlen(filepath) > 0)
+    {
+        strncpy(telemetry_filepath, filepath, sizeof(telemetry_filepath) - 1);
+        telemetry_filepath[sizeof(telemetry_filepath) - 1] = '\0';
+    }
+}
+
+const char* get_telemetry_filepath(void)
+{
+    return telemetry_filepath;
+}
+
+void telemetry_init(void)
+{
+    if (!telemetry_enabled)
+    {
+        return;
+    }
+
+    ensure_parent_dir_exists(telemetry_filepath);
+
+    FILE* fp = fopen(telemetry_filepath, "w");
+    if (fp == NULL)
+    {
+        return;
+    }
+
+    fprintf(fp, "[\n");
+    fclose(fp);
+    is_first_entry = true;
+}
+
+void telemetry_export_state(const char* algorithm_name, int step, const int* arr, int size,
+                            const char* event_msg)
+{
+    if (!telemetry_enabled)
+    {
+        return;
+    }
+
+    FILE* fp = fopen(telemetry_filepath, "a");
+    if (fp == NULL)
+    {
+        return;
+    }
+
+    if (!is_first_entry)
+    {
+        fprintf(fp, ",\n");
+    }
+    is_first_entry = false;
+
+    fprintf(fp, "  {\n");
+    fprintf(fp, "    \"algorithm\": \"%s\",\n", algorithm_name ? algorithm_name : "unknown");
+    fprintf(fp, "    \"step\": %d,\n", step);
+
+    if (arr != NULL && size >= 0)
+    {
+        fprintf(fp, "    \"array\": [");
+        for (int i = 0; i < size; i++)
+        {
+            fprintf(fp, "%d", arr[i]);
+            if (i < size - 1)
+            {
+                fprintf(fp, ", ");
+            }
+        }
+        fprintf(fp, "],\n");
+    }
+    else
+    {
+        fprintf(fp, "    \"array\": null,\n");
+    }
+
+    fprintf(fp, "    \"message\": \"%s\"\n", event_msg ? event_msg : "");
+    fprintf(fp, "  }");
+
+    fclose(fp);
+}
+
+void telemetry_close(void)
+{
+    if (!telemetry_enabled)
+    {
+        return;
+    }
+
+    FILE* fp = fopen(telemetry_filepath, "a");
+    if (fp == NULL)
+    {
+        return;
+    }
+
+    fprintf(fp, "\n]\n");
+    fclose(fp);
+    is_first_entry = true;
+}

--- a/features/telemetry/telemetry.h
+++ b/features/telemetry/telemetry.h
@@ -1,0 +1,17 @@
+#ifndef TELEMETRY_H
+#define TELEMETRY_H
+
+#include <stdbool.h>
+
+void set_telemetry_enabled(bool enabled);
+bool is_telemetry_enabled(void);
+
+void set_telemetry_filepath(const char* filepath);
+const char* get_telemetry_filepath(void);
+
+void telemetry_init(void);
+void telemetry_export_state(const char* algorithm_name, int step, const int* arr, int size,
+                            const char* event_msg);
+void telemetry_close(void);
+
+#endif // TELEMETRY_H

--- a/src/utils/config.c
+++ b/src/utils/config.c
@@ -2,6 +2,7 @@
 #include "cross_platform_timer.h"
 #include "safe_input.h"
 #include "step_debugger.h"
+#include "telemetry.h"
 #include <stdio.h>
 
 #include <unistd.h>
@@ -151,3 +152,13 @@ int is_instant(void)
 }
 
 void init_windows_console(void) {}
+
+void set_telemetry_trace_enabled(int enabled)
+{
+    set_telemetry_enabled(enabled ? true : false);
+}
+
+int is_telemetry_trace_enabled(void)
+{
+    return is_telemetry_enabled() ? 1 : 0;
+}

--- a/src/utils/config.h
+++ b/src/utils/config.h
@@ -19,7 +19,10 @@ int is_instant(void);
 // Checks if the output is a terminal
 int is_terminal_interactive(void);
 
-// Centralized Windows console initialization for UTF-8 and ANSI colors
 void init_windows_console(void);
+
+// Getters/setters for telemetry tracing option
+void set_telemetry_trace_enabled(int enabled);
+int is_telemetry_trace_enabled(void);
 
 #endif

--- a/tests/telemetry/test_telemetry.c
+++ b/tests/telemetry/test_telemetry.c
@@ -1,0 +1,118 @@
+#include "telemetry.h"
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#ifdef _WIN32
+#include <direct.h>
+#endif
+
+static void ensure_dir_exists(const char* path)
+{
+#ifdef _WIN32
+    _mkdir(path);
+#else
+    struct stat st;
+    if (stat(path, &st) == -1)
+    {
+        mkdir(path, 0755);
+    }
+#endif
+}
+
+static void test_telemetry_enable_disable(void)
+{
+    set_telemetry_enabled(false);
+    assert(!is_telemetry_enabled());
+
+    set_telemetry_enabled(true);
+    assert(is_telemetry_enabled());
+}
+
+static void test_telemetry_filepath(void)
+{
+    set_telemetry_filepath("test_binaries/test_trace.json");
+    assert(strcmp(get_telemetry_filepath(), "test_binaries/test_trace.json") == 0);
+}
+
+static void test_telemetry_logging_flow(void)
+{
+    // Clean old test file if exists
+    ensure_dir_exists("test_binaries");
+    remove("test_binaries/test_trace.json");
+
+    set_telemetry_enabled(true);
+    set_telemetry_filepath("test_binaries/test_trace.json");
+
+    telemetry_init();
+
+    int arr1[] = {5, 3, 8};
+    telemetry_export_state("bubble_sort", 0, arr1, 3, "Initial array");
+
+    int arr2[] = {3, 5, 8};
+    telemetry_export_state("bubble_sort", 1, arr2, 3, "Swapped 5 and 3");
+
+    telemetry_close();
+
+    // Verify file contents
+    FILE* fp = fopen("test_binaries/test_trace.json", "r");
+    assert(fp != NULL);
+
+    char buffer[1024];
+    size_t bytes_read = fread(buffer, 1, sizeof(buffer) - 1, fp);
+    buffer[bytes_read] = '\0';
+    fclose(fp);
+
+    // Verify it contains trace components
+    assert(strstr(buffer, "\"algorithm\": \"bubble_sort\"") != NULL);
+    assert(strstr(buffer, "\"step\": 0") != NULL);
+    assert(strstr(buffer, "\"step\": 1") != NULL);
+    assert(strstr(buffer, "\"array\": [5, 3, 8]") != NULL);
+    assert(strstr(buffer, "\"array\": [3, 5, 8]") != NULL);
+    assert(strstr(buffer, "\"message\": \"Initial array\"") != NULL);
+    assert(strstr(buffer, "\"message\": \"Swapped 5 and 3\"") != NULL);
+
+    // Check JSON brackets/formatting
+    assert(buffer[0] == '[');
+    // Find last character (skipping whitespace/newlines)
+    int len = strlen(buffer);
+    while (len > 0 &&
+           (buffer[len - 1] == '\n' || buffer[len - 1] == ' ' || buffer[len - 1] == '\r'))
+    {
+        len--;
+    }
+    assert(buffer[len - 1] == ']');
+
+    // Clean up
+    remove("test_binaries/test_trace.json");
+}
+
+static void test_telemetry_disabled_flow(void)
+{
+    ensure_dir_exists("test_binaries");
+    remove("test_binaries/test_disabled.json");
+
+    set_telemetry_enabled(false);
+    set_telemetry_filepath("test_binaries/test_disabled.json");
+
+    telemetry_init();
+    int arr[] = {1, 2};
+    telemetry_export_state("test", 1, arr, 2, "Should not log");
+    telemetry_close();
+
+    FILE* fp = fopen("test_binaries/test_disabled.json", "r");
+    assert(fp == NULL); // File should not be created
+}
+
+int main(void)
+{
+    printf("Starting Telemetry unit tests...\n");
+    test_telemetry_enable_disable();
+    test_telemetry_filepath();
+    test_telemetry_logging_flow();
+    test_telemetry_disabled_flow();
+    printf("All Telemetry unit tests passed successfully!\n");
+    return 0;
+}


### PR DESCRIPTION
### Description
This PR implements the core engine for the Algorithmic Step-Telemetry Exporter (`features/telemetry`) and defines the global configurations. It adds generic state-exporting capabilities to dump execution trajectories into structured JSON traces.

### Resolves
* Resolves #677 (Core Engine part)

### Changes
- **[telemetry.h](file:///Users/akshatshukla/Library/Mobile%20Documents/com~apple~CloudDocs/Work/open/C_DSA_interactive_suite.git/features/telemetry/telemetry.h)**: Defines the interfaces for initializing, exporting steps, and closing the trace session.
- **[telemetry.c](file:///Users/akshatshukla/Library/Mobile%20Documents/com~apple~CloudDocs/Work/open/C_DSA_interactive_suite.git/features/telemetry/telemetry.c)**: Implements structured JSON file format logging (`[\n ... \n]`) safely and incrementally.
- **[config.h](file:///Users/akshatshukla/Library/Mobile%20Documents/com~apple~CloudDocs/Work/open/C_DSA_interactive_suite.git/src/utils/config.h)** & **[config.c](file:///Users/akshatshukla/Library/Mobile%20Documents/com~apple~CloudDocs/Work/open/C_DSA_interactive_suite.git/src/utils/config.c)**: Exposed global options `set_telemetry_trace_enabled` and `is_telemetry_trace_enabled` to handle exporter status throughout the library.
- **[CMakeLists.txt](file:///Users/akshatshukla/Library/Mobile%20Documents/com~apple~CloudDocs/Work/open/C_DSA_interactive_suite.git/CMakeLists.txt)** & **[Makefile](file:///Users/akshatshukla/Library/Mobile%20Documents/com~apple~CloudDocs/Work/open/C_DSA_interactive_suite.git/Makefile)**: Integrated the new telemetry module into the build system and correctly linked its objects across the test suite.
- **[test_telemetry.c](file:///Users/akshatshukla/Library/Mobile%20Documents/com~apple~CloudDocs/Work/open/C_DSA_interactive_suite.git/tests/telemetry/test_telemetry.c)**: Unit tests confirming file operations, formatting, and boundary cases.

### Verification & Testing
- Ran `make fmt` to verify proper style format.
- Compiled successfully with `make`.
- Ran unit tests with `make test` and confirmed all tests (including `test_telemetry`) pass successfully.