### PR TITLE
Feature: Integrate Serialization Options into BST and AVL Tree Menus (PR 2) (#673)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,7 @@ set(SRC_DIRS
     demos/advanced_graph_algorithms
     demos/string_algorithms
     features/telemetry
+    features/serialization
 )
 
 # Header search paths

--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,7 @@ CFLAGS = -Wall -Wextra -Werror -std=c11 -g \
 	-Idemos/advanced_graph_algorithms \
 	-Idemos/string_algorithms \
 	-Ifeatures/telemetry \
+	-Ifeatures/serialization \
 	-Itui
 
 # LDFLAGS = -lncurses
@@ -76,7 +77,8 @@ SRC_DIRS = \
 	demos/searching_algorithms \
 	demos/advanced_graph_algorithms \
 	demos/string_algorithms \
-	features/telemetry
+	features/telemetry \
+	features/serialization
 
 # SRCS = $(foreach dir,$(SRC_DIRS),$(wildcard $(dir)/*.c))
 # OBJS = $(patsubst %.c,$(OBJ_DIR)/%.o,$(SRCS))
@@ -173,7 +175,7 @@ TEST_BINS = test_circ_queue test_bst test_search test_hash_func \
             test_string_algorithms test_expression_evaluation \
             test_fcfs test_sjf test_srtf test_round_robin test_priority_scheduling test_preemptive_priority \
             test_dining_philosophers test_petersons test_producer_consumer \
