### PR TITLE
Feature: Implement Stack & Queue Generic Export APIs and Tests (PR 2) (#878)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,7 @@ set(SRC_DIRS
     demos/string_algorithms
     features/telemetry
     features/serialization
+    features/export
 )
 
 # Header search paths

--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,7 @@ CFLAGS = -Wall -Wextra -Werror -std=c11 -g \
 	-Idemos/string_algorithms \
 	-Ifeatures/telemetry \
 	-Ifeatures/serialization \
+	-Ifeatures/export \
 	-Itui
 
 # LDFLAGS = -lncurses
@@ -78,7 +79,8 @@ SRC_DIRS = \
 	demos/advanced_graph_algorithms \
 	demos/string_algorithms \
 	features/telemetry \
-	features/serialization
+	features/serialization \
+	features/export
 
 # SRCS = $(foreach dir,$(SRC_DIRS),$(wildcard $(dir)/*.c))
 # OBJS = $(patsubst %.c,$(OBJ_DIR)/%.o,$(SRCS))
@@ -175,7 +177,7 @@ TEST_BINS = test_circ_queue test_bst test_search test_hash_func \
             test_string_algorithms test_expression_evaluation \
             test_fcfs test_sjf test_srtf test_round_robin test_priority_scheduling test_preemptive_priority \
             test_dining_philosophers test_petersons test_producer_consumer \
