### PR TITLE
refactor(ds): make Doubly Circular Linked List (DCLL) generic using void pointers

### DIFF
--- a/demos/data_structures/dcll_demo.c
+++ b/demos/data_structures/dcll_demo.c
@@ -1,6 +1,20 @@
 #include "dcll.h"
 #include "safe_input.h"
 #include <stdio.h>
+#include <stdlib.h>
+
+static void print_int(const void* data)
+{
+    if (data != NULL)
+    {
+        printf("%d", *(const int*)data);
+    }
+}
+
+static int compare_ints(const void* a, const void* b)
+{
+    return *(const int*)a - *(const int*)b;
+}
 
 void dcll_demo(void)
 {
@@ -19,7 +33,7 @@ start_dcll:
     if (dcll_length_status == INPUT_EXIT_SIGNAL)
     {
         printf("\nExiting dcll demo\n");
-        dcll_destroy(&list);
+        dcll_destroy(&list, free);
         return;
     }
 
@@ -44,7 +58,7 @@ start_dcll:
         if (dcll_position_status == INPUT_EXIT_SIGNAL)
         {
             printf("\nExiting dcll demo\n");
-            dcll_destroy(&list);
+            dcll_destroy(&list, free);
             return;
         }
 
@@ -66,7 +80,7 @@ start_dcll:
             if (dcll_end_status == INPUT_EXIT_SIGNAL)
             {
                 printf("\nExiting dcll demo\n");
-                dcll_destroy(&list);
+                dcll_destroy(&list, free);
                 return;
             }
 
@@ -75,14 +89,22 @@ start_dcll:
                 goto dcll_enter_end_value;
             }
 
-            int status = dcll_insertAtEnd(&list, dcll_end_value);
-            if (status == -1)
+            int* val = malloc(sizeof(int));
+            if (val == NULL)
             {
                 printf("\nmalloc allocation failure. try again\n");
                 goto dcll_enter_end_value;
             }
+            *val = dcll_end_value;
+            int status = dcll_insertAtEnd(&list, val);
+            if (status == -1)
+            {
+                free(val);
+                printf("\nmalloc allocation failure. try again\n");
+                goto dcll_enter_end_value;
+            }
             printf("\n");
-            dcll_printlist(&list);
+            dcll_printlist(&list, print_int);
         }
         else if (dcll_position_choice == 0)
         {
@@ -98,7 +120,7 @@ start_dcll:
             if (dcll_start_status == INPUT_EXIT_SIGNAL)
             {
                 printf("\nExiting dcll demo\n");
-                dcll_destroy(&list);
+                dcll_destroy(&list, free);
                 return;
             }
 
@@ -106,14 +128,22 @@ start_dcll:
             {
                 goto dcll_enter_start_value;
             }
-            int status = dcll_insertAtBeginning(&list, dcll_start_value);
-            if (status == -1)
+            int* val = malloc(sizeof(int));
+            if (val == NULL)
             {
                 printf("\nmalloc allocation failure. try again\n");
                 goto dcll_enter_start_value;
             }
+            *val = dcll_start_value;
+            int status = dcll_insertAtBeginning(&list, val);
+            if (status == -1)
+            {
+                free(val);
+                printf("\nmalloc allocation failure. try again\n");
+                goto dcll_enter_start_value;
+            }
             printf("\n");
-            dcll_printlist(&list);
+            dcll_printlist(&list, print_int);
         }
         else if (dcll_position_choice == 2)
         {
@@ -131,7 +161,7 @@ start_dcll:
             if (dcll_pos_status == INPUT_EXIT_SIGNAL)
             {
                 printf("\nExiting dcll demo\n");
-                dcll_destroy(&list);
+                dcll_destroy(&list, free);
                 return;
             }
 
@@ -149,7 +179,7 @@ start_dcll:
             if (dcll_pos_status == INPUT_EXIT_SIGNAL)
             {
                 printf("\nExiting dcll demo\n");
-                dcll_destroy(&list);
+                dcll_destroy(&list, free);
                 return;
             }
 
@@ -158,19 +188,28 @@ start_dcll:
                 goto dcll_enter_pos_index;
             }
 
-            int status = dcll_insertAtPosition(&list, dcll_pos_value, dcll_pos_index);
+            int* val = malloc(sizeof(int));
+            if (val == NULL)
+            {
+                printf("\nmalloc allocation failure. try again\n");
+                goto dcll_enter_pos_value;
+            }
+            *val = dcll_pos_value;
+            int status = dcll_insertAtPosition(&list, val, dcll_pos_index);
             if (status == -1)
             {
+                free(val);
                 printf("\nmalloc allocation failure. try again\n");
                 goto dcll_enter_pos_value;
             }
             else if (status == -2)
             {
+                free(val);
                 printf("\ninvalid position. try again\n");
                 goto dcll_enter_pos_index;
             }
             printf("\n");