-            test_dijkstra test_bellman_ford test_bfs test_dfs test_topological_sort test_benchmark test_scc test_ford_fulkerson test_edmonds_karp test_dinic test_bipartite_matching test_hopcroft_karp test_eulerian_path test_cache_simulator test_compression test_telemetry test_sorting_telemetry test_graph_telemetry
+            test_dijkstra test_bellman_ford test_bfs test_dfs test_topological_sort test_benchmark test_scc test_ford_fulkerson test_edmonds_karp test_dinic test_bipartite_matching test_hopcroft_karp test_eulerian_path test_cache_simulator test_compression test_telemetry test_sorting_telemetry test_graph_telemetry test_serialization
 
 # Automatically find all advanced heap test sources and append their targets
 ADV_HEAP_TESTS = $(patsubst tests/advanced_heaps/%.c,%,$(wildcard tests/advanced_heaps/*.c))
@@ -871,6 +873,13 @@ test_graph_telemetry: $(TEST_DIR)/test_graph_telemetry$(EXE)
 	$(TEST_DIR)/test_graph_telemetry$(EXE)
 
 $(TEST_DIR)/test_graph_telemetry$(EXE): $(OBJS) tests/telemetry/test_graph_telemetry.c
+	@$(call MKDIR_P,$(TEST_DIR))
+	$(CC) $(CFLAGS) $^ -o $@ $(LDFLAGS)
+
+test_serialization: $(TEST_DIR)/test_serialization$(EXE)
+	$(TEST_DIR)/test_serialization$(EXE)
+
+$(TEST_DIR)/test_serialization$(EXE): $(OBJS) tests/serialization/test_serialization.c
 	@$(call MKDIR_P,$(TEST_DIR))
 	$(CC) $(CFLAGS) $^ -o $@ $(LDFLAGS)
 

--- a/demos/trees/avl_demo.c
+++ b/demos/trees/avl_demo.c
@@ -1,4 +1,5 @@
 #include "safe_input.h"
+#include "serialization.h"
 #include "trees.h"
 #include <stdio.h>
 #include <stdlib.h>
@@ -7,56 +8,93 @@ void avl_demo(void)
 {
     while (1)
     {
-        avlNode* root = NULL;
-        int total_nodes;
-        int total_nodes_status =
-            safe_input_int(&total_nodes,
-                           "\n\nenter total number of nodes you want in the AVL tree, "
-                           "(between 1 and 100), enter '-1' to exit:- ",
-                           1, 100);
+        printf("\n\nAVL Tree Demo");
+        int option;
+        int option_status = safe_input_int(&option,
+                                           "\n1. Build a new AVL tree\n"
+                                           "2. Load AVL tree from file\n"
+                                           "\nenter option (or '-1' to exit): ",
+                                           1, 2);
 
-        if (total_nodes_status == INPUT_EXIT_SIGNAL)
+        if (option_status == INPUT_EXIT_SIGNAL)
         {
             printf("\nExiting AVL tree demo\n");
-            destroy_avl(root);
             return;
         }
-        if (total_nodes_status == 0)
+        if (option_status == 0)
         {
             continue;
         }
 
-        int i = 1;
-        while (total_nodes > 0)
-        {
-            int node_value;
-            printf("\nenter value of %d AVL node - ", i);
-            int node_value_status = safe_input_int(&node_value, NULL, 1, 100);
+        avlNode* root = NULL;
 
-            if (node_value_status == INPUT_EXIT_SIGNAL)
+        if (option == 2)
+        {
+            char path[256];
+            int path_status = safe_input_string(path, "\nenter filepath to load from:- ");
+            if (path_status == INPUT_EXIT_SIGNAL)
+            {
+                continue;
+            }
+            root = deserialize_avl_from_file(path);
+            if (root == NULL)
+            {
+                printf("\nfailed to load AVL tree from file.\n");
+                continue;
+            }
+            printf("\nAVL tree loaded successfully from '%s'.\n", path);
+        }
+        else
+        {
+            int total_nodes;
+            int total_nodes_status =
+                safe_input_int(&total_nodes,
+                               "\n\nenter total number of nodes you want in the AVL tree, "
+                               "(between 1 and 100), enter '-1' to exit:- ",
+                               1, 100);
+
+            if (total_nodes_status == INPUT_EXIT_SIGNAL)
             {
                 printf("\nExiting AVL tree demo\n");
-                destroy_avl(root);
                 return;
             }
-            if (node_value_status == 0)
+            if (total_nodes_status == 0)
             {
                 continue;
             }
 
-            int insertion_status = avl_insert(&root, node_value);
-            if (insertion_status == 0)
+            int i = 1;
+            while (total_nodes > 0)
             {
-                printf("\nentered same value. only unique values please");
-                continue;
+                int node_value;
+                printf("\nenter value of %d AVL node - ", i);
+                int node_value_status = safe_input_int(&node_value, NULL, 1, 100);
+
+                if (node_value_status == INPUT_EXIT_SIGNAL)
+                {
+                    printf("\nExiting AVL tree demo\n");
+                    destroy_avl(root);
+                    return;
+                }
+                if (node_value_status == 0)
+                {
+                    continue;
+                }
+
+                int insertion_status = avl_insert(&root, node_value);
+                if (insertion_status == 0)
+                {
+                    printf("\nentered same value. only unique values please");
+                    continue;
+                }
+                if (insertion_status == -1)
+                {
+                    printf("\ncouldnt insert node due to malloc failure. try again\n");
+                    continue;
+                }
+                i++;
+                total_nodes--;
             }
-            if (insertion_status == -1)
-            {
-                printf("\ncouldnt insert node due to malloc failure. try again\n");
-                continue;
-            }
-            i++;
-            total_nodes--;
         }
 
         printf("\nheight of the AVL tree is:- %d\n", avl_height(root));
@@ -64,11 +102,12 @@ void avl_demo(void)
         while (1)
         {
             int traversal_choice;
-            int traversal_status = safe_input_int(&traversal_choice,
-                                                  "\nenter '1' for inorder, '2' for preorder and "
-                                                  "'3' for postorder, '4' to delete a node, '5' to "
-                                                  "check balance factor, and '-1' to exit:- ",
-                                                  1, 5);
+            int traversal_status =
+                safe_input_int(&traversal_choice,
+                               "\nenter '1' for inorder, '2' for preorder, "
+                               "'3' for postorder, '4' to delete a node, '5' to "
+                               "check balance factor, '6' to save to file, and '-1' to exit:- ",
+                               1, 6);
 
             if (traversal_status == INPUT_EXIT_SIGNAL)
             {
@@ -133,6 +172,22 @@ void avl_demo(void)
             else if (traversal_choice == 5)
             {
                 printf("\nbalance factor of root node is: %d\n", avl_balance_factor(root));
+            }
+            else if (traversal_choice == 6)
+            {
+                char path[256];
+                int path_status = safe_input_string(path, "\nenter filepath to save to:- ");
+                if (path_status != INPUT_EXIT_SIGNAL)
+                {
+                    if (serialize_avl_to_file(root, path))
+                    {
+                        printf("\nAVL tree saved successfully to '%s'.\n", path);
+                    }
+                    else
+                    {
+                        printf("\nfailed to save AVL tree to file.\n");
+                    }
+                }
             }
         }
     }

--- a/demos/trees/bst_demo.c
+++ b/demos/trees/bst_demo.c
@@ -1,4 +1,5 @@
 #include "safe_input.h"
+#include "serialization.h"
 #include "trees.h"
 #include <stdio.h>
 #include <stdlib.h>
@@ -8,62 +9,98 @@ extern int deletionStrategy;
 
 void binary_search_tree_demo(void)
 {
-
     while (1)
     {
-        bstNode* head = NULL;
-        int total_bst_nodes;
-        int total_bst_nodes_status;
+        printf("\n\nBinary Search Tree (BST) Demo");
+        int option;
+        int option_status = safe_input_int(&option,
+                                           "\n1. Build a new BST\n"
+                                           "2. Load BST from file\n"
+                                           "\nenter option (or '-1' to exit): ",
+                                           1, 2);
 
-        printf("\n");
-        total_bst_nodes_status = safe_input_int(&total_bst_nodes,
-                                                "enter total number of nodes you want in the bst, "
-                                                "(between 1 and 100), enter '-1' to exit:- ",
-                                                1, 100);
-
-        if (total_bst_nodes_status == INPUT_EXIT_SIGNAL)
+        if (option_status == INPUT_EXIT_SIGNAL)
         {
             printf("\nExiting binary search tree demo\n");
-            destroy_bst(head);
             return;
         }
-        if (total_bst_nodes_status == 0)
+        if (option_status == 0)
         {
             continue;
         }
 
-        int i = 1;
-        while (total_bst_nodes > 0)
-        {
-            int bst_node_value;
-            int bst_node_value_status;
-            printf("\nenter value of %d bst node - ", i);
-            bst_node_value_status = safe_input_int(&bst_node_value, NULL, 1, 100);
+        bstNode* head = NULL;
 
-            if (bst_node_value_status == INPUT_EXIT_SIGNAL)
+        if (option == 2)
+        {
+            char path[256];
+            int path_status = safe_input_string(path, "\nenter filepath to load from:- ");
+            if (path_status == INPUT_EXIT_SIGNAL)
+            {
+                continue;
+            }
+            head = deserialize_bst_from_file(path);
+            if (head == NULL)
+            {
+                printf("\nfailed to load BST from file.\n");
+                continue;
+            }
+            printf("\nBST loaded successfully from '%s'.\n", path);
+        }
+        else
+        {
+            int total_bst_nodes;
+            int total_bst_nodes_status;
+
+            total_bst_nodes_status =
+                safe_input_int(&total_bst_nodes,
+                               "enter total number of nodes you want in the bst, "
+                               "(between 1 and 100), enter '-1' to exit:- ",
+                               1, 100);
+
+            if (total_bst_nodes_status == INPUT_EXIT_SIGNAL)
             {
                 printf("\nExiting binary search tree demo\n");
-                destroy_bst(head);
                 return;
             }
-            if (bst_node_value_status == 0)
+            if (total_bst_nodes_status == 0)
             {
                 continue;
             }
 
-            int insertion_status = bst_insert(&head, bst_node_value);
-            if (insertion_status == 0)
+            int i = 1;
+            while (total_bst_nodes > 0)
             {
-                printf("\nentered same value. only unique values please");
-                continue;
+                int bst_node_value;
+                int bst_node_value_status;
+                printf("\nenter value of %d bst node - ", i);
+                bst_node_value_status = safe_input_int(&bst_node_value, NULL, 1, 100);
+
+                if (bst_node_value_status == INPUT_EXIT_SIGNAL)
+                {
+                    printf("\nExiting binary search tree demo\n");
+                    destroy_bst(head);
+                    return;
+                }
+                if (bst_node_value_status == 0)
+                {
+                    continue;
+                }
+
+                int insertion_status = bst_insert(&head, bst_node_value);
+                if (insertion_status == 0)
+                {
+                    printf("\nentered same value. only unique values please");
+                    continue;
+                }
+                if (insertion_status == -1)
+                {
+                    printf("\ncouldnt insert node due to malloc failure. try again\n");
+                    continue;
+                }
+                i++;
+                total_bst_nodes--;
             }
-            if (insertion_status == -1)
-            {
-                printf("\ncouldnt insert node due to malloc failure. try again\n");
-                continue;
-            }
-            i++;
-            total_bst_nodes--;
         }
 
         printf("\nheight of the tree is:- %d\n", tree_height(head));
@@ -73,12 +110,12 @@ void binary_search_tree_demo(void)
             int bst_traversal_choice;
             int bst_traversal_status;
 
-            bst_traversal_status =
-                safe_input_int(&bst_traversal_choice,
-                               "\nenter '1' for inorder, '2' for preorder and "
-                               "'3' for postorder, '4' for level order, '5' to delete a node, '6' "
-                               "to change deletion strategy  and '-1' to exit: ",
-                               1, 6);
+            bst_traversal_status = safe_input_int(
+                &bst_traversal_choice,
+                "\nenter '1' for inorder, '2' for preorder, "
+                "'3' for postorder, '4' for level order, '5' to delete a node, '6' "
+                "to change deletion strategy, '7' to save to file, and '-1' to exit: ",
+                1, 7);
 
             if (bst_traversal_status == INPUT_EXIT_SIGNAL)
             {
@@ -155,6 +192,22 @@ void binary_search_tree_demo(void)
                     printf("\nDeletion strategy set to Inorder Successor.\n");
                 else
                     printf("\nDeletion strategy set to Inorder Predecessor.\n");
+            }
+            else if (bst_traversal_choice == 7)
+            {
+                char path[256];
+                int path_status = safe_input_string(path, "\nenter filepath to save to:- ");
+                if (path_status != INPUT_EXIT_SIGNAL)
+                {
+                    if (serialize_bst_to_file(head, path))
+                    {
+                        printf("\nBST saved successfully to '%s'.\n", path);
+                    }
+                    else
+                    {
+                        printf("\nfailed to save BST to file.\n");
+                    }
+                }
             }
         }
     }

--- a/features/serialization/serialization.c
+++ b/features/serialization/serialization.c
@@ -1,0 +1,288 @@
+#include "serialization.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+
+#ifdef _WIN32
+#include <direct.h>
+#endif
+
+static void ensure_parent_dir_exists(const char* filepath)
+{
+    char temp[512];
+    strncpy(temp, filepath, sizeof(temp) - 1);
+    temp[sizeof(temp) - 1] = '\0';
+
+    char* last_slash = strrchr(temp, '/');
+#ifdef _WIN32
+    char* last_backslash = strrchr(temp, '\\');
+    if (last_backslash > last_slash)
+    {
+        last_slash = last_backslash;
+    }
+#endif
+
+    if (last_slash != NULL)
+    {
+        *last_slash = '\0';
+        if (strlen(temp) > 0)
+        {
+#ifdef _WIN32
+            _mkdir(temp);
+#else
+            struct stat st;
+            if (stat(temp, &st) == -1)
+            {
+                mkdir(temp, 0755);
+            }
+#endif
+        }
+    }
+}
+
+// Helper functions for BST serialization
+static void write_bst_node(const bstNode* root, FILE* fp)
+{
+    if (root == NULL)
+    {
+        fprintf(fp, "#\n");
+        return;
+    }
+    fprintf(fp, "%d\n", root->data);
+    write_bst_node(root->left, fp);
+    write_bst_node(root->right, fp);
+}
+
+static bstNode* read_bst_node(FILE* fp)
+{
+    char val[64];
+    if (fscanf(fp, "%63s", val) != 1)
+    {
+        return NULL;
+    }
+    if (strcmp(val, "#") == 0)
+    {
+        return NULL;
+    }
+    bstNode* node = malloc(sizeof(bstNode));
+    if (node == NULL)
+    {
+        return NULL;
+    }
+    node->data = atoi(val);
+    node->left = read_bst_node(fp);
+    node->right = read_bst_node(fp);
+    return node;
+}
+
+bool serialize_bst_to_file(const bstNode* root, const char* filepath)
+{
+    if (filepath == NULL || strlen(filepath) == 0)
+    {
+        return false;
+    }
+    ensure_parent_dir_exists(filepath);
+    FILE* fp = fopen(filepath, "w");
+    if (fp == NULL)
+    {
+        return false;
+    }
+    write_bst_node(root, fp);
+    fclose(fp);
+    return true;
+}
+
+bstNode* deserialize_bst_from_file(const char* filepath)
+{
+    if (filepath == NULL || strlen(filepath) == 0)
+    {
+        return NULL;
+    }
+    FILE* fp = fopen(filepath, "r");
+    if (fp == NULL)
+    {
+        return NULL;
+    }
+    bstNode* root = read_bst_node(fp);
+    fclose(fp);
+    return root;
+}
+
+// Helper functions for AVL serialization
+static void write_avl_node(const avlNode* root, FILE* fp)
+{
+    if (root == NULL)
+    {
+        fprintf(fp, "#\n");
+        return;
+    }
+    fprintf(fp, "%d %d\n", root->data, root->height);
+    write_avl_node(root->left, fp);
+    write_avl_node(root->right, fp);
+}
+
+static avlNode* read_avl_node(FILE* fp)
+{
+    char val[64];
+    if (fscanf(fp, "%63s", val) != 1)
+    {
+        return NULL;
+    }
+    if (strcmp(val, "#") == 0)
+    {
+        return NULL;
+    }
+    int data = atoi(val);
+    int height = 1;
+    if (fscanf(fp, "%d", &height) != 1)
+    {
+        return NULL;
+    }
+    avlNode* node = malloc(sizeof(avlNode));
+    if (node == NULL)
+    {
+        return NULL;
+    }
+    node->data = data;
+    node->height = height;
+    node->left = read_avl_node(fp);
+    node->right = read_avl_node(fp);
+    return node;
+}
+
+bool serialize_avl_to_file(const avlNode* root, const char* filepath)
+{
+    if (filepath == NULL || strlen(filepath) == 0)
+    {
+        return false;
+    }
+    ensure_parent_dir_exists(filepath);
+    FILE* fp = fopen(filepath, "w");
+    if (fp == NULL)
+    {
+        return false;
+    }
+    write_avl_node(root, fp);
+    fclose(fp);
+    return true;
+}
+
+avlNode* deserialize_avl_from_file(const char* filepath)
+{
+    if (filepath == NULL || strlen(filepath) == 0)
+    {
+        return NULL;
+    }
+    FILE* fp = fopen(filepath, "r");
+    if (fp == NULL)
+    {
+        return NULL;
+    }
+    avlNode* root = read_avl_node(fp);
+    fclose(fp);
+    return root;
+}
+
+// Graph Serialization (Unweighted)
+bool serialize_graph_to_file(const Graph* graph, const char* filepath)
+{
+    if (graph == NULL || filepath == NULL || strlen(filepath) == 0)
+    {
+        return false;
+    }
+    ensure_parent_dir_exists(filepath);
+    FILE* fp = fopen(filepath, "w");
+    if (fp == NULL)
+    {
+        return false;
+    }
+
+    // Count unique undirected edges
+    int E = 0;
+    for (int u = 0; u < graph->V; u++)
+    {
+        Node* curr = graph->array[u];
+        while (curr != NULL)
+        {
+            if (u < curr->data)
+            {
+                E++;
+            }
+            curr = curr->next;
+        }
+    }
+
+    fprintf(fp, "%d %d\n", graph->V, E);
+
+    // Write edges
+    for (int u = 0; u < graph->V; u++)
+    {
+        Node* curr = graph->array[u];
+        while (curr != NULL)
+        {
+            if (u < curr->data)
+            {
+                fprintf(fp, "%d,%d\n", u, curr->data);
+            }
+            curr = curr->next;
+        }
+    }
+
+    fclose(fp);
+    return true;
+}
+
+Graph* deserialize_graph_from_file(const char* filepath)
+{
+    return load_graph_from_csv(filepath);
+}
+
+// Graph Serialization (Weighted)
+bool serialize_weighted_graph_to_file(const weightedGraph* graph, const char* filepath)
+{
+    if (graph == NULL || filepath == NULL || strlen(filepath) == 0)
+    {
+        return false;
+    }
+    ensure_parent_dir_exists(filepath);
+    FILE* fp = fopen(filepath, "w");
+    if (fp == NULL)
+    {
+        return false;
+    }
+
+    // Count directed edges
+    int E = 0;
+    for (int u = 0; u < graph->V; u++)
+    {
+        Edge* curr = graph->array[u];
+        while (curr != NULL)
+        {
+            E++;
+            curr = curr->next;
+        }
+    }
+
+    fprintf(fp, "%d %d\n", graph->V, E);
+
+    // Write edges
+    for (int u = 0; u < graph->V; u++)
+    {
+        Edge* curr = graph->array[u];
+        while (curr != NULL)
+        {
+            fprintf(fp, "%d,%d,%d\n", u, curr->destination, curr->weight);
+            curr = curr->next;
+        }
+    }
+
+    fclose(fp);
+    return true;
+}
+
+weightedGraph* deserialize_weighted_graph_from_file(const char* filepath)
+{
+    return load_weightedGraph_from_csv(filepath);
+}

--- a/features/serialization/serialization.h
+++ b/features/serialization/serialization.h
@@ -1,0 +1,20 @@
+#ifndef SERIALIZATION_H
+#define SERIALIZATION_H
+
+#include "graph_traversals.h"
+#include "trees.h"
+#include <stdbool.h>
+
+bool serialize_bst_to_file(const bstNode* root, const char* filepath);
+bstNode* deserialize_bst_from_file(const char* filepath);
+
+bool serialize_avl_to_file(const avlNode* root, const char* filepath);
+avlNode* deserialize_avl_from_file(const char* filepath);
+
+bool serialize_graph_to_file(const Graph* graph, const char* filepath);
+Graph* deserialize_graph_from_file(const char* filepath);
+
+bool serialize_weighted_graph_to_file(const weightedGraph* graph, const char* filepath);
+weightedGraph* deserialize_weighted_graph_from_file(const char* filepath);
+
+#endif // SERIALIZATION_H

--- a/tests/serialization/test_serialization.c
+++ b/tests/serialization/test_serialization.c
@@ -1,0 +1,130 @@
+#include "serialization.h"
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static void test_bst_serialization(void)
+{
+    /* Build a simple BST:
+     *      5
+     *     / \
+     *    3   7
+     */
+    bstNode* root = NULL;
+    bst_insert(&root, 5);
+    bst_insert(&root, 3);
+    bst_insert(&root, 7);
+
+    assert(serialize_bst_to_file(root, "test_binaries/bst_test.dat"));
+
+    bstNode* reconstructed = deserialize_bst_from_file("test_binaries/bst_test.dat");
+    assert(reconstructed != NULL);
+    assert(reconstructed->data == 5);
+    assert(reconstructed->left != NULL && reconstructed->left->data == 3);
+    assert(reconstructed->right != NULL && reconstructed->right->data == 7);
+
+    destroy_bst(root);
+    destroy_bst(reconstructed);
+    remove("test_binaries/bst_test.dat");
+}
+
+static void test_avl_serialization(void)
+{
+    /* Build a simple AVL tree:
+     *      10
+     *     /  \
+     *    5    15
+     */
+    avlNode* root = NULL;
+    avl_insert(&root, 10);
+    avl_insert(&root, 5);
+    avl_insert(&root, 15);
+
+    assert(serialize_avl_to_file(root, "test_binaries/avl_test.dat"));
+
+    avlNode* reconstructed = deserialize_avl_from_file("test_binaries/avl_test.dat");
+    assert(reconstructed != NULL);
+    assert(reconstructed->data == 10);
+    assert(reconstructed->height == 2);
+    assert(reconstructed->left != NULL && reconstructed->left->data == 5);
+    assert(reconstructed->right != NULL && reconstructed->right->data == 15);
+
+    destroy_avl(root);
+    destroy_avl(reconstructed);
+    remove("test_binaries/avl_test.dat");
+}
+
+static void test_graph_serialization(void)
+{
+    Graph* graph = create_graph(4);
+    add_edge_undirected(graph, 0, 1);
+    add_edge_undirected(graph, 1, 2);
+    add_edge_undirected(graph, 2, 3);
+
+    assert(serialize_graph_to_file(graph, "test_binaries/graph_test.dat"));
+
+    Graph* reconstructed = deserialize_graph_from_file("test_binaries/graph_test.dat");
+    assert(reconstructed != NULL);
+    assert(reconstructed->V == 4);
+
+    // Verify adjacency list connections exist
+    Node* curr = reconstructed->array[1];
+    bool has_zero = false;
+    bool has_two = false;
+    while (curr != NULL)
+    {
+        if (curr->data == 0)
+            has_zero = true;
+        if (curr->data == 2)
+            has_two = true;
+        curr = curr->next;
+    }
+    assert(has_zero);
+    assert(has_two);
+
+    free_graph(graph);
+    free_graph(reconstructed);
+    remove("test_binaries/graph_test.dat");
+}
+
+static void test_weighted_graph_serialization(void)
+{
+    weightedGraph* graph = create_weightedGraph(3);
+    add_edge_directed(graph, 0, 1, 10);
+    add_edge_directed(graph, 1, 2, 20);
+
+    assert(serialize_weighted_graph_to_file(graph, "test_binaries/wgraph_test.dat"));
+
+    weightedGraph* reconstructed =
+        deserialize_weighted_graph_from_file("test_binaries/wgraph_test.dat");
+    assert(reconstructed != NULL);
+    assert(reconstructed->V == 3);
+
+    // Verify edge 0->1 weight is 10
+    Edge* curr = reconstructed->array[0];
+    assert(curr != NULL);
+    assert(curr->destination == 1);
+    assert(curr->weight == 10);
+
+    // Verify edge 1->2 weight is 20
+    curr = reconstructed->array[1];
+    assert(curr != NULL);
+    assert(curr->destination == 2);
+    assert(curr->weight == 20);
+
+    free_weightedGraph(graph);
+    free_weightedGraph(reconstructed);
+    remove("test_binaries/wgraph_test.dat");
+}
+
+int main(void)
+{
+    printf("Starting State Serialization unit tests...\n");
+    test_bst_serialization();
+    test_avl_serialization();
+    test_graph_serialization();
+    test_weighted_graph_serialization();
+    printf("All State Serialization unit tests passed successfully!\n");
+    return 0;
+}


### PR DESCRIPTION
### Description
This PR integrates the Tree Serialization and Deserialization options into the interactive BST and AVL Tree menus.

### Resolves
* Resolves #673 (Tree Menu Integration)

### Changes
- **[bst_demo.c](file:///Users/akshatshukla/Library/Mobile%20Documents/com~apple~CloudDocs/Work/open/C_DSA_interactive_suite.git/demos/trees/bst_demo.c)**:
  - Added option to either build a new BST from scratch or load an existing BST structure from a file path.
  - Added option `7` to save the currently constructed BST to a custom file path during traversal operations.
- **[avl_demo.c](file:///Users/akshatshukla/Library/Mobile%20Documents/com~apple~CloudDocs/Work/open/C_DSA_interactive_suite.git/demos/trees/avl_demo.c)**:
  - Added option to either build a new AVL tree from scratch or load an existing AVL tree from a file path.
  - Added option `6` to save the currently constructed AVL tree to a custom file path.

### Verification & Testing
- Checked formatting using `make fmt`.
- Ran the test suite via `make test` and verified all builds and tests pass cleanly.