-            test_dijkstra test_bellman_ford test_bfs test_dfs test_topological_sort test_benchmark test_scc test_ford_fulkerson test_edmonds_karp test_dinic test_bipartite_matching test_hopcroft_karp test_eulerian_path test_cache_simulator test_compression test_telemetry test_sorting_telemetry test_graph_telemetry test_serialization
+            test_dijkstra test_bellman_ford test_bfs test_dfs test_topological_sort test_benchmark test_scc test_ford_fulkerson test_edmonds_karp test_dinic test_bipartite_matching test_hopcroft_karp test_eulerian_path test_cache_simulator test_compression test_telemetry test_sorting_telemetry test_graph_telemetry test_serialization test_export
 
 # Automatically find all advanced heap test sources and append their targets
 ADV_HEAP_TESTS = $(patsubst tests/advanced_heaps/%.c,%,$(wildcard tests/advanced_heaps/*.c))
@@ -880,6 +882,13 @@ test_serialization: $(TEST_DIR)/test_serialization$(EXE)
 	$(TEST_DIR)/test_serialization$(EXE)
 
 $(TEST_DIR)/test_serialization$(EXE): $(OBJS) tests/serialization/test_serialization.c
+	@$(call MKDIR_P,$(TEST_DIR))
+	$(CC) $(CFLAGS) $^ -o $@ $(LDFLAGS)
+
+test_export: $(TEST_DIR)/test_export$(EXE)
+	$(TEST_DIR)/test_export$(EXE)
+
+$(TEST_DIR)/test_export$(EXE): $(OBJS) tests/export/test_export.c
 	@$(call MKDIR_P,$(TEST_DIR))
 	$(CC) $(CFLAGS) $^ -o $@ $(LDFLAGS)
 

--- a/features/export/export.c
+++ b/features/export/export.c
@@ -121,3 +121,169 @@ int dll_export(const doubly_ll_Node* head, const char* filepath, ExportFormat fo
     fclose(fp);
     return 1;
 }
+
+int stack_export(const stack* s, const char* filepath, ExportFormat format,
+                 void (*write_node_data)(FILE* fp, const void* data))
+{
+    if (s == NULL || filepath == NULL || strlen(filepath) == 0 || write_node_data == NULL)
+    {
+        return 0;
+    }
+
+    ensure_parent_dir_exists(filepath);
+    FILE* fp = fopen(filepath, "w");
+    if (fp == NULL)
+    {
+        return 0;
+    }
+
+    const Node* curr = s->top;
+
+    if (format == EXPORT_FORMAT_TEXT)
+    {
+        while (curr != NULL)
+        {
+            write_node_data(fp, curr->data);
+            fprintf(fp, " -> ");
+            curr = curr->next;
+        }
+        fprintf(fp, "NULL\n");
+    }
+    else if (format == EXPORT_FORMAT_CSV)
+    {
+        fprintf(fp, "index,value\n");
+        int index = 0;
+        while (curr != NULL)
+        {
+            fprintf(fp, "%d,", index);
+            write_node_data(fp, curr->data);
+            fprintf(fp, "\n");
+            index++;
+            curr = curr->next;
+        }
+    }
+    else if (format == EXPORT_FORMAT_JSON)
+    {
+        fprintf(fp, "[\n");
+        while (curr != NULL)
+        {
+            fprintf(fp, "  ");
+            write_node_data(fp, curr->data);
+            if (curr->next != NULL)
+            {
+                fprintf(fp, ",\n");
+            }
+            else
+            {
+                fprintf(fp, "\n");
+            }
+            curr = curr->next;
+        }
+        fprintf(fp, "]\n");
+    }
+
+    fclose(fp);
+    return 1;
+}
+
+int queue_export(const Queue* q, QueueType type, const char* filepath, ExportFormat format,
+                 void (*write_node_data)(FILE* fp, const void* data))
+{
+    if (q == NULL || q->arr == NULL || filepath == NULL || strlen(filepath) == 0 ||
+        write_node_data == NULL)
+    {
+        return 0;
+    }
+
+    // Collect elements in order
+    int count = 0;
+    void** temp_arr = malloc(sizeof(void*) * q->N);
+    if (temp_arr == NULL)
+    {
+        return 0;
+    }
+
+    if (type == QUEUE_TYPE_CIRCULAR)
+    {
+        int i = q->front;
+        while (i != q->rear)
+        {
+            temp_arr[count++] = q->arr[i];
+            i = (i + 1) % q->N;
+        }
+    }
+    else if (type == QUEUE_TYPE_SIMPLE)
+    {
+        if (q->front != -1)
+        {
+            for (int i = q->front; i <= q->rear; i++)
+            {
+                temp_arr[count++] = q->arr[i];
+            }
+        }
+    }
+    else if (type == QUEUE_TYPE_DEQUE)
+    {
+        if (q->front != -1)
+        {
+            int i = q->front;
+            while (1)
+            {
+                temp_arr[count++] = q->arr[i];
+                if (i == q->rear)
+                    break;
+                i = (i + 1) % q->N;
+            }
+        }
+    }
+
+    ensure_parent_dir_exists(filepath);
+    FILE* fp = fopen(filepath, "w");
+    if (fp == NULL)
+    {
+        free(temp_arr);
+        return 0;
+    }
+
+    if (format == EXPORT_FORMAT_TEXT)
+    {
+        for (int i = 0; i < count; i++)
+        {
+            write_node_data(fp, temp_arr[i]);
+            fprintf(fp, " -> ");
+        }
+        fprintf(fp, "NULL\n");
+    }
+    else if (format == EXPORT_FORMAT_CSV)
+    {
+        fprintf(fp, "index,value\n");
+        for (int i = 0; i < count; i++)
+        {
+            fprintf(fp, "%d,", i);
+            write_node_data(fp, temp_arr[i]);
+            fprintf(fp, "\n");
+        }
+    }
+    else if (format == EXPORT_FORMAT_JSON)
+    {
+        fprintf(fp, "[\n");
+        for (int i = 0; i < count; i++)
+        {
+            fprintf(fp, "  ");
+            write_node_data(fp, temp_arr[i]);
+            if (i < count - 1)
+            {
+                fprintf(fp, ",\n");
+            }
+            else
+            {
+                fprintf(fp, "\n");
+            }
+        }
+        fprintf(fp, "]\n");
+    }
+
+    fclose(fp);
+    free(temp_arr);
+    return 1;
+}

--- a/features/export/export.c
+++ b/features/export/export.c
@@ -1,0 +1,123 @@
+#include "export.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+
+#ifdef _WIN32
+#include <direct.h>
+#endif
+
+static void ensure_parent_dir_exists(const char* filepath)
+{
+    char temp[512];
+    strncpy(temp, filepath, sizeof(temp) - 1);
+    temp[sizeof(temp) - 1] = '\0';
+
+    char* last_slash = strrchr(temp, '/');
+#ifdef _WIN32
+    char* last_backslash = strrchr(temp, '\\');
+    if (last_backslash > last_slash)
+    {
+        last_slash = last_backslash;
+    }
+#endif
+
+    if (last_slash != NULL)
+    {
+        *last_slash = '\0';
+        if (strlen(temp) > 0)
+        {
+#ifdef _WIN32
+            _mkdir(temp);
+#else
+            struct stat st;
+            if (stat(temp, &st) == -1)
+            {
+                mkdir(temp, 0755);
+            }
+#endif
+        }
+    }
+}
+
+void write_data_int(FILE* fp, const void* data)
+{
+    if (data != NULL)
+    {
+        fprintf(fp, "%d", *(const int*)data);
+    }
+}
+
+void write_data_string(FILE* fp, const void* data)
+{
+    if (data != NULL)
+    {
+        fprintf(fp, "%s", (const char*)data);
+    }
+}
+
+int dll_export(const doubly_ll_Node* head, const char* filepath, ExportFormat format,
+               void (*write_node_data)(FILE* fp, const void* data))
+{
+    if (filepath == NULL || strlen(filepath) == 0 || write_node_data == NULL)
+    {
+        return 0;
+    }
+
+    ensure_parent_dir_exists(filepath);
+    FILE* fp = fopen(filepath, "w");
+    if (fp == NULL)
+    {
+        return 0;
+    }
+
+    const doubly_ll_Node* curr = head;
+
+    if (format == EXPORT_FORMAT_TEXT)
+    {
+        while (curr != NULL)
+        {
+            write_node_data(fp, curr->data);
+            fprintf(fp, " -> ");
+            curr = curr->next;
+        }
+        fprintf(fp, "NULL\n");
+    }
+    else if (format == EXPORT_FORMAT_CSV)
+    {
+        fprintf(fp, "index,value\n");
+        int index = 0;
+        while (curr != NULL)
+        {
+            fprintf(fp, "%d,", index);
+            write_node_data(fp, curr->data);
+            fprintf(fp, "\n");
+            index++;
+            curr = curr->next;
+        }
+    }
+    else if (format == EXPORT_FORMAT_JSON)
+    {
+        fprintf(fp, "[\n");
+        while (curr != NULL)
+        {
+            fprintf(fp, "  ");
+            write_node_data(fp, curr->data);
+            if (curr->next != NULL)
+            {
+                fprintf(fp, ",\n");
+            }
+            else
+            {
+                fprintf(fp, "\n");
+            }
+            curr = curr->next;
+        }
+        fprintf(fp, "]\n");
+    }
+
+    fclose(fp);
+    return 1;
+}

--- a/features/export/export.h
+++ b/features/export/export.h
@@ -2,6 +2,8 @@
 #define EXPORT_H
 
 #include "dll.h"
+#include "queue.h"
+#include "stack.h"
 #include <stdio.h>
 
 typedef enum
@@ -11,6 +13,13 @@ typedef enum
     EXPORT_FORMAT_JSON
 } ExportFormat;
 
+typedef enum
+{
+    QUEUE_TYPE_SIMPLE,
+    QUEUE_TYPE_CIRCULAR,
+    QUEUE_TYPE_DEQUE
+} QueueType;
+
 // Pre-defined formatter helpers
 void write_data_int(FILE* fp, const void* data);
 void write_data_string(FILE* fp, const void* data);
@@ -18,5 +27,13 @@ void write_data_string(FILE* fp, const void* data);
 // Generic export function for Doubly Linked List
 int dll_export(const doubly_ll_Node* head, const char* filepath, ExportFormat format,
                void (*write_node_data)(FILE* fp, const void* data));
+
+// Generic export function for Stack
+int stack_export(const stack* s, const char* filepath, ExportFormat format,
+                 void (*write_node_data)(FILE* fp, const void* data));
+
+// Generic export function for Queue (simple, circular, and deque)
+int queue_export(const Queue* q, QueueType type, const char* filepath, ExportFormat format,
+                 void (*write_node_data)(FILE* fp, const void* data));
 
 #endif // EXPORT_H

--- a/features/export/export.h
+++ b/features/export/export.h
@@ -1,0 +1,22 @@
+#ifndef EXPORT_H
+#define EXPORT_H
+
+#include "dll.h"
+#include <stdio.h>
+
+typedef enum
+{
+    EXPORT_FORMAT_TEXT,
+    EXPORT_FORMAT_CSV,
+    EXPORT_FORMAT_JSON
+} ExportFormat;
+
+// Pre-defined formatter helpers
+void write_data_int(FILE* fp, const void* data);
+void write_data_string(FILE* fp, const void* data);
+
+// Generic export function for Doubly Linked List
+int dll_export(const doubly_ll_Node* head, const char* filepath, ExportFormat format,
+               void (*write_node_data)(FILE* fp, const void* data));
+
+#endif // EXPORT_H

--- a/tests/export/test_export.c
+++ b/tests/export/test_export.c
@@ -67,11 +67,96 @@ static void test_dll_export_string(void)
     delete_dll(head, NULL);
 }
 
+static void test_stack_export_int(void)
+{
+    stack* s = createStack();
+    assert(s != NULL);
+
+    int val1 = 30, val2 = 20, val3 = 10;
+    push(s, &val1);
+    push(s, &val2);
+    push(s, &val3);
+
+    // Text Export Test
+    assert(stack_export(s, "test_binaries/stack.txt", EXPORT_FORMAT_TEXT, write_data_int));
+    verify_file_content("test_binaries/stack.txt", "10 -> 20 -> 30 -> NULL\n");
+
+    // CSV Export Test
+    assert(stack_export(s, "test_binaries/stack.csv", EXPORT_FORMAT_CSV, write_data_int));
+    verify_file_content("test_binaries/stack.csv", "index,value\n0,10\n1,20\n2,30\n");
+
+    // JSON Export Test
+    assert(stack_export(s, "test_binaries/stack.json", EXPORT_FORMAT_JSON, write_data_int));
+    verify_file_content("test_binaries/stack.json", "[\n  10,\n  20,\n  30\n]\n");
+
+    destroyStack(s, NULL);
+}
+
+static void test_queue_export_int(void)
+{
+    Queue q_simple;
+    init_simple_queue(5, &q_simple);
+    int* val1 = malloc(sizeof(int));
+    int* val2 = malloc(sizeof(int));
+    *val1 = 100;
+    *val2 = 200;
+    enqueue_simple(&q_simple, val1);
+    enqueue_simple(&q_simple, val2);
+
+    printf("  Starting simple queue export test...\n");
+    assert(queue_export(&q_simple, QUEUE_TYPE_SIMPLE, "test_binaries/queue_simple.txt",
+                        EXPORT_FORMAT_TEXT, write_data_int));
+    verify_file_content("test_binaries/queue_simple.txt", "100 -> 200 -> NULL\n");
+    printf("  Simple queue export passed.\n");
+
+    destroy_simple_queue(&q_simple);
+
+    Queue q_circ;
+    init_circ_queue(5, &q_circ);
+    int* cval1 = malloc(sizeof(int));
+    int* cval2 = malloc(sizeof(int));
+    *cval1 = 10;
+    *cval2 = 20;
+    enqueue(&q_circ, cval1);
+    enqueue(&q_circ, cval2);
+
+    printf("  Starting circular queue export test...\n");
+    assert(queue_export(&q_circ, QUEUE_TYPE_CIRCULAR, "test_binaries/queue_circ.csv",
+                        EXPORT_FORMAT_CSV, write_data_int));
+    verify_file_content("test_binaries/queue_circ.csv", "index,value\n0,10\n1,20\n");
+    printf("  Circular queue export passed.\n");
+
+    destroy_circ_queue(&q_circ);
+
+    Queue dq;
+    init_deque(5, &dq);
+    int* dval1 = malloc(sizeof(int));
+    int* dval2 = malloc(sizeof(int));
+    *dval1 = 5;
+    *dval2 = 15;
+    deque_insert_rear(&dq, dval1);
+    deque_insert_front(&dq, dval2);
+
+    printf("  Starting deque export test...\n");
+    assert(queue_export(&dq, QUEUE_TYPE_DEQUE, "test_binaries/deque.json", EXPORT_FORMAT_JSON,
+                        write_data_int));
+    verify_file_content("test_binaries/deque.json", "[\n  15,\n  5\n]\n");
+    printf("  Deque export passed.\n");
+
+    destroy_deque(&dq);
+}
+
 int main(void)
 {
     printf("Starting Generic File Export unit tests...\n");
     test_dll_export_int();
+    printf("test_dll_export_int passed\n");
     test_dll_export_string();
+    printf("test_dll_export_string passed\n");
+    test_stack_export_int();
+    printf("test_stack_export_int passed\n");
+    test_queue_export_int();
+    printf("test_queue_export_int passed\n");
     printf("All Generic File Export unit tests passed successfully!\n");
     return 0;
 }

--- a/tests/export/test_export.c
+++ b/tests/export/test_export.c
@@ -1,0 +1,77 @@
+#include "dll.h"
+#include "export.h"
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static void verify_file_content(const char* filepath, const char* expected)
+{
+    FILE* fp = fopen(filepath, "r");
+    assert(fp != NULL);
+
+    char buffer[4096];
+    size_t bytes_read = fread(buffer, 1, sizeof(buffer) - 1, fp);
+    buffer[bytes_read] = '\0';
+    fclose(fp);
+
+    assert(strcmp(buffer, expected) == 0);
+    remove(filepath);
+}
+
+static void test_dll_export_int(void)
+{
+    doubly_ll_Node* head = NULL;
+    int val1 = 10, val2 = 20, val3 = 30;
+
+    dll_insertAtEnd(&head, &val1);
+    dll_insertAtEnd(&head, &val2);
+    dll_insertAtEnd(&head, &val3);
+
+    // Text Export Test
+    assert(dll_export(head, "test_binaries/dll_int.txt", EXPORT_FORMAT_TEXT, write_data_int));
+    verify_file_content("test_binaries/dll_int.txt", "10 -> 20 -> 30 -> NULL\n");
+
+    // CSV Export Test
+    assert(dll_export(head, "test_binaries/dll_int.csv", EXPORT_FORMAT_CSV, write_data_int));
+    verify_file_content("test_binaries/dll_int.csv", "index,value\n0,10\n1,20\n2,30\n");
+
+    // JSON Export Test
+    assert(dll_export(head, "test_binaries/dll_int.json", EXPORT_FORMAT_JSON, write_data_int));
+    verify_file_content("test_binaries/dll_int.json", "[\n  10,\n  20,\n  30\n]\n");
+
+    delete_dll(head, NULL);
+}
+
+static void test_dll_export_string(void)
+{
+    doubly_ll_Node* head = NULL;
+    char* val1 = "apple";
+    char* val2 = "banana";
+
+    dll_insertAtEnd(&head, val1);
+    dll_insertAtEnd(&head, val2);
+
+    // Text Export Test
+    assert(dll_export(head, "test_binaries/dll_str.txt", EXPORT_FORMAT_TEXT, write_data_string));
+    verify_file_content("test_binaries/dll_str.txt", "apple -> banana -> NULL\n");
+
+    // CSV Export Test
+    assert(dll_export(head, "test_binaries/dll_str.csv", EXPORT_FORMAT_CSV, write_data_string));
+    verify_file_content("test_binaries/dll_str.csv", "index,value\n0,apple\n1,banana\n");
+
+    // JSON Export Test
+    assert(dll_export(head, "test_binaries/dll_str.json", EXPORT_FORMAT_JSON, write_data_string));
+    verify_file_content("test_binaries/dll_str.json", "[\n  apple,\n  banana\n]\n");
+
+    delete_dll(head, NULL);
+}
+
+int main(void)
+{
+    printf("Starting Generic File Export unit tests...\n");
+    test_dll_export_int();
+    test_dll_export_string();
+    printf("All Generic File Export unit tests passed successfully!\n");
+    return 0;
+}


### PR DESCRIPTION
### Description
This PR implements generic export support for the Stack, Simple Queue, Circular Queue, and Deque data structures, complete with verification unit tests.

### Resolves
* Resolves #878 (Stack & Queue Export implementation)

### Changes
- **[export.h](file:///Users/akshatshukla/Library/Mobile%20Documents/com~apple~CloudDocs/Work/open/C_DSA_interactive_suite.git/features/export/export.h)**:
  - Declared `QueueType` enum to support Simple Queue, Circular Queue, and Deque traversals.
  - Declared `stack_export` and `queue_export` APIs.
- **[export.c](file:///Users/akshatshukla/Library/Mobile%20Documents/com~apple~CloudDocs/Work/open/C_DSA_interactive_suite.git/features/export/export.c)**:
  - Implemented `stack_export` using top-to-bottom sequence parsing.
  - Implemented `queue_export` with a unified exporter backend that collects circular or linear array elements before formatting.
- **[test_export.c](file:///Users/akshatshukla/Library/Mobile%20Documents/com~apple~CloudDocs/Work/open/C_DSA_interactive_suite.git/tests/export/test_export.c)**: Added `test_stack_export_int` and `test_queue_export_int` verifying text, CSV, and JSON outputs for Stacks, Circular Queues, Simple Queues, and Deques.

### Verification & Testing
- Formatted all files via `make fmt`.
- Ran unit tests with `make test` & `make test_export` and verified all tests pass cleanly.