-            dcll_printlist(&list);
+            dcll_printlist(&list, print_int);
         }
 
         dcll_element_count--;
@@ -194,7 +233,7 @@ start_dcll:
             continue;
         }
 
-        int index = dcll_search(&list, dcll_search_value);
+        int index = dcll_search(&list, &dcll_search_value, compare_ints);
         printf("\nelement found at index :- %d", index);
     }
 
@@ -216,7 +255,7 @@ start_dcll:
         if (dcll_delete_status == INPUT_EXIT_SIGNAL)
         {
             printf("\nExiting dcll demo\n");
-            dcll_destroy(&list);
+            dcll_destroy(&list, free);
             return;
         }
         if (dcll_delete_status == 0)
@@ -226,7 +265,7 @@ start_dcll:
 
         if (dcll_delete_choice == 0)
         {
-            int status = dcll_deleteAtBeginning(&list);
+            int status = dcll_deleteAtBeginning(&list, free);
             if (status == -1)
             {
                 printf("\nList is empty\n");
@@ -234,12 +273,12 @@ start_dcll:
             else
             {
                 printf("\ndcll after deletion - ");
-                dcll_printlist(&list);
+                dcll_printlist(&list, print_int);
             }
         }
         else if (dcll_delete_choice == 1)
         {
-            int status = dcll_deleteAtEnd(&list);
+            int status = dcll_deleteAtEnd(&list, free);
             if (status == -1)
             {
                 printf("\nList is empty\n");
@@ -247,7 +286,7 @@ start_dcll:
             else
             {
                 printf("\ndcll after deletion - ");
-                dcll_printlist(&list);
+                dcll_printlist(&list, print_int);
             }
         }
         else if (dcll_delete_choice == 2)
@@ -261,7 +300,7 @@ start_dcll:
             if (dcll_delete_status == INPUT_EXIT_SIGNAL)
             {
                 printf("\nExiting dcll demo\n");
-                dcll_destroy(&list);
+                dcll_destroy(&list, free);
                 return;
             }
             if (dcll_delete_status == 0)
@@ -269,7 +308,7 @@ start_dcll:
                 continue;
             }
 
-            int status = dcll_deleteByValue(&list, dcll_delete_value);
+            int status = dcll_deleteByValue(&list, &dcll_delete_value, compare_ints, free);
             if (status == -2)
             {
                 printf("\nList is empty\n");
@@ -281,7 +320,7 @@ start_dcll:
             else
             {
                 printf("\ndcll after deletion - ");
-                dcll_printlist(&list);
+                dcll_printlist(&list, print_int);
             }
         }
         else if (dcll_delete_choice == 3)
@@ -306,7 +345,7 @@ start_dcll:
             if (dcll_pos_delete_status == INPUT_EXIT_SIGNAL)
             {
                 printf("\nExiting dcll demo\n");
-                dcll_destroy(&list);
+                dcll_destroy(&list, free);
                 return;
             }
 
@@ -315,7 +354,7 @@ start_dcll:
                 goto dcll_delete_pos_input;
             }
 
-            int status = dcll_deleteAtPosition(&list, dcll_pos_delete_index);
+            int status = dcll_deleteAtPosition(&list, dcll_pos_delete_index, free);
             if (status == -1)
             {
                 printf("\nList is empty\n");
@@ -327,10 +366,10 @@ start_dcll:
             else
             {
                 printf("\ndcll after deletion - ");
-                dcll_printlist(&list);
+                dcll_printlist(&list, print_int);
             }
         }
     }
 
-    dcll_destroy(&list);
+    dcll_destroy(&list, free);
 }

--- a/help/help_data_structures.c
+++ b/help/help_data_structures.c
@@ -91,19 +91,20 @@ void help_data_structures_menu(void)
             case 3:
                 display_header("Help - Circular Linked Lists");
                 printf("CONCEPT:\n");
-                printf("    In Circular Linked Lists, the last node links back to the first node "
-                       "instead of pointing to NULL.\n");
+                printf(
+                    "    In Circular Linked Lists, the last node links back to the first node\n");
+                printf("    instead of pointing to NULL.\n");
                 printf("    • Singly Circular (SCLL): Single link pointing forward, looping last "
                        "to first.\n");
                 printf("    • Doubly Circular (DCLL): Predecessor and successor links form a full "
                        "circular loop.\n\n");
