### PR TITLE
Feature: Hook Telemetry Exporter into Graph Algorithms & add CLI trace settings (PR 3) (#677)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,7 @@ set(SRC_DIRS
     demos/searching_algorithms
     demos/advanced_graph_algorithms
     demos/string_algorithms
+    features/telemetry
 )
 
 # Header search paths

--- a/Makefile
+++ b/Makefile
@@ -173,7 +173,7 @@ TEST_BINS = test_circ_queue test_bst test_search test_hash_func \
             test_string_algorithms test_expression_evaluation \
             test_fcfs test_sjf test_srtf test_round_robin test_priority_scheduling test_preemptive_priority \
             test_dining_philosophers test_petersons test_producer_consumer \
-            test_dijkstra test_bellman_ford test_bfs test_dfs test_topological_sort test_benchmark test_scc test_ford_fulkerson test_edmonds_karp test_dinic test_bipartite_matching test_hopcroft_karp test_eulerian_path test_cache_simulator test_compression test_telemetry
+            test_dijkstra test_bellman_ford test_bfs test_dfs test_topological_sort test_benchmark test_scc test_ford_fulkerson test_edmonds_karp test_dinic test_bipartite_matching test_hopcroft_karp test_eulerian_path test_cache_simulator test_compression test_telemetry test_sorting_telemetry
 
 # Automatically find all advanced heap test sources and append their targets
 ADV_HEAP_TESTS = $(patsubst tests/advanced_heaps/%.c,%,$(wildcard tests/advanced_heaps/*.c))
@@ -857,6 +857,13 @@ test_telemetry: $(TEST_DIR)/test_telemetry$(EXE)
 	$(TEST_DIR)/test_telemetry$(EXE)
 
 $(TEST_DIR)/test_telemetry$(EXE): $(OBJS) tests/telemetry/test_telemetry.c
+	@$(call MKDIR_P,$(TEST_DIR))
+	$(CC) $(CFLAGS) $^ -o $@ $(LDFLAGS)
+
+test_sorting_telemetry: $(TEST_DIR)/test_sorting_telemetry$(EXE)
+	$(TEST_DIR)/test_sorting_telemetry$(EXE)
+
+$(TEST_DIR)/test_sorting_telemetry$(EXE): $(OBJS) tests/telemetry/test_sorting_telemetry.c
 	@$(call MKDIR_P,$(TEST_DIR))
 	$(CC) $(CFLAGS) $^ -o $@ $(LDFLAGS)
 

--- a/Makefile
+++ b/Makefile
@@ -173,7 +173,7 @@ TEST_BINS = test_circ_queue test_bst test_search test_hash_func \
             test_string_algorithms test_expression_evaluation \
             test_fcfs test_sjf test_srtf test_round_robin test_priority_scheduling test_preemptive_priority \
             test_dining_philosophers test_petersons test_producer_consumer \
-            test_dijkstra test_bellman_ford test_bfs test_dfs test_topological_sort test_benchmark test_scc test_ford_fulkerson test_edmonds_karp test_dinic test_bipartite_matching test_hopcroft_karp test_eulerian_path test_cache_simulator test_compression test_telemetry test_sorting_telemetry
+            test_dijkstra test_bellman_ford test_bfs test_dfs test_topological_sort test_benchmark test_scc test_ford_fulkerson test_edmonds_karp test_dinic test_bipartite_matching test_hopcroft_karp test_eulerian_path test_cache_simulator test_compression test_telemetry test_sorting_telemetry test_graph_telemetry
 
 # Automatically find all advanced heap test sources and append their targets
 ADV_HEAP_TESTS = $(patsubst tests/advanced_heaps/%.c,%,$(wildcard tests/advanced_heaps/*.c))
@@ -864,6 +864,13 @@ test_sorting_telemetry: $(TEST_DIR)/test_sorting_telemetry$(EXE)
 	$(TEST_DIR)/test_sorting_telemetry$(EXE)
 
 $(TEST_DIR)/test_sorting_telemetry$(EXE): $(OBJS) tests/telemetry/test_sorting_telemetry.c
+	@$(call MKDIR_P,$(TEST_DIR))
+	$(CC) $(CFLAGS) $^ -o $@ $(LDFLAGS)
+
+test_graph_telemetry: $(TEST_DIR)/test_graph_telemetry$(EXE)
+	$(TEST_DIR)/test_graph_telemetry$(EXE)
+
+$(TEST_DIR)/test_graph_telemetry$(EXE): $(OBJS) tests/telemetry/test_graph_telemetry.c
 	@$(call MKDIR_P,$(TEST_DIR))
 	$(CC) $(CFLAGS) $^ -o $@ $(LDFLAGS)
 

--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,7 @@ CFLAGS = -Wall -Wextra -Werror -std=c11 -g \
 	-Idemos/searching_algorithms \
 	-Idemos/advanced_graph_algorithms \
 	-Idemos/string_algorithms \
+	-Ifeatures/telemetry \
 	-Itui
 
 # LDFLAGS = -lncurses
@@ -74,7 +75,8 @@ SRC_DIRS = \
 	demos/graph_traversals \
 	demos/searching_algorithms \
 	demos/advanced_graph_algorithms \
-	demos/string_algorithms
+	demos/string_algorithms \
+	features/telemetry
 
 # SRCS = $(foreach dir,$(SRC_DIRS),$(wildcard $(dir)/*.c))
 # OBJS = $(patsubst %.c,$(OBJ_DIR)/%.o,$(SRCS))
@@ -102,7 +104,7 @@ endif
 SRCS = $(foreach dir,$(SRC_DIRS),$(wildcard $(dir)/*.c))
 SRCS := $(filter-out src/utils/io_utility.c,$(SRCS))
 OBJS = $(patsubst %.c,$(OBJ_DIR)/%.o,$(SRCS))
-HELP_OBJS = $(OBJ_DIR)/help/help.o $(OBJ_DIR)/help/help_data_structures.o $(OBJ_DIR)/help/help_sorting_searching.o $(OBJ_DIR)/help/help_graphs_trees.o $(OBJ_DIR)/help/help_advanced_topics.o $(OBJ_DIR)/help/help_expression_evaluation.o $(OBJ_DIR)/help/help_error_correction.o $(OBJ_DIR)/help/help_hashing.o
+HELP_OBJS = $(OBJ_DIR)/help/help.o $(OBJ_DIR)/help/help_data_structures.o $(OBJ_DIR)/help/help_sorting_searching.o $(OBJ_DIR)/help/help_graphs_trees.o $(OBJ_DIR)/help/help_advanced_topics.o $(OBJ_DIR)/help/help_expression_evaluation.o $(OBJ_DIR)/help/help_error_correction.o $(OBJ_DIR)/help/help_hashing.o $(OBJ_DIR)/features/telemetry/telemetry.o
 
 TARGET = dsa
 
@@ -171,7 +173,7 @@ TEST_BINS = test_circ_queue test_bst test_search test_hash_func \
             test_string_algorithms test_expression_evaluation \
             test_fcfs test_sjf test_srtf test_round_robin test_priority_scheduling test_preemptive_priority \
             test_dining_philosophers test_petersons test_producer_consumer \
-            test_dijkstra test_bellman_ford test_bfs test_dfs test_topological_sort test_benchmark test_scc test_ford_fulkerson test_edmonds_karp test_dinic test_bipartite_matching test_hopcroft_karp test_eulerian_path test_cache_simulator test_compression
+            test_dijkstra test_bellman_ford test_bfs test_dfs test_topological_sort test_benchmark test_scc test_ford_fulkerson test_edmonds_karp test_dinic test_bipartite_matching test_hopcroft_karp test_eulerian_path test_cache_simulator test_compression test_telemetry
 
 # Automatically find all advanced heap test sources and append their targets
 ADV_HEAP_TESTS = $(patsubst tests/advanced_heaps/%.c,%,$(wildcard tests/advanced_heaps/*.c))
@@ -848,6 +850,13 @@ test_compression: $(TEST_DIR)/test_compression$(EXE)
 	$(TEST_DIR)/test_compression$(EXE)
 
 $(TEST_DIR)/test_compression$(EXE): $(OBJ_DIR)/src/compression/rle.o $(OBJ_DIR)/src/compression/huffman.o $(OBJ_DIR)/src/compression/huffman_visualizer.o $(OBJ_DIR)/src/compression/lzw.o $(OBJ_DIR)/src/compression/bwt.o tests/compression/test_compression.c
+	@$(call MKDIR_P,$(TEST_DIR))
+	$(CC) $(CFLAGS) $^ -o $@ $(LDFLAGS)
+
+test_telemetry: $(TEST_DIR)/test_telemetry$(EXE)
+	$(TEST_DIR)/test_telemetry$(EXE)
+
+$(TEST_DIR)/test_telemetry$(EXE): $(OBJS) tests/telemetry/test_telemetry.c
 	@$(call MKDIR_P,$(TEST_DIR))
 	$(CC) $(CFLAGS) $^ -o $@ $(LDFLAGS)
 

--- a/features/debugger/step_debugger.c
+++ b/features/debugger/step_debugger.c
@@ -1,4 +1,5 @@
 #include "step_debugger.h"
+#include "telemetry.h"
 #include <stdio.h>
 #include <string.h>
 
@@ -57,6 +58,11 @@ void algorithm_step_hook(const char* event_msg)
 {
     if (event_msg == NULL)
         return;
+
+    if (is_telemetry_enabled())
+    {
+        telemetry_log_step(NULL, 0, event_msg);
+    }
 
     // Shift events in circular log
     if (event_count < 5)

--- a/features/telemetry/telemetry.c
+++ b/features/telemetry/telemetry.c
@@ -69,11 +69,24 @@ const char* get_telemetry_filepath(void)
     return telemetry_filepath;
 }
 
-void telemetry_init(void)
+static char current_algorithm_name[128] = "unknown";
+static int current_step_count = 0;
+
+void telemetry_init(const char* algorithm_name)
 {
     if (!telemetry_enabled)
     {
         return;
+    }
+
+    if (algorithm_name != NULL)
+    {
+        strncpy(current_algorithm_name, algorithm_name, sizeof(current_algorithm_name) - 1);
+        current_algorithm_name[sizeof(current_algorithm_name) - 1] = '\0';
+    }
+    else
+    {
+        strcpy(current_algorithm_name, "unknown");
     }
 
     ensure_parent_dir_exists(telemetry_filepath);
@@ -87,6 +100,12 @@ void telemetry_init(void)
     fprintf(fp, "[\n");
     fclose(fp);
     is_first_entry = true;
+    current_step_count = 0;
+}
+
+void telemetry_log_step(const int* arr, int size, const char* event_msg)
+{
+    telemetry_export_state(current_algorithm_name, current_step_count++, arr, size, event_msg);
 }
 
 void telemetry_export_state(const char* algorithm_name, int step, const int* arr, int size,
@@ -153,4 +172,5 @@ void telemetry_close(void)
     fprintf(fp, "\n]\n");
     fclose(fp);
     is_first_entry = true;
+    current_step_count = 0;
 }

--- a/features/telemetry/telemetry.c
+++ b/features/telemetry/telemetry.c
@@ -1,0 +1,156 @@
+#include "telemetry.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#ifdef _WIN32
+#include <direct.h>
+#endif
+
+static bool telemetry_enabled = false;
+static char telemetry_filepath[512] = "benchmarks/algo_trace.json";
+static bool is_first_entry = true;
+
+static void ensure_parent_dir_exists(const char* filepath)
+{
+    char temp[512];
+    strncpy(temp, filepath, sizeof(temp) - 1);
+    temp[sizeof(temp) - 1] = '\0';
+
+    char* last_slash = strrchr(temp, '/');
+#ifdef _WIN32
+    char* last_backslash = strrchr(temp, '\\');
+    if (last_backslash > last_slash)
+    {
+        last_slash = last_backslash;
+    }
+#endif
+
+    if (last_slash != NULL)
+    {
+        *last_slash = '\0';
+        if (strlen(temp) > 0)
+        {
+#ifdef _WIN32
+            _mkdir(temp);
+#else
+            struct stat st;
+            if (stat(temp, &st) == -1)
+            {
+                mkdir(temp, 0755);
+            }
+#endif
+        }
+    }
+}
+
+void set_telemetry_enabled(bool enabled)
+{
+    telemetry_enabled = enabled;
+}
+
+bool is_telemetry_enabled(void)
+{
+    return telemetry_enabled;
+}
+
+void set_telemetry_filepath(const char* filepath)
+{
+    if (filepath != NULL && strlen(filepath) > 0)
+    {
+        strncpy(telemetry_filepath, filepath, sizeof(telemetry_filepath) - 1);
+        telemetry_filepath[sizeof(telemetry_filepath) - 1] = '\0';
+    }
+}
+
+const char* get_telemetry_filepath(void)
+{
+    return telemetry_filepath;
+}
+
+void telemetry_init(void)
+{
+    if (!telemetry_enabled)
+    {
+        return;
+    }
+
+    ensure_parent_dir_exists(telemetry_filepath);
+
+    FILE* fp = fopen(telemetry_filepath, "w");
+    if (fp == NULL)
+    {
+        return;
+    }
+
+    fprintf(fp, "[\n");
+    fclose(fp);
+    is_first_entry = true;
+}
+
+void telemetry_export_state(const char* algorithm_name, int step, const int* arr, int size,
+                            const char* event_msg)
+{
+    if (!telemetry_enabled)
+    {
+        return;
+    }
+
+    FILE* fp = fopen(telemetry_filepath, "a");
+    if (fp == NULL)
+    {
+        return;
+    }
+
+    if (!is_first_entry)
+    {
+        fprintf(fp, ",\n");
+    }
+    is_first_entry = false;
+
+    fprintf(fp, "  {\n");
+    fprintf(fp, "    \"algorithm\": \"%s\",\n", algorithm_name ? algorithm_name : "unknown");
+    fprintf(fp, "    \"step\": %d,\n", step);
+
+    if (arr != NULL && size >= 0)
+    {
+        fprintf(fp, "    \"array\": [");
+        for (int i = 0; i < size; i++)
+        {
+            fprintf(fp, "%d", arr[i]);
+            if (i < size - 1)
+            {
+                fprintf(fp, ", ");
+            }
+        }
+        fprintf(fp, "],\n");
+    }
+    else
+    {
+        fprintf(fp, "    \"array\": null,\n");
+    }
+
+    fprintf(fp, "    \"message\": \"%s\"\n", event_msg ? event_msg : "");
+    fprintf(fp, "  }");
+
+    fclose(fp);
+}
+
+void telemetry_close(void)
+{
+    if (!telemetry_enabled)
+    {
+        return;
+    }
+
+    FILE* fp = fopen(telemetry_filepath, "a");
+    if (fp == NULL)
+    {
+        return;
+    }
+
+    fprintf(fp, "\n]\n");
+    fclose(fp);
+    is_first_entry = true;
+}

--- a/features/telemetry/telemetry.h
+++ b/features/telemetry/telemetry.h
@@ -9,7 +9,8 @@ bool is_telemetry_enabled(void);
 void set_telemetry_filepath(const char* filepath);
 const char* get_telemetry_filepath(void);
 
-void telemetry_init(void);
+void telemetry_init(const char* algorithm_name);
+void telemetry_log_step(const int* arr, int size, const char* event_msg);
 void telemetry_export_state(const char* algorithm_name, int step, const int* arr, int size,
                             const char* event_msg);
 void telemetry_close(void);

--- a/features/telemetry/telemetry.h
+++ b/features/telemetry/telemetry.h
@@ -1,0 +1,17 @@
+#ifndef TELEMETRY_H
+#define TELEMETRY_H
+
+#include <stdbool.h>
+
+void set_telemetry_enabled(bool enabled);
+bool is_telemetry_enabled(void);
+
+void set_telemetry_filepath(const char* filepath);
+const char* get_telemetry_filepath(void);
+
+void telemetry_init(void);
+void telemetry_export_state(const char* algorithm_name, int step, const int* arr, int size,
+                            const char* event_msg);
+void telemetry_close(void);
+
+#endif // TELEMETRY_H

--- a/src/advanced_sorting_algorithms/bucket_sort.c
+++ b/src/advanced_sorting_algorithms/bucket_sort.c
@@ -3,6 +3,7 @@
 #include "safe_input.h"
 #include "sll.h"
 #include "sorting_visualizer.h"
+#include "telemetry.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <time.h>
@@ -153,7 +154,9 @@ static void bucket_sort_internal(int arr[], int n, int is_top_level, int total_l
 
 void bucket_sort(int arr[], int n)
 {
+    telemetry_init("bucket_sort");
     bucket_sort_internal(arr, n, 1, n);
+    telemetry_close();
 }
 
 void bucket_sort_demo(void)

--- a/src/advanced_sorting_algorithms/heap_sort.c
+++ b/src/advanced_sorting_algorithms/heap_sort.c
@@ -3,6 +3,7 @@
 #include "priority_queue.h"
 #include "safe_input.h"
 #include "sorting_visualizer.h"
+#include "telemetry.h"
 #include <stdio.h>
 #include <time.h>
 
@@ -22,9 +23,14 @@ void heap_sort(int arr[], int n)
     if (n <= 1)
         return;
 
+    telemetry_init("heap_sort");
+
     priority_queue* pq = pq_init(MIN_HEAP);
     if (pq == NULL)
+    {
+        telemetry_close();
         return;
+    }
 
     int inserted = 0;
     for (int i = 0; i < n; i++)
@@ -42,6 +48,7 @@ void heap_sort(int arr[], int n)
     }
 
     destroy_pq(pq);
+    telemetry_close();
 }
 
 void heap_sort_demo(void)

--- a/src/advanced_sorting_algorithms/merge_sort.c
+++ b/src/advanced_sorting_algorithms/merge_sort.c
@@ -1,6 +1,7 @@
 #include "advanced_sorting.h"
 #include "safe_input.h"
 #include "sorting_visualizer.h"
+#include "telemetry.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <time.h>
@@ -85,7 +86,9 @@ void merge_sort(int arr[], int n)
     {
         return;
     }
+    telemetry_init("merge_sort");
     merge_recursion(arr, 0, n - 1, n);
+    telemetry_close();
 }
 
 void merge_sort_demo(void)

--- a/src/advanced_sorting_algorithms/quick_sort.c
+++ b/src/advanced_sorting_algorithms/quick_sort.c
@@ -1,5 +1,6 @@
 #include "safe_input.h"
 #include "sorting_visualizer.h"
+#include "telemetry.h"
 #include <stdio.h>
 #include <time.h>
 
@@ -55,8 +56,10 @@ static void quicksort_recursive(int arr[], int low, int high, int total_len)
 
 void quicksort(int arr[], int low, int high)
 {
+    telemetry_init("quick_sort");
     int total_len = (high >= low) ? (high + 1) : 0;
     quicksort_recursive(arr, low, high, total_len);
+    telemetry_close();
 }
 
 void quicksort_demo(void)

--- a/src/advanced_sorting_algorithms/radix_sort.c
+++ b/src/advanced_sorting_algorithms/radix_sort.c
@@ -1,6 +1,7 @@
 #include "advanced_sorting.h"
 #include "safe_input.h"
 #include "sorting_visualizer.h"
+#include "telemetry.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <time.h>
@@ -67,12 +68,15 @@ void radix_sort(int arr[], int n)
         }
     }
 
+    telemetry_init("radix_sort");
+
     int max = get_max(arr, n);
 
     for (int exp = 1; max / exp > 0; exp *= 10)
     {
         counting_sort(arr, n, exp);
     }
+    telemetry_close();
 }
 
 void radix_sort_demo(void)

--- a/src/graph_traversals/bfs.c
+++ b/src/graph_traversals/bfs.c
@@ -3,6 +3,7 @@
 #include "returnMallocVal.h"
 #include "safe_input.h"
 #include "step_debugger.h"
+#include "telemetry.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -13,9 +14,11 @@
 // algorithm's efficiency.
 void bfs(Graph* graph, int start)
 {
+    telemetry_init("bfs");
     if (graph == NULL)
     {
         printf("\nError: NULL graph passed to BFS");
+        telemetry_close();
         return;
     }
     int size = graph->V;
@@ -27,6 +30,7 @@ void bfs(Graph* graph, int start)
     if (start < 0 || start >= size)
     {
         printf("\ninvalid node passed as starting node");
+        telemetry_close();
         return;
     }
 
@@ -35,6 +39,7 @@ void bfs(Graph* graph, int start)
     if (!init_circ_queue(size + 1, &nodes))
     {
         printf("\nerror initializing queue. returning....");
+        telemetry_close();
         return;
     }
 
@@ -88,6 +93,7 @@ void bfs(Graph* graph, int start)
     printf("\ntotal CPU time taken for BFS traversal:- %f seconds\n", total_t);
 
     destroy_circ_queue(&nodes);
+    telemetry_close();
 }
 
 Graph* create_graph(int V)

--- a/src/graph_traversals/dfs.c
+++ b/src/graph_traversals/dfs.c
@@ -2,6 +2,7 @@
 #include "safe_input.h"
 #include "stack.h"
 #include "step_debugger.h"
+#include "telemetry.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -14,9 +15,11 @@ void dfs(Graph* graph, int start);
 // algorithm's efficiency.
 void dfs(Graph* graph, int start)
 {
+    telemetry_init("dfs");
     if (graph == NULL)
     {
         printf("\nError: NULL graph passed to DFS");
+        telemetry_close();
         return;
     }
     int size = graph->V;
@@ -28,6 +31,7 @@ void dfs(Graph* graph, int start)
     if (start < 0 || start >= size)
     {
         printf("\ninvalid node passed as starting node");
+        telemetry_close();
         return;
     }
 
@@ -36,6 +40,7 @@ void dfs(Graph* graph, int start)
     if (nodes == NULL)
     {
         printf("stack could not be initialized due to a malloc failure");
+        telemetry_close();
         return;
     }
 
@@ -83,5 +88,6 @@ void dfs(Graph* graph, int start)
     printf("end\n");
     printf("\ntotal CPU time taken for DFS traversal:- %f seconds\n", total_t);
     destroyStack(nodes);
+    telemetry_close();
     return;
 }

--- a/src/graph_traversals/dijkstra.c
+++ b/src/graph_traversals/dijkstra.c
@@ -2,6 +2,7 @@
 #include "graph_traversals.h"
 #include "safe_input.h"
 #include "step_debugger.h"
+#include "telemetry.h"
 #include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -132,9 +133,11 @@ bool extractTop_pq_graph(PQ_graph* pq, PQ_graph_node* result)
 // and must not be treated as a measure of the algorithm's efficiency.
 void dijkstra(weightedGraph* graph, int start)
 {
+    telemetry_init("dijkstra");
     if (graph == NULL || start < 0 || start >= graph->V)
     {
         printf("\nError: invalid graph or starting node passed to Dijkstra");
+        telemetry_close();
         return;
     }
     int size = graph->V;
@@ -333,6 +336,7 @@ void dijkstra(weightedGraph* graph, int start)
     }
 
     printf("\ntotal CPU time taken for Dijkstra's algorithm:- %f seconds\n", total_t);
+    telemetry_close();
 }
 
 weightedGraph* create_weightedGraph(int V)

--- a/src/main.c
+++ b/src/main.c
@@ -203,7 +203,16 @@ int main(int argc, char* argv[])
         if (strcmp(argv[i], "--profile") == 0)
         {
             init_memory_tracker();
-            break;
+        }
+        else if (strcmp(argv[i], "--export-trace") == 0)
+        {
+            set_telemetry_trace_enabled(1);
+        }
+        else if (strcmp(argv[i], "--export-trace-path") == 0 && i + 1 < argc)
+        {
+            set_telemetry_trace_enabled(1);
+            set_telemetry_trace_filepath(argv[i + 1]);
+            i++;
         }
     }
 

--- a/src/sorting_algorithms_n2/bubble_sort.c
+++ b/src/sorting_algorithms_n2/bubble_sort.c
@@ -2,6 +2,7 @@
 #include "safe_input.h"
 #include "sorting_visualizer.h"
 #include "step_debugger.h"
+#include "telemetry.h"
 #include <stdio.h>
 #include <time.h>
 
@@ -12,6 +13,7 @@ void bubble_sort_optimized(int arr[], int length_of_array);
 // efficiency of the algorithm and is for demonstration only.
 void bubble_sort_optimized(int arr[], int length_of_array)
 {
+    telemetry_init("bubble_sort");
 
     clock_t start_t, end_t;
     double total_t;
@@ -56,4 +58,5 @@ void bubble_sort_optimized(int arr[], int length_of_array)
     printf("\nfinal array sorted by bubble sort is - ");
     print_array(arr, length_of_array);
     printf("\nTotal CPU time taken:- %f seconds", total_t);
+    telemetry_close();
 }

--- a/src/sorting_algorithms_n2/insertion_sort.c
+++ b/src/sorting_algorithms_n2/insertion_sort.c
@@ -2,6 +2,7 @@
 #include "safe_input.h"
 #include "sorting_visualizer.h"
 #include "step_debugger.h"
+#include "telemetry.h"
 #include <stdio.h>
 #include <time.h>
 
@@ -12,6 +13,7 @@ void insertion_sort(int arr[], int length_of_array);
 // efficiency of the algorithm and is for demonstration only.
 void insertion_sort(int arr[], int length_of_array)
 {
+    telemetry_init("insertion_sort");
 
     clock_t start_t, end_t;
     double total_t;
@@ -51,4 +53,5 @@ void insertion_sort(int arr[], int length_of_array)
     printf("\nfinal array sorted by insertion sort - ");
     print_array(arr, length_of_array);
     printf("\nTotal CPU time taken:- %f seconds", total_t);
+    telemetry_close();
 }

--- a/src/sorting_algorithms_n2/selection_sort.c
+++ b/src/sorting_algorithms_n2/selection_sort.c
@@ -2,6 +2,7 @@
 #include "safe_input.h"
 #include "sorting_visualizer.h"
 #include "step_debugger.h"
+#include "telemetry.h"
 #include <stdio.h>
 #include <time.h>
 
@@ -9,6 +10,7 @@ void selection_sort(int arr[], int length_of_array);
 
 void selection_sort(int arr[], int length_of_array)
 {
+    telemetry_init("selection_sort");
     clock_t start_t, end_t;
     double total_t;
 
@@ -56,4 +58,5 @@ void selection_sort(int arr[], int length_of_array)
     printf("\nfinal array sorted by selection sort is:- ");
     print_array(arr, length_of_array);
     printf("\nTotal CPU time taken:- %f seconds", total_t);
+    telemetry_close();
 }

--- a/src/sorting_algorithms_n2/shell_sort.c
+++ b/src/sorting_algorithms_n2/shell_sort.c
@@ -1,6 +1,7 @@
 #include "array.h"
 #include "safe_input.h"
 #include "sorting_visualizer.h"
+#include "telemetry.h"
 #include <stdio.h>
 #include <time.h>
 
@@ -12,6 +13,7 @@ void shell_sort(int arr[], int length_of_array);
 /* Performs shell sort using shell's original N/2, N/4... gap sequence */
 void shell_sort(int arr[], int length_of_array)
 {
+    telemetry_init("shell_sort");
     clock_t start_t, end_t;
     double total_t;
 
@@ -49,4 +51,5 @@ void shell_sort(int arr[], int length_of_array)
     printf("\nfinal array sorted by shell sort - ");
     print_array(arr, length_of_array);
     printf("\nTotal CPU time taken:- %f seconds", total_t);
+    telemetry_close();
 }

--- a/src/utils/config.c
+++ b/src/utils/config.c
@@ -42,7 +42,10 @@ int get_paused(void)
 #if defined(__GNUC__) || defined(__clang__)
 __attribute__((weak)) void algorithm_step_hook(const char* event_msg)
 {
-    (void)event_msg;
+    if (is_telemetry_enabled() && event_msg != NULL)
+    {
+        telemetry_log_step(NULL, 0, event_msg);
+    }
 }
 #endif
 
@@ -161,4 +164,14 @@ void set_telemetry_trace_enabled(int enabled)
 int is_telemetry_trace_enabled(void)
 {
     return is_telemetry_enabled() ? 1 : 0;
+}
+
+void set_telemetry_trace_filepath(const char* filepath)
+{
+    set_telemetry_filepath(filepath);
+}
+
+const char* get_telemetry_trace_filepath(void)
+{
+    return get_telemetry_filepath();
 }

--- a/src/utils/config.c
+++ b/src/utils/config.c
@@ -2,6 +2,7 @@
 #include "cross_platform_timer.h"
 #include "safe_input.h"
 #include "step_debugger.h"
+#include "telemetry.h"
 #include <stdio.h>
 
 #include <unistd.h>
@@ -151,3 +152,13 @@ int is_instant(void)
 }
 
 void init_windows_console(void) {}
+
+void set_telemetry_trace_enabled(int enabled)
+{
+    set_telemetry_enabled(enabled ? true : false);
+}
+
+int is_telemetry_trace_enabled(void)
+{
+    return is_telemetry_enabled() ? 1 : 0;
+}

--- a/src/utils/config.h
+++ b/src/utils/config.h
@@ -24,5 +24,7 @@ void init_windows_console(void);
 // Getters/setters for telemetry tracing option
 void set_telemetry_trace_enabled(int enabled);
 int is_telemetry_trace_enabled(void);
+void set_telemetry_trace_filepath(const char* filepath);
+const char* get_telemetry_trace_filepath(void);
 
 #endif

--- a/src/utils/config.h
+++ b/src/utils/config.h
@@ -19,7 +19,10 @@ int is_instant(void);
 // Checks if the output is a terminal
 int is_terminal_interactive(void);
 
-// Centralized Windows console initialization for UTF-8 and ANSI colors
 void init_windows_console(void);
+
+// Getters/setters for telemetry tracing option
+void set_telemetry_trace_enabled(int enabled);
+int is_telemetry_trace_enabled(void);
 
 #endif

--- a/src/utils/sorting_visualizer.c
+++ b/src/utils/sorting_visualizer.c
@@ -1,10 +1,16 @@
 #include "sorting_visualizer.h"
 #include "config.h"
+#include "telemetry.h"
 #include <stdio.h>
 
 void visualize_sort(const int arr[], int n, int active_idx1, int active_idx2, int pivot_idx,
                     const char* status_message)
 {
+    if (is_telemetry_enabled() && arr != NULL && n > 0)
+    {
+        telemetry_log_step(arr, n, status_message);
+    }
+
     if (arr == NULL || n <= 0 || !is_terminal_interactive())
     {
         return;

--- a/tests/telemetry/test_graph_telemetry.c
+++ b/tests/telemetry/test_graph_telemetry.c
@@ -1,0 +1,81 @@
+#include "graph_traversals.h"
+#include "telemetry.h"
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static void verify_telemetry_file(const char* expected_algo_name)
+{
+    FILE* fp = fopen("test_binaries/graph_trace.json", "r");
+    assert(fp != NULL);
+
+    char buffer[65536];
+    size_t bytes_read = fread(buffer, 1, sizeof(buffer) - 1, fp);
+    buffer[bytes_read] = '\0';
+    fclose(fp);
+
+    // Verify it is a valid JSON array and has the correct algorithm name
+    assert(buffer[0] == '[');
+    assert(strstr(buffer, expected_algo_name) != NULL);
+    assert(strstr(buffer, "\"step\":") != NULL);
+    assert(strstr(buffer, "\"message\":") != NULL);
+
+    int len = strlen(buffer);
+    while (len > 0 &&
+           (buffer[len - 1] == '\n' || buffer[len - 1] == ' ' || buffer[len - 1] == '\r'))
+    {
+        len--;
+    }
+    assert(buffer[len - 1] == ']');
+
+    // Clean up
+    remove("test_binaries/graph_trace.json");
+}
+
+static void test_dfs_telemetry(void)
+{
+    set_telemetry_enabled(true);
+    set_telemetry_filepath("test_binaries/graph_trace.json");
+
+    Graph* g = create_graph(4);
+    add_edge_undirected(g, 0, 1);
+    add_edge_undirected(g, 0, 2);
+    add_edge_undirected(g, 1, 2);
+    add_edge_undirected(g, 2, 0);
+    add_edge_undirected(g, 2, 3);
+    add_edge_undirected(g, 3, 3);
+
+    dfs(g, 2);
+
+    verify_telemetry_file("dfs");
+    free_graph(g);
+}
+
+static void test_bfs_telemetry(void)
+{
+    set_telemetry_enabled(true);
+    set_telemetry_filepath("test_binaries/graph_trace.json");
+
+    Graph* g = create_graph(4);
+    add_edge_undirected(g, 0, 1);
+    add_edge_undirected(g, 0, 2);
+    add_edge_undirected(g, 1, 2);
+    add_edge_undirected(g, 2, 0);
+    add_edge_undirected(g, 2, 3);
+    add_edge_undirected(g, 3, 3);
+
+    bfs(g, 2);
+
+    verify_telemetry_file("bfs");
+    free_graph(g);
+}
+
+int main(void)
+{
+    printf("Starting Graph Telemetry integration tests...\n");
+    test_dfs_telemetry();
+    test_bfs_telemetry();
+    printf("All Graph Telemetry integration tests passed successfully!\n");
+    return 0;
+}

--- a/tests/telemetry/test_sorting_telemetry.c
+++ b/tests/telemetry/test_sorting_telemetry.c
@@ -1,0 +1,149 @@
+#include "advanced_sorting.h"
+#include "sorting_algorithms_n2.h"
+#include "telemetry.h"
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static void verify_telemetry_file(const char* expected_algo_name)
+{
+    FILE* fp = fopen("test_binaries/sorting_trace.json", "r");
+    assert(fp != NULL);
+
+    char buffer[2048];
+    size_t bytes_read = fread(buffer, 1, sizeof(buffer) - 1, fp);
+    buffer[bytes_read] = '\0';
+    fclose(fp);
+
+    // Verify it is a valid JSON array and has the correct algorithm name
+    assert(buffer[0] == '[');
+    assert(strstr(buffer, expected_algo_name) != NULL);
+    assert(strstr(buffer, "\"step\":") != NULL);
+
+    int len = strlen(buffer);
+    while (len > 0 &&
+           (buffer[len - 1] == '\n' || buffer[len - 1] == ' ' || buffer[len - 1] == '\r'))
+    {
+        len--;
+    }
+    assert(buffer[len - 1] == ']');
+
+    // Clean up
+    remove("test_binaries/sorting_trace.json");
+}
+
+static void test_bubble_sort_telemetry(void)
+{
+    set_telemetry_enabled(true);
+    set_telemetry_filepath("test_binaries/sorting_trace.json");
+
+    int arr[] = {4, 2, 1, 3};
+    bubble_sort_optimized(arr, 4);
+
+    verify_telemetry_file("bubble_sort");
+}
+
+static void test_insertion_sort_telemetry(void)
+{
+    set_telemetry_enabled(true);
+    set_telemetry_filepath("test_binaries/sorting_trace.json");
+
+    int arr[] = {4, 2, 1, 3};
+    insertion_sort(arr, 4);
+
+    verify_telemetry_file("insertion_sort");
+}
+
+static void test_selection_sort_telemetry(void)
+{
+    set_telemetry_enabled(true);
+    set_telemetry_filepath("test_binaries/sorting_trace.json");
+
+    int arr[] = {4, 2, 1, 3};
+    selection_sort(arr, 4);
+
+    verify_telemetry_file("selection_sort");
+}
+
+static void test_shell_sort_telemetry(void)
+{
+    set_telemetry_enabled(true);
+    set_telemetry_filepath("test_binaries/sorting_trace.json");
+
+    int arr[] = {4, 2, 1, 3};
+    shell_sort(arr, 4);
+
+    verify_telemetry_file("shell_sort");
+}
+
+static void test_quick_sort_telemetry(void)
+{
+    set_telemetry_enabled(true);
+    set_telemetry_filepath("test_binaries/sorting_trace.json");
+
+    int arr[] = {4, 2, 1, 3};
+    quicksort(arr, 0, 3);
+
+    verify_telemetry_file("quick_sort");
+}
+
+static void test_merge_sort_telemetry(void)
+{
+    set_telemetry_enabled(true);
+    set_telemetry_filepath("test_binaries/sorting_trace.json");
+
+    int arr[] = {4, 2, 1, 3};
+    merge_sort(arr, 4);
+
+    verify_telemetry_file("merge_sort");
+}
+
+static void test_heap_sort_telemetry(void)
+{
+    set_telemetry_enabled(true);
+    set_telemetry_filepath("test_binaries/sorting_trace.json");
+
+    int arr[] = {4, 2, 1, 3};
+    heap_sort(arr, 4);
+
+    verify_telemetry_file("heap_sort");
+}
+
+static void test_radix_sort_telemetry(void)
+{
+    set_telemetry_enabled(true);
+    set_telemetry_filepath("test_binaries/sorting_trace.json");
+
+    int arr[] = {4, 2, 1, 3};
+    radix_sort(arr, 4);
+
+    verify_telemetry_file("radix_sort");
+}
+
+static void test_bucket_sort_telemetry(void)
+{
+    set_telemetry_enabled(true);
+    set_telemetry_filepath("test_binaries/sorting_trace.json");
+
+    int arr[] = {4, 2, 1, 3};
+    bucket_sort(arr, 4);
+
+    verify_telemetry_file("bucket_sort");
+}
+
+int main(void)
+{
+    printf("Starting Sorting Telemetry integration tests...\n");
+    test_bubble_sort_telemetry();
+    test_insertion_sort_telemetry();
+    test_selection_sort_telemetry();
+    test_shell_sort_telemetry();
+    test_quick_sort_telemetry();
+    test_merge_sort_telemetry();
+    test_heap_sort_telemetry();
+    test_radix_sort_telemetry();
+    test_bucket_sort_telemetry();
+    printf("All Sorting Telemetry integration tests passed successfully!\n");
+    return 0;
+}

--- a/tests/telemetry/test_sorting_telemetry.c
+++ b/tests/telemetry/test_sorting_telemetry.c
@@ -11,7 +11,7 @@ static void verify_telemetry_file(const char* expected_algo_name)
     FILE* fp = fopen("test_binaries/sorting_trace.json", "r");
     assert(fp != NULL);
 
-    char buffer[2048];
+    char buffer[65536];
     size_t bytes_read = fread(buffer, 1, sizeof(buffer) - 1, fp);
     buffer[bytes_read] = '\0';
     fclose(fp);

--- a/tests/telemetry/test_telemetry.c
+++ b/tests/telemetry/test_telemetry.c
@@ -46,13 +46,13 @@ static void test_telemetry_logging_flow(void)
     set_telemetry_enabled(true);
     set_telemetry_filepath("test_binaries/test_trace.json");
 
-    telemetry_init();
+    telemetry_init("bubble_sort");
 
     int arr1[] = {5, 3, 8};
-    telemetry_export_state("bubble_sort", 0, arr1, 3, "Initial array");
+    telemetry_log_step(arr1, 3, "Initial array");
 
     int arr2[] = {3, 5, 8};
-    telemetry_export_state("bubble_sort", 1, arr2, 3, "Swapped 5 and 3");
+    telemetry_log_step(arr2, 3, "Swapped 5 and 3");
 
     telemetry_close();
 
@@ -97,9 +97,9 @@ static void test_telemetry_disabled_flow(void)
     set_telemetry_enabled(false);
     set_telemetry_filepath("test_binaries/test_disabled.json");
 
-    telemetry_init();
+    telemetry_init("test");
     int arr[] = {1, 2};
-    telemetry_export_state("test", 1, arr, 2, "Should not log");
+    telemetry_log_step(arr, 2, "Should not log");
     telemetry_close();
 
     FILE* fp = fopen("test_binaries/test_disabled.json", "r");

--- a/tests/telemetry/test_telemetry.c
+++ b/tests/telemetry/test_telemetry.c
@@ -1,0 +1,118 @@
+#include "telemetry.h"
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#ifdef _WIN32
+#include <direct.h>
+#endif
+
+static void ensure_dir_exists(const char* path)
+{
+#ifdef _WIN32
+    _mkdir(path);
+#else
+    struct stat st;
+    if (stat(path, &st) == -1)
+    {
+        mkdir(path, 0755);
+    }
+#endif
+}
+
+static void test_telemetry_enable_disable(void)
+{
+    set_telemetry_enabled(false);
+    assert(!is_telemetry_enabled());
+
+    set_telemetry_enabled(true);
+    assert(is_telemetry_enabled());
+}
+
+static void test_telemetry_filepath(void)
+{
+    set_telemetry_filepath("test_binaries/test_trace.json");
+    assert(strcmp(get_telemetry_filepath(), "test_binaries/test_trace.json") == 0);
+}
+
+static void test_telemetry_logging_flow(void)
+{
+    // Clean old test file if exists
+    ensure_dir_exists("test_binaries");
+    remove("test_binaries/test_trace.json");
+
+    set_telemetry_enabled(true);
+    set_telemetry_filepath("test_binaries/test_trace.json");
+
+    telemetry_init();
+
+    int arr1[] = {5, 3, 8};
+    telemetry_export_state("bubble_sort", 0, arr1, 3, "Initial array");
+
+    int arr2[] = {3, 5, 8};
+    telemetry_export_state("bubble_sort", 1, arr2, 3, "Swapped 5 and 3");
+
+    telemetry_close();
+
+    // Verify file contents
+    FILE* fp = fopen("test_binaries/test_trace.json", "r");
+    assert(fp != NULL);
+
+    char buffer[1024];
+    size_t bytes_read = fread(buffer, 1, sizeof(buffer) - 1, fp);
+    buffer[bytes_read] = '\0';
+    fclose(fp);
+
+    // Verify it contains trace components
+    assert(strstr(buffer, "\"algorithm\": \"bubble_sort\"") != NULL);
+    assert(strstr(buffer, "\"step\": 0") != NULL);
+    assert(strstr(buffer, "\"step\": 1") != NULL);
+    assert(strstr(buffer, "\"array\": [5, 3, 8]") != NULL);
+    assert(strstr(buffer, "\"array\": [3, 5, 8]") != NULL);
+    assert(strstr(buffer, "\"message\": \"Initial array\"") != NULL);
+    assert(strstr(buffer, "\"message\": \"Swapped 5 and 3\"") != NULL);
+
+    // Check JSON brackets/formatting
+    assert(buffer[0] == '[');
+    // Find last character (skipping whitespace/newlines)
+    int len = strlen(buffer);
+    while (len > 0 &&
+           (buffer[len - 1] == '\n' || buffer[len - 1] == ' ' || buffer[len - 1] == '\r'))
+    {
+        len--;
+    }
+    assert(buffer[len - 1] == ']');
+
+    // Clean up
+    remove("test_binaries/test_trace.json");
+}
+
+static void test_telemetry_disabled_flow(void)
+{
+    ensure_dir_exists("test_binaries");
+    remove("test_binaries/test_disabled.json");
+
+    set_telemetry_enabled(false);
+    set_telemetry_filepath("test_binaries/test_disabled.json");
+
+    telemetry_init();
+    int arr[] = {1, 2};
+    telemetry_export_state("test", 1, arr, 2, "Should not log");
+    telemetry_close();
+
+    FILE* fp = fopen("test_binaries/test_disabled.json", "r");
+    assert(fp == NULL); // File should not be created
+}
+
+int main(void)
+{
+    printf("Starting Telemetry unit tests...\n");
+    test_telemetry_enable_disable();
+    test_telemetry_filepath();
+    test_telemetry_logging_flow();
+    test_telemetry_disabled_flow();
+    printf("All Telemetry unit tests passed successfully!\n");
+    return 0;
+}


### PR DESCRIPTION
### Description
This PR integrates the telemetry exporter into the Graph Traversal Algorithms and adds CLI options to control telemetry trace settings.

### Resolves
* Resolves #677 (Graph Integration & CLI Flags part)

### Changes
- **[main.c](file:///Users/akshatshukla/Library/Mobile%20Documents/com~apple~CloudDocs/Work/open/C_DSA_interactive_suite.git/src/main.c)**: Added parsing for command line flags:
  - `--export-trace`: Enables trace exporting.
  - `--export-trace-path <filepath>`: Enables trace exporting and overrides output path.
- **[config.h](file:///Users/akshatshukla/Library/Mobile%20Documents/com~apple~CloudDocs/Work/open/C_DSA_interactive_suite.git/src/utils/config.h)** & **[config.c](file:///Users/akshatshukla/Library/Mobile%20Documents/com~apple~CloudDocs/Work/open/C_DSA_interactive_suite.git/src/utils/config.c)**: Exposed filepath getters/setters.
- **[step_debugger.c](file:///Users/akshatshukla/Library/Mobile%20Documents/com~apple~CloudDocs/Work/open/C_DSA_interactive_suite.git/features/debugger/step_debugger.c)**: Hooked `telemetry_log_step` inside `algorithm_step_hook` so that any algorithm calling `algorithm_step_hook` will automatically export state/message telemetry.
- **Graph Algorithms**: Integrated `telemetry_init` and `telemetry_close` around DFS, BFS, and Dijkstra.
- **[test_graph_telemetry.c](file:///Users/akshatshukla/Library/Mobile%20Documents/com~apple~CloudDocs/Work/open/C_DSA_interactive_suite.git/tests/telemetry/test_graph_telemetry.c)**: Integration tests verifying telemetry logging for DFS and BFS.
- **[test_sorting_telemetry.c](file:///Users/akshatshukla/Library/Mobile%20Documents/com~apple~CloudDocs/Work/open/C_DSA_interactive_suite.git/tests/telemetry/test_sorting_telemetry.c)**: Increased trace buffer size to prevent read truncations.

### Verification & Testing
- Checked formatting using `make fmt`.
- Ran unit and integration tests (`make test` & `make test_graph_telemetry`) and verified all tests passed successfully.