-                printf("GENERIC DESIGN IN SCLL:\n");
-                printf("    Just like the Doubly Linked List, our Singly Circular List is fully "
-                       "generic.\n");
-                printf("    It stores data as generic 'void*' pointers and utilizes "
-                       "programmer-defined\n");
-                printf("    callbacks for printing elements, comparing keys, and cleaning up "
-                       "memory.\n\n");
+                printf("HOW WE ACHIEVE GENERIC DESIGN (Storing any type of data):\n");
+                printf("    Both our SCLL and DCLL implementations are fully generic using void "
+                       "pointers (void* data).\n");
+                printf("    This allows the circular lists to hold integers, strings, or custom "
+                       "structures.\n");
+                printf("    Just like the DLL, you pass helper callbacks for printing, searching, "
+                       "and freeing memory.\n\n");
                 printf("=================================================================\n");
                 printf("Press [ENTER] to return...\n");
                 printf("=================================================================\n");

--- a/src/data_structures/dcll.c
+++ b/src/data_structures/dcll.c
@@ -16,7 +16,7 @@
 // Allocates a node holding `value`. Returns NULL on malloc failure. The caller is responsible
 // for linking it into the ring (next and prev are left as NULL on purpose).
 
-static dcll_Node* dcll_create_node(int value)
+static dcll_Node* dcll_create_node(void* value)
 {
     dcll_Node* node = malloc(sizeof(dcll_Node));
     if (node == NULL)
@@ -36,7 +36,7 @@ void dcll_init(dcll* list)
     list->length = 0;
 }
 
-int dcll_insertAtBeginning(dcll* list, int value)
+int dcll_insertAtBeginning(dcll* list, void* value)
 {
     dcll_Node* node = dcll_create_node(value);
     if (node == NULL)
@@ -66,7 +66,7 @@ int dcll_insertAtBeginning(dcll* list, int value)
     return 1;
 }
 
-int dcll_insertAtEnd(dcll* list, int value)
+int dcll_insertAtEnd(dcll* list, void* value)
 {
     dcll_Node* node = dcll_create_node(value);
     if (node == NULL)
@@ -96,7 +96,7 @@ int dcll_insertAtEnd(dcll* list, int value)
     return 1;
 }
 
-int dcll_insertAtPosition(dcll* list, int value, int position)
+int dcll_insertAtPosition(dcll* list, void* value, int position)
 {
     // Valid insert positions are 0..length (length == append at the end).
     if (position < 0 || position > list->length)
@@ -136,7 +136,7 @@ int dcll_insertAtPosition(dcll* list, int value, int position)
     return 1;
 }
 
-int dcll_deleteAtBeginning(dcll* list)
+int dcll_deleteAtBeginning(dcll* list, void (*free_data)(void*))
 {
     if (list->head == NULL)
     {
@@ -148,6 +148,10 @@ int dcll_deleteAtBeginning(dcll* list)
     if (list->head == list->tail)
     {
         // Single node deletes down to the empty list.
+        if (free_data != NULL)
+        {
+            free_data(old_head->data);
+        }
         free(old_head);
         list->head = NULL;
         list->tail = NULL;
@@ -157,6 +161,10 @@ int dcll_deleteAtBeginning(dcll* list)
         list->head = old_head->next;
         list->head->prev = list->tail; // new head's prev closes onto tail
         list->tail->next = list->head; // tail closes ring onto new head
+        if (free_data != NULL)
+        {
+            free_data(old_head->data);
+        }
         free(old_head);
     }
 
@@ -164,7 +172,7 @@ int dcll_deleteAtBeginning(dcll* list)
     return 1;
 }
 
-int dcll_deleteAtEnd(dcll* list)
+int dcll_deleteAtEnd(dcll* list, void (*free_data)(void*))
 {
     if (list->head == NULL)
     {
@@ -176,6 +184,10 @@ int dcll_deleteAtEnd(dcll* list)
     if (list->head == list->tail)
     {
         // Single node deletes down to the empty list.
+        if (free_data != NULL)
+        {
+            free_data(old_tail->data);
+        }
         free(old_tail);
         list->head = NULL;
         list->tail = NULL;
@@ -186,6 +198,10 @@ int dcll_deleteAtEnd(dcll* list)
         list->tail = old_tail->prev;
         list->tail->next = list->head; // re-close the ring forward
         list->head->prev = list->tail; // re-close the ring backward
+        if (free_data != NULL)
+        {
+            free_data(old_tail->data);
+        }
         free(old_tail);
     }
 
@@ -193,30 +209,55 @@ int dcll_deleteAtEnd(dcll* list)
     return 1;
 }
 
-int dcll_deleteByValue(dcll* list, int value)
+int dcll_deleteByValue(dcll* list, const void* value, int (*compare)(const void*, const void*),
+                       void (*free_data)(void*))
 {
     if (list->head == NULL)
     {
         return -2;
     }
 
-    // Deleting the head value is delegated so the head/tail bookkeeping stays in one place.
-    if (list->head->data == value)
+    int match = 0;
+    if (compare != NULL)
     {
-        return dcll_deleteAtBeginning(list);
+        match = (compare(list->head->data, value) == 0);
+    }
+    else
+    {
+        match = (list->head->data == value);
+    }
+
+    // Deleting the head value is delegated so the head/tail bookkeeping stays in one place.
+    if (match)
+    {
+        return dcll_deleteAtBeginning(list, free_data);
     }
 
     // Search for the node holding `value`, bounded by one full lap.
     dcll_Node* cur = list->head->next;
     while (cur != list->head)
     {
-        if (cur->data == value)
+        int element_match = 0;
+        if (compare != NULL)
+        {
+            element_match = (compare(cur->data, value) == 0);
+        }
+        else
+        {
+            element_match = (cur->data == value);
+        }
+
+        if (element_match)
         {
             cur->prev->next = cur->next;
             cur->next->prev = cur->prev;
             if (cur == list->tail)
             {
                 list->tail = cur->prev; // removed the tail: prev becomes the new tail
+            }
+            if (free_data != NULL)
+            {
+                free_data(cur->data);
             }
             free(cur);
             list->length--;
@@ -228,7 +269,7 @@ int dcll_deleteByValue(dcll* list, int value)
     return -1; // value not present
 }
 
-int dcll_deleteAtPosition(dcll* list, int position)
+int dcll_deleteAtPosition(dcll* list, int position, void (*free_data)(void*))
 {
     if (list->head == NULL)
     {
@@ -242,12 +283,12 @@ int dcll_deleteAtPosition(dcll* list, int position)
 
     if (position == 0)
     {
-        return dcll_deleteAtBeginning(list);
+        return dcll_deleteAtBeginning(list, free_data);
     }
 
     if (position == list->length - 1)
     {
-        return dcll_deleteAtEnd(list);
+        return dcll_deleteAtEnd(list, free_data);
     }
 
     // Walk to the target node.
@@ -259,13 +300,17 @@ int dcll_deleteAtPosition(dcll* list, int position)
 
     target->prev->next = target->next;
     target->next->prev = target->prev;
+    if (free_data != NULL)
+    {
+        free_data(target->data);
+    }
     free(target);
 
     list->length--;
     return 1;
 }
 
-int dcll_search(const dcll* list, int key)
+int dcll_search(const dcll* list, const void* key, int (*compare)(const void*, const void*))
 {
     if (list->head == NULL)
     {
@@ -276,7 +321,17 @@ int dcll_search(const dcll* list, int key)
     const dcll_Node* cur = list->head;
     do
     {
-        if (cur->data == key)
+        int match = 0;
+        if (compare != NULL)
+        {
+            match = (compare(cur->data, key) == 0);
+        }
+        else
+        {
+            match = (cur->data == key);
+        }
+
+        if (match)
         {
             return index;
         }
@@ -292,7 +347,7 @@ int dcll_getLength(const dcll* list)
     return list->length;
 }
 
-void dcll_printlist(const dcll* list)
+void dcll_printlist(const dcll* list, void (*print_element)(const void*))
 {
     printf("HEAD->");
     if (list->head == NULL)
@@ -304,14 +359,22 @@ void dcll_printlist(const dcll* list)
     const dcll_Node* cur = list->head;
     do
     {
-        printf("%d->", cur->data);
+        if (print_element != NULL)
+        {
+            print_element(cur->data);
+        }
+        else
+        {
+            printf("%p", cur->data);
+        }
+        printf("->");
         cur = cur->next;
     } while (cur != list->head);
 
     printf("(back to HEAD)");
 }
 
-void dcll_destroy(dcll* list)
+void dcll_destroy(dcll* list, void (*free_data)(void*))
 {
     if (list->head == NULL)
     {
@@ -324,6 +387,10 @@ void dcll_destroy(dcll* list)
     while (cur != NULL)
     {
         dcll_Node* upcoming = cur->next;
+        if (free_data != NULL)
+        {
+            free_data(cur->data);
+        }
         free(cur);
         cur = upcoming;
     }

--- a/src/data_structures/dcll.h
+++ b/src/data_structures/dcll.h
@@ -5,7 +5,7 @@
 
 typedef struct dcll_Node
 {
-    int data;
+    void* data;
     struct dcll_Node* next;
     struct dcll_Node* prev;
 } dcll_Node;
@@ -22,44 +22,45 @@ void dcll_init(dcll* list);
 
 // Insert a value at the beginning of a doubly circular linked list. Returns 1 on success, -1 on
 // failure.
-int dcll_insertAtBeginning(dcll* list, int value);
+int dcll_insertAtBeginning(dcll* list, void* value);
 
 // Insert a value at the end of a doubly circular linked list. Returns 1 on success, -1 on failure.
-int dcll_insertAtEnd(dcll* list, int value);
+int dcll_insertAtEnd(dcll* list, void* value);
 
 // Insert a value at a specific position in a doubly circular linked list. Returns 1 on success, -1
 // on failure, -2 on invalid position.
-int dcll_insertAtPosition(dcll* list, int value, int position);
+int dcll_insertAtPosition(dcll* list, void* value, int position);
 
 // Delete the first element from a doubly circular linked list. Returns 1 on success, -1 if the list
 // is empty.
-int dcll_deleteAtBeginning(dcll* list);
+int dcll_deleteAtBeginning(dcll* list, void (*free_data)(void*));
 
 // Delete the last element from a doubly circular linked list. Returns 1 on success, -1 if the list
 // is empty.
-int dcll_deleteAtEnd(dcll* list);
+int dcll_deleteAtEnd(dcll* list, void (*free_data)(void*));
 
 // Delete the first occurrence of a value from a doubly circular linked list. Returns 1 on success,
-// -1 if not found.
-int dcll_deleteByValue(dcll* list, int value);
+// -1 if not found, -2 if empty list.
+int dcll_deleteByValue(dcll* list, const void* value, int (*compare)(const void*, const void*),
+                       void (*free_data)(void*));
 
 // Delete a node at a specific position in a doubly circular linked list. Returns 1 on success, -1
 // if the list is empty, -2 on invalid position.
-int dcll_deleteAtPosition(dcll* list, int position);
+int dcll_deleteAtPosition(dcll* list, int position, void (*free_data)(void*));
 
 // Search for a value in a doubly circular linked list. Returns The index of the value or -1 if not
 // found.
-int dcll_search(const dcll* list, int key);
+int dcll_search(const dcll* list, const void* key, int (*compare)(const void*, const void*));
 
 // Get the number of nodes in a doubly circular linked list. Returns The number of nodes in the
 // list.
 int dcll_getLength(const dcll* list);
 
 // Print the contents of a doubly circular linked list.
-void dcll_printlist(const dcll* list);
+void dcll_printlist(const dcll* list, void (*print_element)(const void*));
 
 // Free resources used by a doubly circular linked list.
-void dcll_destroy(dcll* list);
+void dcll_destroy(dcll* list, void (*free_data)(void*));
 
 // Run the doubly circular linked list demonstration module.
 void dcll_demo(void);

--- a/tests/data_structures/test_dcll.c
+++ b/tests/data_structures/test_dcll.c
@@ -50,7 +50,7 @@ static int list_to_array(const dcll* list, int arr[], int max)
     const dcll_Node* cur = list->head;
     while (i < list->length && i < max)
     {
-        arr[i++] = cur->data;
+        arr[i++] = *(int*)(cur->data);
         cur = cur->next;
     }
     return i;
@@ -68,10 +68,15 @@ static int list_to_array_reverse(const dcll* list, int arr[], int max)
     const dcll_Node* cur = list->tail;
     while (i < list->length && i < max)
     {
-        arr[i++] = cur->data;
+        arr[i++] = *(int*)(cur->data);
         cur = cur->prev;
     }
     return i;
+}
+
+static int compare_ints(const void* a, const void* b)
+{
+    return *(const int*)a - *(const int*)b;
 }
 
 void test_insert_begin_end()
@@ -79,23 +84,30 @@ void test_insert_begin_end()
     dcll list;
     dcll_init(&list);
 
-    assert(dcll_insertAtEnd(&list, 10) == 1);
+    int* val10 = malloc(sizeof(int));
+    *val10 = 10;
+    assert(dcll_insertAtEnd(&list, val10) == 1);
     // Single node points to itself in both directions and is both head and tail.
     assert(list.head == list.tail);
     assert(list.head->next == list.head);
     assert(list.head->prev == list.head);
     assert_invariant(&list);
 
-    assert(dcll_insertAtEnd(&list, 20) == 1);
-    assert(dcll_insertAtBeginning(&list, 5) == 1);
+    int* val20 = malloc(sizeof(int));
+    *val20 = 20;
+    assert(dcll_insertAtEnd(&list, val20) == 1);
+
+    int* val5 = malloc(sizeof(int));
+    *val5 = 5;
+    assert(dcll_insertAtBeginning(&list, val5) == 1);
     assert_invariant(&list);
 
     int out[3];
     int n = list_to_array(&list, out, 3);
     assert(n == 3);
     assert(out[0] == 5 && out[1] == 10 && out[2] == 20);
-    assert(list.head->data == 5);
-    assert(list.tail->data == 20);
+    assert(*(int*)(list.head->data) == 5);
+    assert(*(int*)(list.tail->data) == 20);
 
     // Verify prev pointers by walking backward.
     int rev[3];
@@ -103,7 +115,7 @@ void test_insert_begin_end()
     assert(m == 3);
     assert(rev[0] == 20 && rev[1] == 10 && rev[2] == 5);
 
-    dcll_destroy(&list);
+    dcll_destroy(&list, free);
     printf("dcll insert begin/end tests passed\n");
 }
 
@@ -113,25 +125,34 @@ void test_insert_at_position()
     dcll_init(&list);
 
     // Insert into empty list at position 0.
-    assert(dcll_insertAtPosition(&list, 10, 0) == 1);
+    int* val10 = malloc(sizeof(int));
+    *val10 = 10;
+    assert(dcll_insertAtPosition(&list, val10, 0) == 1);
     // Append at the end (position == length).
-    assert(dcll_insertAtPosition(&list, 30, 1) == 1);
+    int* val30 = malloc(sizeof(int));
+    *val30 = 30;
+    assert(dcll_insertAtPosition(&list, val30, 1) == 1);
     // Interior insert.
-    assert(dcll_insertAtPosition(&list, 20, 1) == 1);
+    int* val20 = malloc(sizeof(int));
+    *val20 = 20;
+    assert(dcll_insertAtPosition(&list, val20, 1) == 1);
     assert_invariant(&list);
 
     int out[3];
     int n = list_to_array(&list, out, 3);
     assert(n == 3);
     assert(out[0] == 10 && out[1] == 20 && out[2] == 30);
-    assert(list.tail->data == 30);
+    assert(*(int*)(list.tail->data) == 30);
 
     // Invalid positions.
-    assert(dcll_insertAtPosition(&list, 99, 10) == -2);
-    assert(dcll_insertAtPosition(&list, 99, -1) == -2);
+    int* val99 = malloc(sizeof(int));
+    *val99 = 99;
+    assert(dcll_insertAtPosition(&list, val99, 10) == -2);
+    assert(dcll_insertAtPosition(&list, val99, -1) == -2);
+    free(val99);
     assert_invariant(&list);
 
-    dcll_destroy(&list);
+    dcll_destroy(&list, free);
     printf("dcll insert at position tests passed\n");
 }
 
@@ -141,22 +162,24 @@ void test_delete_begin_end()
     dcll_init(&list);
     for (int v = 1; v <= 3; v++)
     {
-        assert(dcll_insertAtEnd(&list, v) == 1);
+        int* val = malloc(sizeof(int));
+        *val = v;
+        assert(dcll_insertAtEnd(&list, val) == 1);
     }
 
-    assert(dcll_deleteAtBeginning(&list) == 1);
-    assert(list.head->data == 2);
+    assert(dcll_deleteAtBeginning(&list, free) == 1);
+    assert(*(int*)(list.head->data) == 2);
     assert_invariant(&list);
 
-    assert(dcll_deleteAtEnd(&list) == 1);
-    assert(list.tail->data == 2);
+    assert(dcll_deleteAtEnd(&list, free) == 1);
+    assert(*(int*)(list.tail->data) == 2);
     assert(list.head == list.tail); // back down to a single node
     assert_invariant(&list);
 
-    assert(dcll_deleteAtBeginning(&list) == 1);
+    assert(dcll_deleteAtBeginning(&list, free) == 1);
     assert(list.head == NULL && list.tail == NULL && list.length == 0);
 
-    dcll_destroy(&list);
+    dcll_destroy(&list, free);
     printf("dcll delete begin/end tests passed\n");
 }
 
@@ -166,31 +189,37 @@ void test_delete_by_value()
     dcll_init(&list);
     for (int v = 1; v <= 4; v++)
     {
-        assert(dcll_insertAtEnd(&list, v) == 1);
+        int* val = malloc(sizeof(int));
+        *val = v;
+        assert(dcll_insertAtEnd(&list, val) == 1);
     }
 
     // Delete an interior value.
-    assert(dcll_deleteByValue(&list, 2) == 1);
+    int key2 = 2;
+    assert(dcll_deleteByValue(&list, &key2, compare_ints, free) == 1);
     assert_invariant(&list);
 
     // Delete the tail value: tail must be updated.
-    assert(dcll_deleteByValue(&list, 4) == 1);
-    assert(list.tail->data == 3);
+    int key4 = 4;
+    assert(dcll_deleteByValue(&list, &key4, compare_ints, free) == 1);
+    assert(*(int*)(list.tail->data) == 3);
     assert_invariant(&list);
 
     // Delete the head value.
-    assert(dcll_deleteByValue(&list, 1) == 1);
-    assert(list.head->data == 3);
+    int key1 = 1;
+    assert(dcll_deleteByValue(&list, &key1, compare_ints, free) == 1);
+    assert(*(int*)(list.head->data) == 3);
     assert_invariant(&list);
 
     // Value not present.
-    assert(dcll_deleteByValue(&list, 99) == -1);
+    int key99 = 99;
+    assert(dcll_deleteByValue(&list, &key99, compare_ints, free) == -1);
 
     int out[2];
     int n = list_to_array(&list, out, 2);
     assert(n == 1 && out[0] == 3);
 
-    dcll_destroy(&list);
+    dcll_destroy(&list, free);
     printf("dcll delete by value tests passed\n");
 }
 
@@ -200,14 +229,16 @@ void test_delete_at_position()
     dcll_init(&list);
     for (int v = 1; v <= 4; v++)
     {
-        assert(dcll_insertAtEnd(&list, v) == 1);
+        int* val = malloc(sizeof(int));
+        *val = v;
+        assert(dcll_insertAtEnd(&list, val) == 1);
     }
 
     // Delete head via position 0.
-    assert(dcll_deleteAtPosition(&list, 0) == 1);
+    assert(dcll_deleteAtPosition(&list, 0, free) == 1);
     // Delete the new last node (position length-1) -> tail update.
-    assert(dcll_deleteAtPosition(&list, list.length - 1) == 1);
-    assert(list.tail->data == 3);
+    assert(dcll_deleteAtPosition(&list, list.length - 1, free) == 1);
+    assert(*(int*)(list.tail->data) == 3);
     assert_invariant(&list);
 
     int out[2];
@@ -215,10 +246,10 @@ void test_delete_at_position()
     assert(n == 2 && out[0] == 2 && out[1] == 3);
 
     // Invalid positions.
-    assert(dcll_deleteAtPosition(&list, 10) == -2);
-    assert(dcll_deleteAtPosition(&list, -1) == -2);
+    assert(dcll_deleteAtPosition(&list, 10, free) == -2);
+    assert(dcll_deleteAtPosition(&list, -1, free) == -2);
 
-    dcll_destroy(&list);
+    dcll_destroy(&list, free);
     printf("dcll delete at position tests passed\n");
 }
 
@@ -231,15 +262,20 @@ void test_search_and_length()
     int values[] = {5, 10, 15};
     for (int i = 0; i < 3; i++)
     {
-        assert(dcll_insertAtEnd(&list, values[i]) == 1);
+        int* val = malloc(sizeof(int));
+        *val = values[i];
+        assert(dcll_insertAtEnd(&list, val) == 1);
     }
     assert(dcll_getLength(&list) == 3);
 
-    assert(dcll_search(&list, 5) == 0);
-    assert(dcll_search(&list, 15) == 2);
-    assert(dcll_search(&list, 100) == -1);
+    int key5 = 5;
+    int key15 = 15;
+    int key100 = 100;
+    assert(dcll_search(&list, &key5, compare_ints) == 0);
+    assert(dcll_search(&list, &key15, compare_ints) == 2);
+    assert(dcll_search(&list, &key100, compare_ints) == -1);
 
-    dcll_destroy(&list);
+    dcll_destroy(&list, free);
     printf("dcll search and length tests passed\n");
 }
 
@@ -249,29 +285,36 @@ void test_edge_cases()
     dcll_init(&list);
 
     // Operations on an empty list return the documented error codes.
-    assert(dcll_deleteAtBeginning(&list) == -1);
-    assert(dcll_deleteAtEnd(&list) == -1);
-    assert(dcll_deleteByValue(&list, 10) == -2);
-    assert(dcll_deleteAtPosition(&list, 0) == -1); // empty list -> -1 (not an invalid-position -2)
-    assert(dcll_search(&list, 10) == -1);
+    assert(dcll_deleteAtBeginning(&list, free) == -1);
+    assert(dcll_deleteAtEnd(&list, free) == -1);
+    int key10 = 10;
+    assert(dcll_deleteByValue(&list, &key10, compare_ints, free) == -2);
+    assert(dcll_deleteAtPosition(&list, 0, free) ==
+           -1); // empty list -> -1 (not an invalid-position -2)
+    assert(dcll_search(&list, &key10, compare_ints) == -1);
     assert(dcll_getLength(&list) == 0);
 
     // Single-node list: node points to itself in both directions, head == tail.
-    assert(dcll_insertAtBeginning(&list, 42) == 1);
+    int* val42 = malloc(sizeof(int));
+    *val42 = 42;
+    assert(dcll_insertAtBeginning(&list, val42) == 1);
     assert(list.head == list.tail);
     assert(list.head->next == list.head);
     assert(list.head->prev == list.head);
-    assert(dcll_search(&list, 42) == 0);
+    int key42 = 42;
+    assert(dcll_search(&list, &key42, compare_ints) == 0);
     assert_invariant(&list);
 
     // Delete down to empty, then reuse the same list object.
-    assert(dcll_deleteAtEnd(&list) == 1);
+    assert(dcll_deleteAtEnd(&list, free) == 1);
     assert(list.head == NULL && list.length == 0);
-    assert(dcll_insertAtEnd(&list, 7) == 1);
-    assert(list.head->data == 7);
+    int* val7 = malloc(sizeof(int));
+    *val7 = 7;
+    assert(dcll_insertAtEnd(&list, val7) == 1);
+    assert(*(int*)(list.head->data) == 7);
     assert_invariant(&list);
 
-    dcll_destroy(&list);
+    dcll_destroy(&list, free);
     printf("dcll edge case tests passed\n");
 }
 
@@ -283,7 +326,9 @@ void test_prev_pointers()
     // Specifically test that prev pointers are correct after various operations.
     for (int v = 1; v <= 5; v++)
     {
-        assert(dcll_insertAtEnd(&list, v) == 1);
+        int* val = malloc(sizeof(int));
+        *val = v;
+        assert(dcll_insertAtEnd(&list, val) == 1);
     }
 
     // Walk backward and verify order is reversed.
@@ -294,14 +339,15 @@ void test_prev_pointers()
     assert_invariant(&list);
 
     // Delete middle node and re-verify backward walk.
-    assert(dcll_deleteByValue(&list, 3) == 1);
+    int key3 = 3;
+    assert(dcll_deleteByValue(&list, &key3, compare_ints, free) == 1);
     int rev2[4];
     int m = list_to_array_reverse(&list, rev2, 4);
     assert(m == 4);
     assert(rev2[0] == 5 && rev2[1] == 4 && rev2[2] == 2 && rev2[3] == 1);
     assert_invariant(&list);
 
-    dcll_destroy(&list);
+    dcll_destroy(&list, free);
     printf("dcll prev pointer tests passed\n");
 }
 
@@ -311,13 +357,15 @@ void test_destroy_is_idempotent()
     dcll_init(&list);
     for (int v = 1; v <= 3; v++)
     {
-        assert(dcll_insertAtEnd(&list, v) == 1);
+        int* val = malloc(sizeof(int));
+        *val = v;
+        assert(dcll_insertAtEnd(&list, val) == 1);
     }
 
-    dcll_destroy(&list);
+    dcll_destroy(&list, free);
     assert(list.head == NULL && list.tail == NULL && list.length == 0);
     // Destroying an already-empty list is a safe no-op.
-    dcll_destroy(&list);
+    dcll_destroy(&list, free);
     assert(list.head == NULL);
 
     printf("dcll destroy tests passed\n");


### PR DESCRIPTION
# PR Description

## What is this PR about? 
Following the linked list genericization roadmap (Issue #859), this PR upgrades the **Doubly Circular Linked List (DCLL)** to be fully generic. It can now store any type of variable (integers, strings, custom structures, etc.) rather than only integers.

We have also updated the interactive **Help Menu** inside the application to explain these generic concepts in a simple, friendly way to help beginners learn C pointers and memory management.

---

## How it works

Since standard C does not have templates, we use two techniques to support generic data:

1. **Void Pointers (`void* data`):**
   A `void*` is a generic pointer. It acts as a blank envelope, holding the memory address of any variable type. Our `dcll_Node` struct has been updated to use `void* data`.

2. **Callback Functions:**
   Because a generic list does not know what type of data it holds, we pass callback helper functions:
   * **Printer Callback:** Tells the list how to print the items.
   * **Compare Callback:** Tells the list how to check if two items are equal for searching or deleting.
   * **Destructor Callback:** Tells the list how to free the dynamically allocated data from memory to prevent memory leaks.

---

## File Summary 

* **`dcll.h` / `dcll.c`:** Changed `int data` to `void* data` inside `dcll_Node` and updated all operations (insertions, deletions, searching) to accept generic inputs and custom callback function pointers.
* **`dcll_demo.c`:** Updated the interactive demo to heap-allocate (`malloc`) user inputs and pass printing, comparison, and destructor (`free`) callbacks.
* **`test_dcll.c`:** Updated the unit test suite to assert correct behavior, including verification that `prev` pointer rings remain intact.
* **`help_data_structures.c`:** Updated Case 3 (Circular Linked Lists help menu) to explain how both Singly Circular (SCLL) and Doubly Circular (DCLL) lists are genericized using `void*` and callbacks.

---

## Verification Done
1. Verified compiler syntax checks:
   ```bash
   gcc -Wall -Wextra -Werror -std=c11 -o test_dcll src/data_structures/dcll.c tests/data_structures/test_dcll.c -Isrc/data_structures -Isrc/utils
   ```
   Compilation completed with zero warnings or errors.
2. Ran the unit test binary:
   ```bash
   ./test_dcll
   ```
   **Result:**
   ```text
   dcll insert begin/end tests passed
   dcll insert at position tests passed
   dcll delete begin/end tests passed
   dcll delete by value tests passed
   dcll delete at position tests passed
   dcll search and length tests passed
   dcll edge case tests passed
   dcll prev pointer tests passed
   dcll destroy tests passed
   All DCLL tests passed
   ```