### PR TITLE
refactor(ds): Upgrade Singly Linked List (SLL) and Stack to be generic with void* payloads

### DIFF
--- a/demos/data_structures/sll_demo.c
+++ b/demos/data_structures/sll_demo.c
@@ -1,6 +1,20 @@
 #include "safe_input.h"
 #include "sll.h"
 #include <stdio.h>
+#include <stdlib.h>
+
+static void print_int(const void* data)
+{
+    if (data != NULL)
+    {
+        printf("%d", *(const int*)data);
+    }
+}
+
+static int compare_ints(const void* a, const void* b)
+{
+    return *(const int*)a - *(const int*)b;
+}
 
 void sll_demo(void)
 {
@@ -17,7 +31,7 @@ start_sll:
     if (sll_length_status == INPUT_EXIT_SIGNAL)
     {
         printf("\nExiting sll demo.\n");
-        delete_sll(head);
+        delete_sll(head, free);
         return;
     }
 
@@ -42,7 +56,7 @@ start_sll:
         if (sll_position_status == INPUT_EXIT_SIGNAL)
         {
             printf("\nExiting sll demo.\n");
-            delete_sll(head);
+            delete_sll(head, free);
             return;
         }
 
@@ -64,7 +78,7 @@ start_sll:
             if (sll_end_status == INPUT_EXIT_SIGNAL)
             {
                 printf("\nExiting sll demo.\n");
-                delete_sll(head);
+                delete_sll(head, free);
                 return;
             }
 
@@ -73,21 +87,29 @@ start_sll:
                 goto sll_enter_end_value;
             }
 
-            int status = sll_insertAtEnd(&head, sll_end_value);
-            if (status == -1)
+            int* val = malloc(sizeof(int));
+            if (val == NULL)
             {
                 printf("\nmalloc allocation failure. try again\n");
                 goto sll_enter_end_value;
             }
+            *val = sll_end_value;
+            int status = sll_insertAtEnd(&head, val);
+            if (status == -1)
+            {
+                free(val);
+                printf("\nmalloc allocation failure. try again\n");
+                goto sll_enter_end_value;
+            }
             printf("\n");
-            sll_printlist(head);
+            sll_printlist(head, print_int);
         }
         else if (sll_position_choice == 0)
         {
             int sll_start_status;
             int sll_start_value;
 
-        sll_enter_start_value:
+        dcll_enter_start_value:
             sll_start_status = safe_input_int(&sll_start_value,
                                               "enter the no. you want to insert at beginning, "
                                               "(between 1 and 100), enter '-1' to exit :- ",
@@ -96,22 +118,30 @@ start_sll:
             if (sll_start_status == INPUT_EXIT_SIGNAL)
             {
                 printf("\nExiting sll demo.\n");
-                delete_sll(head);
+                delete_sll(head, free);
                 return;
             }
 
             if (sll_start_status == 0)
             {
-                goto sll_enter_start_value;
+                goto dcll_enter_start_value;
             }
-            int status = sll_insertAtBeginning(&head, sll_start_value);
-            if (status == -1)
+            int* val = malloc(sizeof(int));
+            if (val == NULL)
             {
                 printf("\nmalloc allocation failure. try again\n");
-                goto sll_enter_start_value;
+                goto dcll_enter_start_value;
+            }
+            *val = sll_start_value;
+            int status = sll_insertAtBeginning(&head, val);
+            if (status == -1)
+            {
+                free(val);
+                printf("\nmalloc allocation failure. try again\n");
+                goto dcll_enter_start_value;
             }
             printf("\n");
-            sll_printlist(head);
+            sll_printlist(head, print_int);
         }
         else if (sll_position_choice == 2)
         {
@@ -129,7 +159,7 @@ start_sll:
             if (sll_pos_status == INPUT_EXIT_SIGNAL)
             {
                 printf("\nExiting sll demo.\n");
-                delete_sll(head);
+                delete_sll(head, free);
                 return;
             }
 
@@ -146,7 +176,7 @@ start_sll:
             if (sll_pos_status == INPUT_EXIT_SIGNAL)
             {
                 printf("\nExiting sll demo.\n");
-                delete_sll(head);
+                delete_sll(head, free);
                 return;
             }
 
@@ -155,19 +185,28 @@ start_sll:
                 goto sll_enter_pos_index;
             }
 
-            int status = sll_insertAtPosition(&head, sll_pos_value, sll_pos_index);
+            int* val = malloc(sizeof(int));
+            if (val == NULL)
+            {
+                printf("\nmalloc allocation failure. try again\n");
+                goto sll_enter_pos_value;
+            }
+            *val = sll_pos_value;
+            int status = sll_insertAtPosition(&head, val, sll_pos_index);
             if (status == -1)
             {
+                free(val);
                 printf("\nmalloc allocation failure. try again\n");
                 goto sll_enter_pos_value;
             }
             else if (status == -2)
             {
+                free(val);
                 printf("\ninvalid position. try again\n");
                 goto sll_enter_pos_index;
             }
             printf("\n");
-            sll_printlist(head);
+            sll_printlist(head, print_int);
         }
 
         sll_element_count--;
@@ -178,12 +217,12 @@ start_sll:
     if (rev_sll_status == 1)
     {
         printf("\nReverse of the given list is :- ");
-        sll_printlist(head);
+        sll_printlist(head, print_int);
 
         sll_reverseList(&head);
 
         printf("\nRestored original list :- ");
-        sll_printlist(head);
+        sll_printlist(head, print_int);
     }
     else if (rev_sll_status == -1)
     {
@@ -212,7 +251,7 @@ start_sll:
             continue;
         }
 
-        int index = sll_search(head, sll_search_value);
+        int index = sll_search(head, &sll_search_value, compare_ints);
         printf("\nelement found at index :- %d", index);
     }
 
@@ -232,7 +271,7 @@ start_sll:
         if (sll_delete_status == INPUT_EXIT_SIGNAL)
         {
             printf("\nExiting sll demo.\n");
-            delete_sll(head);
+            delete_sll(head, free);
             return;
         }
         if (sll_delete_status == 0)
@@ -251,7 +290,7 @@ start_sll:
             if (sll_delete_status == INPUT_EXIT_SIGNAL)
             {
                 printf("\nExiting sll demo.\n");
-                delete_sll(head);
+                delete_sll(head, free);
                 return;
             }
             if (sll_delete_status == 0)
@@ -259,7 +298,7 @@ start_sll:
                 continue;
             }
 
-            int status = sll_deleteByValue(&head, sll_delete_value);
+            int status = sll_deleteByValue(&head, &sll_delete_value, compare_ints, free);
             if (status == -2)
             {
                 printf("\nList is empty.Nothing to delete.");
@@ -271,7 +310,7 @@ start_sll:
             else
             {
                 printf("\nsll after deletion - ");
-                sll_printlist(head);
+                sll_printlist(head, print_int);
             }
         }
         else if (sll_delete_choice == 1)
@@ -290,7 +329,7 @@ start_sll:
             if (sll_pos_delete_status == INPUT_EXIT_SIGNAL)
             {
                 printf("\nExiting sll demo.\n");
-                delete_sll(head);
+                delete_sll(head, free);
                 return;
             }
 
@@ -299,7 +338,7 @@ start_sll:
                 goto sll_delete_pos_input;
             }
 
-            int status = sll_deleteAtPosition(&head, sll_pos_delete_index);
+            int status = sll_deleteAtPosition(&head, sll_pos_delete_index, free);
             if (status == -1)
             {
                 printf("\nList is empty\n");
@@ -311,7 +350,7 @@ start_sll:
             else
             {
                 printf("\nsll after deletion - ");
-                sll_printlist(head);
+                sll_printlist(head, print_int);
             }
         }
     }

--- a/demos/data_structures/stack_demo.c
+++ b/demos/data_structures/stack_demo.c
@@ -50,7 +50,7 @@ void stack_demo(void)
             {
                 continue;
             }
-            if (push(s, val) == 1)
+            if (push(s, (void*)(intptr_t)val) == 1)
             {
                 printf("\nSuccessfully pushed %d onto the stack.\n", val);
             }
@@ -68,7 +68,7 @@ void stack_demo(void)
             }
             else
             {
-                int val = pop(s);
+                int val = (int)(intptr_t)pop(s);
                 printf("\nPopped element: %d\n", val);
             }
             printStackAsInts(s);
@@ -81,13 +81,13 @@ void stack_demo(void)
             }
             else
             {
-                int val = peek(s);
+                int val = (int)(intptr_t)peek(s);
                 printf("\nTop element: %d\n", val);
             }
             printStackAsInts(s);
         }
     }
 
-    destroyStack(s);
+    destroyStack(s, NULL);
     printf("\nStack destroyed. Returning to Data Structures menu...\n");
 }

--- a/src/advanced_graph_algorithms/bipartite_matching.c
+++ b/src/advanced_graph_algorithms/bipartite_matching.c
@@ -33,7 +33,7 @@ bool bipartite_color(Graph* graph, int* color)
                 Node* temp = graph->array[u];
                 while (temp != NULL)
                 {
-                    int v = temp->data;
+                    int v = (int)(intptr_t)temp->data;
                     if (color[v] == -1)
                     {
                         color[v] = 1 - color[u];
@@ -161,7 +161,7 @@ int max_bipartite_matching(Graph* graph, int** match_pairs, int* match_count)
             Node* temp = graph->array[u];
             while (temp != NULL)
             {
-                int v = temp->data;
+                int v = (int)(intptr_t)temp->data;
                 if (color[v] == 1)
                 {
                     residual[u][v] = 1;
@@ -217,7 +217,7 @@ int max_bipartite_matching(Graph* graph, int** match_pairs, int* match_count)
             Node* temp = graph->array[u];
             while (temp != NULL)
             {
-                int v = temp->data;
+                int v = (int)(intptr_t)temp->data;
                 if (color[v] == 1 && residual[u][v] == 0)
                 {
                     count++;

--- a/src/advanced_graph_algorithms/eulerian_path.c
+++ b/src/advanced_graph_algorithms/eulerian_path.c
@@ -28,7 +28,7 @@ int find_eulerian_path(Graph* graph, int** path, int* path_len)
         while (temp != NULL)
         {
             out_degree[u]++;
-            in_degree[temp->data]++;
+            in_degree[(int)(intptr_t)temp->data]++;
             total_edges++;
             temp = temp->next;
         }
@@ -146,7 +146,7 @@ int find_eulerian_path(Graph* graph, int** path, int* path_len)
         int u = curr_stack[curr_top - 1];
         if (adj_copy[u] != NULL)
         {
-            int v = adj_copy[u]->data;
+            int v = (int)(intptr_t)adj_copy[u]->data;
             adj_copy[u] = adj_copy[u]->next;
             curr_stack[curr_top++] = v;
         }

--- a/src/advanced_graph_algorithms/hopcroft_karp.c
+++ b/src/advanced_graph_algorithms/hopcroft_karp.c
@@ -35,7 +35,7 @@ static bool hopcroft_karp_bfs(Graph* graph, int* pair_u, int* pair_v, int* dist,
             Node* temp = graph->array[u];
             while (temp != NULL)
             {
-                int v = temp->data;
+                int v = (int)(intptr_t)temp->data;
                 if (color[v] == 1)
                 {
                     if (dist[pair_v[v]] == INT_MAX)
@@ -62,7 +62,7 @@ static bool hopcroft_karp_dfs(Graph* graph, int u, int* pair_u, int* pair_v, int
         Node* temp = graph->array[u];
         while (temp != NULL)
         {
-            int v = temp->data;
+            int v = (int)(intptr_t)temp->data;
             if (color[v] == 1)
             {
                 if (dist[pair_v[v]] == dist[u] + 1)

--- a/src/advanced_graph_algorithms/scc.c
+++ b/src/advanced_graph_algorithms/scc.c
@@ -10,13 +10,13 @@ static void tarjan_dfs(Graph* graph, int u, int* disc, int* low, bool* on_stack,
         return;
 
     disc[u] = low[u] = ++(*time);
-    push(st, u);
+    push(st, (void*)(intptr_t)u);
     on_stack[u] = true;
 
     Node* temp = graph->array[u];
     while (temp != NULL)
     {
-        int v = temp->data;
+        int v = (int)(intptr_t)temp->data;
         if (disc[v] == -1)
         {
             tarjan_dfs(graph, v, disc, low, on_stack, st, time, sccs, sizes, count, success);
@@ -44,7 +44,7 @@ static void tarjan_dfs(Graph* graph, int u, int* disc, int* low, bool* on_stack,
         int w = -1;
         while (w != u)
         {
-            w = pop(st);
+            w = (int)(intptr_t)pop(st);
             on_stack[w] = false;
             comp_size++;
             int* new_comp = realloc(comp, sizeof(int) * comp_size);
@@ -128,7 +128,7 @@ int** find_scc_tarjan(Graph* graph, int* scc_count, int** scc_sizes)
             if (!success)
             {
                 free_scc_result(sccs, sizes, count);
-                destroyStack(st);
+                destroyStack(st, NULL);
                 free(disc);
                 free(low);
                 free(on_stack);
@@ -137,7 +137,7 @@ int** find_scc_tarjan(Graph* graph, int* scc_count, int** scc_sizes)
         }
     }
 
-    destroyStack(st);
+    destroyStack(st, NULL);
     free(disc);
     free(low);
     free(on_stack);
@@ -153,14 +153,14 @@ static void kosaraju_dfs1(Graph* graph, int u, bool* visited, stack* st)
     Node* temp = graph->array[u];
     while (temp != NULL)
     {
-        int v = temp->data;
+        int v = (int)(intptr_t)temp->data;
         if (!visited[v])
         {
             kosaraju_dfs1(graph, v, visited, st);
         }
         temp = temp->next;
     }
-    push(st, u);
+    push(st, (void*)(intptr_t)u);
 }
 
 Graph* transpose_graph(Graph* graph)
@@ -175,7 +175,7 @@ Graph* transpose_graph(Graph* graph)
         Node* temp = graph->array[u];
         while (temp != NULL)
         {
-            int v = temp->data;
+            int v = (int)(intptr_t)temp->data;
             add_edge_directed_unweighted(trans, v, u);
             temp = temp->next;
         }
@@ -199,7 +199,7 @@ static void kosaraju_dfs2(Graph* graph, int u, bool* visited, int** comp, int* c
     Node* temp = graph->array[u];
     while (temp != NULL)
     {
-        int v = temp->data;
+        int v = (int)(intptr_t)temp->data;
         if (!visited[v])
         {
             kosaraju_dfs2(graph, v, visited, comp, comp_size);
@@ -237,7 +237,7 @@ int** find_scc_kosaraju(Graph* graph, int* scc_count, int** scc_sizes)
     Graph* trans = transpose_graph(graph);
     if (trans == NULL)
     {
-        destroyStack(st);
+        destroyStack(st, NULL);
         free(visited);
         return NULL;
     }
@@ -249,7 +249,7 @@ int** find_scc_kosaraju(Graph* graph, int* scc_count, int** scc_sizes)
 
     while (!isEmpty(st))
     {
-        int u = pop(st);
+        int u = (int)(intptr_t)pop(st);
         if (!visited[u])
         {
             int* comp = NULL;
@@ -263,7 +263,7 @@ int** find_scc_kosaraju(Graph* graph, int* scc_count, int** scc_sizes)
                 free(comp);
                 free_scc_result(sccs, sizes, count - 1);
                 free_graph(trans);
-                destroyStack(st);
+                destroyStack(st, NULL);
                 free(visited);
                 return NULL;
             }
@@ -275,7 +275,7 @@ int** find_scc_kosaraju(Graph* graph, int* scc_count, int** scc_sizes)
                 free(comp);
                 free_scc_result(sccs, sizes, count - 1);
                 free_graph(trans);
-                destroyStack(st);
+                destroyStack(st, NULL);
                 free(visited);
                 return NULL;
             }
@@ -286,7 +286,7 @@ int** find_scc_kosaraju(Graph* graph, int* scc_count, int** scc_sizes)
     }
 
     free_graph(trans);
-    destroyStack(st);
+    destroyStack(st, NULL);
     free(visited);
 
     *scc_count = count;

--- a/src/advanced_graph_algorithms/scc_visualize.c
+++ b/src/advanced_graph_algorithms/scc_visualize.c
@@ -33,13 +33,14 @@ static void print_graph_state(Graph* graph, int active_node, int* disc, int* low
         }
         while (temp != NULL)
         {
-            if (temp->data == active_node)
+            int val = (int)(intptr_t)temp->data;
+            if (val == active_node)
             {
-                printf("\033[1;33m%d\033[0m -> ", temp->data); // Yellow for reference
+                printf("\033[1;33m%d\033[0m -> ", val); // Yellow for reference
             }
             else
             {
-                printf("%d -> ", temp->data);
+                printf("%d -> ", val);
             }
             temp = temp->next;
         }
@@ -95,7 +96,7 @@ static void tarjan_dfs_vis(Graph* graph, int u, int* disc, int* low, bool* on_st
         return;
 
     disc[u] = low[u] = ++(*time);
-    push(st, u);
+    push(st, (void*)(intptr_t)u);
     on_stack[u] = true;
 
     print_graph_state(graph, u, disc, low, on_stack, st, "Tarjan DFS");
@@ -103,7 +104,7 @@ static void tarjan_dfs_vis(Graph* graph, int u, int* disc, int* low, bool* on_st
     Node* temp = graph->array[u];
     while (temp != NULL)
     {
-        int v = temp->data;
+        int v = (int)(intptr_t)temp->data;
         if (disc[v] == -1)
         {
             tarjan_dfs_vis(graph, v, disc, low, on_stack, st, time, sccs, sizes, count, success);
@@ -136,7 +137,7 @@ static void tarjan_dfs_vis(Graph* graph, int u, int* disc, int* low, bool* on_st
 
         while (w != u)
         {
-            w = pop(st);
+            w = (int)(intptr_t)pop(st);
             on_stack[w] = false;
             comp_size++;
             int* new_comp = realloc(comp, sizeof(int) * comp_size);
@@ -220,7 +221,7 @@ void visualize_tarjan(Graph* graph)
             if (!success)
             {
                 free_scc_result(sccs, sizes, count);
-                destroyStack(st);
+                destroyStack(st, NULL);
                 free(disc);
                 free(low);
                 free(on_stack);
@@ -245,7 +246,7 @@ void visualize_tarjan(Graph* graph)
     fflush(stdout);
     getchar();
 
-    destroyStack(st);
+    destroyStack(st, NULL);
     free(disc);
     free(low);
     free(on_stack);
@@ -266,14 +267,14 @@ static void kosaraju_dfs1_vis(Graph* graph, int u, bool* visited, stack* st, con
     Node* temp = graph->array[u];
     while (temp != NULL)
     {
-        int v = temp->data;
+        int v = (int)(intptr_t)temp->data;
         if (!visited[v])
         {
             kosaraju_dfs1_vis(graph, v, visited, st, phase);
         }
         temp = temp->next;
     }
-    push(st, u);
+    push(st, (void*)(intptr_t)u);
 }
 
 static void kosaraju_dfs2_vis(Graph* graph, int u, bool* visited, int** comp, int* comp_size)
@@ -302,7 +303,7 @@ static void kosaraju_dfs2_vis(Graph* graph, int u, bool* visited, int** comp, in
     Node* temp = graph->array[u];
     while (temp != NULL)
     {
-        int v = temp->data;
+        int v = (int)(intptr_t)temp->data;
         if (!visited[v])
         {
             kosaraju_dfs2_vis(graph, v, visited, comp, comp_size);
@@ -334,7 +335,7 @@ void visualize_kosaraju(Graph* graph)
 
     while (!isEmpty(st))
     {
-        int u = pop(st);
+        int u = (int)(intptr_t)pop(st);
         if (!visited[u])
         {
             int* comp = NULL;
@@ -348,7 +349,7 @@ void visualize_kosaraju(Graph* graph)
                 free(comp);
                 free_scc_result(sccs, sizes, count - 1);
                 free_graph(trans);
-                destroyStack(st);
+                destroyStack(st, NULL);
                 free(visited);
                 return;
             }
@@ -360,7 +361,7 @@ void visualize_kosaraju(Graph* graph)
                 free(comp);
                 free_scc_result(sccs, sizes, count - 1);
                 free_graph(trans);
-                destroyStack(st);
+                destroyStack(st, NULL);
                 free(visited);
                 return;
             }
@@ -387,7 +388,7 @@ void visualize_kosaraju(Graph* graph)
     getchar();
 
     free_graph(trans);
-    destroyStack(st);
+    destroyStack(st, NULL);
     free(visited);
     free_scc_result(sccs, sizes, count);
 }

--- a/src/advanced_sorting_algorithms/bucket_sort.c
+++ b/src/advanced_sorting_algorithms/bucket_sort.c
@@ -67,13 +67,13 @@ static void bucket_sort_internal(int arr[], int n, int is_top_level, int total_l
         }
 
         // Insert element into the bucket list using SLL utility
-        int insert_status = sll_insertAtBeginning(&buckets[bucket_idx], arr[i]);
+        int insert_status = sll_insertAtBeginning(&buckets[bucket_idx], (void*)(intptr_t)arr[i]);
         if (insert_status == -1)
         {
             // Cleanup allocated memory on error
             for (int j = 0; j < N; j++)
             {
-                delete_sll(buckets[j]);
+                delete_sll(buckets[j], NULL);
             }
             free(buckets);
             return;
@@ -94,14 +94,14 @@ static void bucket_sort_internal(int arr[], int n, int is_top_level, int total_l
 
         if (bucket_size == 1)
         {
-            arr[arr_idx] = buckets[i]->data;
+            arr[arr_idx] = (int)(intptr_t)(buckets[i]->data);
             if (is_top_level)
             {
                 visualize_sort(arr, total_len, arr_idx, -1, -1,
                                "Bucket Sort: Gathering elements back to main array");
             }
             arr_idx++;
-            delete_sll(buckets[i]);
+            delete_sll(buckets[i], NULL);
             buckets[i] = NULL;
         }
         else if (bucket_size > 1)
@@ -113,7 +113,7 @@ static void bucket_sort_internal(int arr[], int n, int is_top_level, int total_l
                 // Cleanup remaining buckets on memory failure
                 for (int j = i; j < N; j++)
                 {
-                    delete_sll(buckets[j]);
+                    delete_sll(buckets[j], NULL);
                 }
                 free(buckets);
                 return;
@@ -123,10 +123,10 @@ static void bucket_sort_internal(int arr[], int n, int is_top_level, int total_l
             int temp_idx = 0;
             while (curr != NULL)
             {
-                temp_arr[temp_idx++] = curr->data;
+                temp_arr[temp_idx++] = (int)(intptr_t)(curr->data);
                 curr = curr->next;
             }
-            delete_sll(buckets[i]);
+            delete_sll(buckets[i], NULL);
             buckets[i] = NULL;
 
             // Recursively sort the elements in the bucket

--- a/src/data_structures/sll.c
+++ b/src/data_structures/sll.c
@@ -7,7 +7,7 @@
 // deleteByValue and reverseList
 
 // insert at end returns -1 on allocation failure and 1 on successful insertion
-int sll_insertAtEnd(Node** head_ref, int value)
+int sll_insertAtEnd(Node** head_ref, void* value)
 {
     Node* newnode = malloc(sizeof(Node));
     if (newnode == NULL)
@@ -30,21 +30,24 @@ int sll_insertAtEnd(Node** head_ref, int value)
 }
 
 // returns -1 if list and 1 on successful deletion
-int sll_deleteAtBeginning(Node** head_ref)
+int sll_deleteAtBeginning(Node** head_ref, void (*free_data)(void*))
 {
     if (*head_ref == NULL)
     {
         return -1;
     }
     Node* temp = *head_ref;
-    temp = temp->next;
-    free(*head_ref);
-    *head_ref = temp;
+    *head_ref = temp->next;
+    if (free_data != NULL)
+    {
+        free_data(temp->data);
+    }
+    free(temp);
     return 1;
 }
 
 // insertAtBeginning function returns -1 on allocation failure and 1 on succesful insertion
-int sll_insertAtBeginning(Node** head_ref, int value)
+int sll_insertAtBeginning(Node** head_ref, void* value)
 {
     Node* newnode = malloc(sizeof(Node));
     if (newnode == NULL)
@@ -56,7 +59,7 @@ int sll_insertAtBeginning(Node** head_ref, int value)
 }
 
 // return -1 if list is empty and 1 on successful deletion
-int sll_deleteAtEnd(Node** head_ref)
+int sll_deleteAtEnd(Node** head_ref, void (*free_data)(void*))
 {
     if (*head_ref == NULL)
     {
@@ -65,6 +68,10 @@ int sll_deleteAtEnd(Node** head_ref)
     Node* temp = *head_ref;
     if (temp->next == NULL)
     {
+        if (free_data != NULL)
+        {
+            free_data(temp->data);
+        }
         free(temp);
         *head_ref = NULL;
         return 1;
@@ -76,28 +83,50 @@ int sll_deleteAtEnd(Node** head_ref)
         prev = curr;
         curr = curr->next;
     }
+    if (free_data != NULL)
+    {
+        free_data(curr->data);
+    }
     free(curr);
     prev->next = NULL;
     return 1;
 }
 
-void sll_printlist(const Node* head)
+void sll_printlist(const Node* head, void (*print_element)(const void*))
 {
     printf("HEAD->");
     while (head != NULL)
     {
-        printf("%d ->", head->data);
+        if (print_element != NULL)
+        {
+            print_element(head->data);
+        }
+        else
+        {
+            printf("%p", head->data);
+        }
+        printf(" ->");
         head = head->next;
     }
     printf("NULL");
 }
 
-int sll_search(const Node* head, int key)
+int sll_search(const Node* head, const void* key, int (*compare)(const void*, const void*))
 {
     int index = 0;
     while (head != NULL)
     {
-        if (head->data == key)
+        int match = 0;
+        if (compare != NULL)
+        {
+            match = (compare(head->data, key) == 0);
+        }
+        else
+        {
+            match = (head->data == key);
+        }
+
+        if (match)
         {
             return index; // if value found returns index number
         }
@@ -108,7 +137,8 @@ int sll_search(const Node* head, int key)
 }
 
 // return -2 if list is empty, -1 if element not found and 1 on successful deletion
-int sll_deleteByValue(Node** head_ref, int value)
+int sll_deleteByValue(Node** head_ref, const void* value, int (*compare)(const void*, const void*),
+                      void (*free_data)(void*))
 {
     if (*head_ref == NULL)
     {
@@ -116,14 +146,44 @@ int sll_deleteByValue(Node** head_ref, int value)
     }
     Node* curr = *head_ref;
     Node* prev = NULL;
-    if (curr->data == value)
+
+    int head_match = 0;
+    if (compare != NULL)
+    {
+        head_match = (compare(curr->data, value) == 0);
+    }
+    else
+    {
+        head_match = (curr->data == value);
+    }
+
+    if (head_match)
     {
         *head_ref = curr->next;
+        if (free_data != NULL)
+        {
+            free_data(curr->data);
+        }
         free(curr);
         return 1;
     }
-    while (curr->data != value)
+    while (1)
     {
+        int match = 0;
+        if (compare != NULL)
+        {
+            match = (compare(curr->data, value) == 0);
+        }
+        else
+        {
+            match = (curr->data == value);
+        }
+
+        if (match)
+        {
+            break;
+        }
+
         prev = curr;
         curr = curr->next;
         if (curr == NULL)
@@ -132,6 +192,10 @@ int sll_deleteByValue(Node** head_ref, int value)
         }
     }
     prev->next = curr->next;
+    if (free_data != NULL)
+    {
+        free_data(curr->data);
+    }
     free(curr);
     return 1;
 }
@@ -162,11 +226,15 @@ int sll_reverseList(Node** head_ref)
     return 1;
 }
 
-void delete_sll(Node* head)
+void delete_sll(Node* head, void (*free_data)(void*))
 {
     while (head != NULL)
     {
         Node* upcoming = head->next;
+        if (free_data != NULL)
+        {
+            free_data(head->data);
+        }
         free(head);
         head = upcoming;
     }
@@ -186,7 +254,7 @@ int sll_getLength(const Node* head)
 
 // Insert at a specific position (0-indexed)
 // Returns 1 on success, -1 on malloc failure, -2 on invalid position
-int sll_insertAtPosition(Node** head_ref, int value, int position)
+int sll_insertAtPosition(Node** head_ref, void* value, int position)
 {
     int length = sll_getLength(*head_ref);
 
@@ -221,7 +289,7 @@ int sll_insertAtPosition(Node** head_ref, int value, int position)
 
 // Delete at a specific position (0-indexed)
 // Returns 1 on success, -1 on empty list, -2 on invalid position
-int sll_deleteAtPosition(Node** head_ref, int position)
+int sll_deleteAtPosition(Node** head_ref, int position, void (*free_data)(void*))
 {
     if (*head_ref == NULL)
     {
@@ -240,6 +308,10 @@ int sll_deleteAtPosition(Node** head_ref, int position)
     if (position == 0)
     {
         *head_ref = temp->next;
+        if (free_data != NULL)
+        {
+            free_data(temp->data);
+        }
         free(temp);
         return 1;
     }
@@ -252,6 +324,10 @@ int sll_deleteAtPosition(Node** head_ref, int position)
     }
 
     prev->next = temp->next;
+    if (free_data != NULL)
+    {
+        free_data(temp->data);
+    }
     free(temp);
     return 1;
 }

--- a/src/data_structures/sll.h
+++ b/src/data_structures/sll.h
@@ -1,56 +1,59 @@
 #ifndef SLL_H
 #define SLL_H
 
+#include <stdint.h>
+
 typedef struct Node
 {
-    int data;
+    void* data;
     struct Node* next;
 } Node;
 
 // Print the elements of a singly linked list.
-void sll_printlist(const Node* head);
+void sll_printlist(const Node* head, void (*print_element)(const void*));
 
 // Insert a value at the end of a singly linked list. Returns 1 on success, -1 on allocation
 // failure.
-int sll_insertAtEnd(Node** head_ref, int value);
+int sll_insertAtEnd(Node** head_ref, void* value);
 
 // Delete the first element from a singly linked list. Returns 1 on success, -1 if the list is
 // empty.
-int sll_deleteAtBeginning(Node** head_ref);
+int sll_deleteAtBeginning(Node** head_ref, void (*free_data)(void*));
 
 // Delete the last element from a singly linked list. Returns 1 on success, -1 if the list is empty.
-int sll_deleteAtEnd(Node** head_ref);
+int sll_deleteAtEnd(Node** head_ref, void (*free_data)(void*));
 
 // Delete the first occurrence of a value from a singly linked list. Returns 1 on success, -2 if the
 // list is empty, -1 if not found.
-int sll_deleteByValue(Node** head_ref, int value);
+int sll_deleteByValue(Node** head_ref, const void* value, int (*compare)(const void*, const void*),
+                      void (*free_data)(void*));
 
 // Insert a value at the beginning of a singly linked list. Returns 1 on success, -1 on allocation
 // failure.
-int sll_insertAtBeginning(Node** head_ref, int value);
+int sll_insertAtBeginning(Node** head_ref, void* value);
 
 // Run the singly linked list demonstration module.
 void sll_demo(void);
 
 // Search for a key in a singly linked list. Returns The index of the key or -1 if not found.
-int sll_search(const Node* head, int key);
+int sll_search(const Node* head, const void* key, int (*compare)(const void*, const void*));
 
 // Reverse a singly linked list in place. Returns 1 on success, -2 if empty, -1 if only one node
 // exists.
 int sll_reverseList(Node** head_ref);
 
 // Free all nodes in a singly linked list.
-void delete_sll(Node* head);
+void delete_sll(Node* head, void (*free_data)(void*));
 
 // Get the number of nodes in a singly linked list. Returns The number of nodes in the list.
 int sll_getLength(const Node* head);
 
 // Insert a value at a specific position in a singly linked list. Returns 1 on success, -1 on
 // allocation failure, -2 on invalid position.
-int sll_insertAtPosition(Node** head_ref, int value, int position);
+int sll_insertAtPosition(Node** head_ref, void* value, int position);
 
 // Delete a node at a specific position in a singly linked list. Returns 1 on success, -1 if the
 // list is empty, -2 on invalid position.
-int sll_deleteAtPosition(Node** head_ref, int position);
+int sll_deleteAtPosition(Node** head_ref, int position, void (*free_data)(void*));
 
 #endif

--- a/src/data_structures/stack.c
+++ b/src/data_structures/stack.c
@@ -3,7 +3,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-int push(stack* s, int value)
+int push(stack* s, void* value)
 {
     if (s == NULL)
         return 0;
@@ -14,12 +14,12 @@ int push(stack* s, int value)
     return 0;
 }
 
-int pop(stack* s)
+void* pop(stack* s)
 {
     if (s == NULL || s->top == NULL)
-        return -1;
-    int top_of_stack = s->top->data;
-    sll_deleteAtBeginning(&(s->top));
+        return NULL;
+    void* top_of_stack = s->top->data;
+    sll_deleteAtBeginning(&(s->top), NULL); // DO NOT free the payload here, caller gets it
     return top_of_stack;
 }
 
@@ -39,21 +39,18 @@ bool isEmpty(const stack* s)
     return s->top == NULL;
 }
 
-void destroyStack(stack* s)
+void destroyStack(stack* s, void (*free_data)(void*))
 {
     if (s == NULL)
         return;
-    while (!isEmpty(s))
-    {
-        pop(s);
-    }
+    delete_sll(s->top, free_data);
     free(s);
 }
 
-int peek(const stack* s)
+void* peek(const stack* s)
 {
     if (s == NULL || s->top == NULL)
-        return -1;
+        return NULL;
     return s->top->data;
 }
 
@@ -72,7 +69,7 @@ void printStack(const stack* s)
     Node* curr = s->top;
     while (curr != NULL)
     {
-        printf("| %c ", curr->data);
+        printf("| %c ", (char)(intptr_t)(curr->data));
         curr = curr->next;
     }
     printf("|\n");
@@ -93,7 +90,7 @@ void printStackAsInts(const stack* s)
     Node* curr = s->top;
     while (curr != NULL)
     {
-        printf("| %d ", curr->data);
+        printf("| %d ", (int)(intptr_t)(curr->data));
         curr = curr->next;
     }
     printf("|\n");

--- a/src/data_structures/stack.h
+++ b/src/data_structures/stack.h
@@ -14,19 +14,19 @@ typedef struct stack
 stack* createStack(void);
 
 // Push a value onto the stack. Returns 1 on success, -1 if the stack is invalid.
-int push(stack* s, int value);
+int push(stack* s, void* value);
 
 // Pop a value from the stack. Returns The popped value.
-int pop(stack* s);
+void* pop(stack* s);
 
 // Check if the stack is empty. Returns true if empty, false otherwise.
 bool isEmpty(const stack* s);
 
 // Destroy a stack and free its resources.
-void destroyStack(stack* s);
+void destroyStack(stack* s, void (*free_data)(void*));
 
 // Peek at the top value of the stack without popping it. Returns The top value.
-int peek(const stack* s);
+void* peek(const stack* s);
 
 // Print the stack contents using characters.
 void printStack(const stack* s);

--- a/src/expression_evaluation/infix_to_postfix.c
+++ b/src/expression_evaluation/infix_to_postfix.c
@@ -5,7 +5,7 @@
 #include "safe_input.h"
 #include <ctype.h>
 #include <stdio.h>
-
+#include <stdlib.h>
 #include <string.h>
 
 // rn this program only has support for four operators - +-/* and parantheses. this program doesnt
@@ -56,7 +56,7 @@ int infix_to_postfix_convert(const char* infix_expr, char* postfix_expr, size_t 
         {
             if ((size_t)pf_idx + 1 >= max_size)
             {
-                destroyStack(operators);
+                destroyStack(operators, NULL);
                 return EXPR_ERROR_MALFORMED;
             }
             postfix_expr[pf_idx++] = ch;
@@ -67,19 +67,19 @@ int infix_to_postfix_convert(const char* infix_expr, char* postfix_expr, size_t 
         }
         else if (ch == '(')
         {
-            push(operators, ch);
+            push(operators, (void*)(intptr_t)ch);
             action_msg = "Pushed '(' onto stack";
         }
         else if (ch == ')')
         {
             action_msg = "Popped operators until matching '(' was found";
 
-            while (!isEmpty(operators) && peek(operators) != '(')
+            while (!isEmpty(operators) && (char)(intptr_t)peek(operators) != '(')
             {
-                op = pop(operators);
+                op = (char)(intptr_t)pop(operators);
                 if ((size_t)pf_idx + 1 >= max_size)
                 {
-                    destroyStack(operators);
+                    destroyStack(operators, NULL);
                     return EXPR_ERROR_MALFORMED;
                 }
                 postfix_expr[pf_idx++] = op;
@@ -88,7 +88,7 @@ int infix_to_postfix_convert(const char* infix_expr, char* postfix_expr, size_t 
 
             if (isEmpty(operators))
             {
-                destroyStack(operators);
+                destroyStack(operators, NULL);
                 return EXPR_ERROR_UNMATCHED_PARENTHESES;
             }
             pop(operators); // Remove '('
@@ -97,34 +97,34 @@ int infix_to_postfix_convert(const char* infix_expr, char* postfix_expr, size_t 
         {
             if (isEmpty(operators))
             {
-                push(operators, ch);
+                push(operators, (void*)(intptr_t)ch);
                 snprintf(opbuf, sizeof(opbuf), "Pushed operator '%c' onto stack", ch);
                 action_msg = opbuf;
             }
-            else if (precedence(ch) > precedence(peek(operators)))
+            else if (precedence(ch) > precedence((char)(intptr_t)peek(operators)))
             {
-                push(operators, ch);
+                push(operators, (void*)(intptr_t)ch);
                 snprintf(opbuf, sizeof(opbuf), "Pushed operator '%c' onto stack", ch);
                 action_msg = opbuf;
             }
-            else if (precedence(ch) <= precedence(peek(operators)))
+            else if (precedence(ch) <= precedence((char)(intptr_t)peek(operators)))
             {
                 int prec_lower = precedence(ch);
 
-                while (!isEmpty(operators) && peek(operators) != '(' &&
-                       precedence(peek(operators)) >= prec_lower)
+                while (!isEmpty(operators) && (char)(intptr_t)peek(operators) != '(' &&
+                       precedence((char)(intptr_t)peek(operators)) >= prec_lower)
                 {
-                    op = pop(operators);
+                    op = (char)(intptr_t)pop(operators);
                     if ((size_t)pf_idx + 1 >= max_size)
                     {
-                        destroyStack(operators);
+                        destroyStack(operators, NULL);
                         return EXPR_ERROR_MALFORMED;
                     }
                     postfix_expr[pf_idx++] = op;
                     postfix_expr[pf_idx] = '\0';
                 }
 
-                push(operators, ch);
+                push(operators, (void*)(intptr_t)ch);
                 snprintf(opbuf, sizeof(opbuf),
                          "Popped operators with higher/equal precedence, then pushed '%c'", ch);
                 action_msg = opbuf;
@@ -132,7 +132,7 @@ int infix_to_postfix_convert(const char* infix_expr, char* postfix_expr, size_t 
         }
         else
         {
-            destroyStack(operators);
+            destroyStack(operators, NULL);
             return EXPR_ERROR_INVALID_CHAR;
         }
 
@@ -154,16 +154,16 @@ int infix_to_postfix_convert(const char* infix_expr, char* postfix_expr, size_t 
         {
             clear_screen();
         }
-        char op = pop(operators);
+        char op = (char)(intptr_t)pop(operators);
         if (op == '(')
         {
-            destroyStack(operators);
+            destroyStack(operators, NULL);
             return EXPR_ERROR_UNMATCHED_PARENTHESES;
         }
 
         if ((size_t)pf_idx + 1 >= max_size)
         {
-            destroyStack(operators);
+            destroyStack(operators, NULL);
             return EXPR_ERROR_MALFORMED;
         }
         postfix_expr[pf_idx++] = op;
@@ -178,7 +178,7 @@ int infix_to_postfix_convert(const char* infix_expr, char* postfix_expr, size_t 
         printf("----------------------------------\n");
     }
 
-    destroyStack(operators);
+    destroyStack(operators, NULL);
     return EXPR_SUCCESS;
 }
 

--- a/src/expression_evaluation/infix_to_prefix.c
+++ b/src/expression_evaluation/infix_to_prefix.c
@@ -5,7 +5,7 @@
 #include "safe_input.h"
 #include <ctype.h>
 #include <stdio.h>
-
+#include <stdlib.h>
 #include <string.h>
 
 static void reverse_string(char* str)
@@ -56,7 +56,7 @@ int infix_to_prefix_convert(const char* infix_expr, char* prefix_expr, size_t ma
 
     if (strlen(infix_expr) >= sizeof(reversed_expr))
     {
-        destroyStack(operators);
+        destroyStack(operators, NULL);
         return EXPR_ERROR_MALFORMED;
     }
 
@@ -84,7 +84,7 @@ int infix_to_prefix_convert(const char* infix_expr, char* prefix_expr, size_t ma
         {
             if ((size_t)pf_idx + 1 >= sizeof(postfix_expr))
             {
-                destroyStack(operators);
+                destroyStack(operators, NULL);
                 return EXPR_ERROR_MALFORMED;
             }
             postfix_expr[pf_idx++] = ch;
@@ -95,25 +95,25 @@ int infix_to_prefix_convert(const char* infix_expr, char* prefix_expr, size_t ma
         }
         else if (ch == '(')
         {
-            push(operators, ch);
+            push(operators, (void*)(intptr_t)ch);
             action_msg = "Pushed '(' onto stack";
         }
         else if (ch == ')')
         {
-            while (!isEmpty(operators) && peek(operators) != '(')
+            while (!isEmpty(operators) && (char)(intptr_t)peek(operators) != '(')
             {
                 if ((size_t)pf_idx + 1 >= sizeof(postfix_expr))
                 {
-                    destroyStack(operators);
+                    destroyStack(operators, NULL);
                     return EXPR_ERROR_MALFORMED;
                 }
-                postfix_expr[pf_idx++] = pop(operators);
+                postfix_expr[pf_idx++] = (char)(intptr_t)pop(operators);
                 postfix_expr[pf_idx] = '\0';
             }
 
             if (isEmpty(operators))
             {
-                destroyStack(operators);
+                destroyStack(operators, NULL);
                 return EXPR_ERROR_UNMATCHED_PARENTHESES;
             }
             pop(operators);
@@ -121,25 +121,25 @@ int infix_to_prefix_convert(const char* infix_expr, char* prefix_expr, size_t ma
         }
         else if (isOperator(ch))
         {
-            while (!isEmpty(operators) && peek(operators) != '(' &&
-                   precedence(peek(operators)) > precedence(ch))
+            while (!isEmpty(operators) && (char)(intptr_t)peek(operators) != '(' &&
+                   precedence((char)(intptr_t)peek(operators)) > precedence(ch))
             {
                 if ((size_t)pf_idx + 1 >= sizeof(postfix_expr))
                 {
-                    destroyStack(operators);
+                    destroyStack(operators, NULL);
                     return EXPR_ERROR_MALFORMED;
                 }
-                postfix_expr[pf_idx++] = pop(operators);
+                postfix_expr[pf_idx++] = (char)(intptr_t)pop(operators);
                 postfix_expr[pf_idx] = '\0';
             }
 
-            push(operators, ch);
+            push(operators, (void*)(intptr_t)ch);
             snprintf(opbuf, sizeof(opbuf), "Processed operator '%c'", ch);
             action_msg = opbuf;
         }
         else
         {
-            destroyStack(operators);
+            destroyStack(operators, NULL);
             return EXPR_ERROR_INVALID_CHAR;
         }
 
@@ -162,16 +162,16 @@ int infix_to_prefix_convert(const char* infix_expr, char* prefix_expr, size_t ma
             clear_screen();
         }
 
-        char op = pop(operators);
+        char op = (char)(intptr_t)pop(operators);
         if (op == '(')
         {
-            destroyStack(operators);
+            destroyStack(operators, NULL);
             return EXPR_ERROR_UNMATCHED_PARENTHESES;
         }
 
         if ((size_t)pf_idx + 1 >= sizeof(postfix_expr))
         {
-            destroyStack(operators);
+            destroyStack(operators, NULL);
             return EXPR_ERROR_MALFORMED;
         }
         postfix_expr[pf_idx++] = op;
@@ -190,14 +190,14 @@ int infix_to_prefix_convert(const char* infix_expr, char* prefix_expr, size_t ma
 
     if (strlen(postfix_expr) >= max_size)
     {
-        destroyStack(operators);
+        destroyStack(operators, NULL);
         return EXPR_ERROR_MALFORMED;
     }
 
     strcpy(prefix_expr, postfix_expr);
     reverse_string(prefix_expr);
 
-    destroyStack(operators);
+    destroyStack(operators, NULL);
     return EXPR_SUCCESS;
 }
 

--- a/src/expression_evaluation/parantheses_checker.c
+++ b/src/expression_evaluation/parantheses_checker.c
@@ -22,7 +22,7 @@ int check_parantheses(char* s)
         printf("Char    : %c\n", s[i]);
         if (s[i] == '(' || s[i] == '[' || s[i] == '{')
         {
-            push(parantheses, s[i]);
+            push(parantheses, (void*)(intptr_t)s[i]);
             printf("Action  : Pushed '%c' onto stack\n", s[i]);
             if (isEmpty(parantheses))
                 printf("Stack   : Empty\n");
@@ -38,10 +38,10 @@ int check_parantheses(char* s)
             {
                 printf("Action  : No matching opening bracket found for '%c'\n", s[i]);
                 printf("Stack   : Empty\n");
-                destroyStack(parantheses);
+                destroyStack(parantheses, NULL);
                 return EXPR_ERROR_UNMATCHED_PARENTHESES;
             }
-            int top = pop(parantheses);
+            int top = (int)(intptr_t)pop(parantheses);
 
             if (s[i] == ')')
             {
@@ -55,7 +55,7 @@ int check_parantheses(char* s)
                     else
                         printStack(parantheses);
 
-                    destroyStack(parantheses);
+                    destroyStack(parantheses, NULL);
                     return EXPR_ERROR_UNMATCHED_PARENTHESES;
                 }
                 printf("Action  : Matched '(' with ')'\n");
@@ -72,7 +72,7 @@ int check_parantheses(char* s)
                     else
                         printStack(parantheses);
 
-                    destroyStack(parantheses);
+                    destroyStack(parantheses, NULL);
                     return EXPR_ERROR_UNMATCHED_PARENTHESES;
                 }
                 printf("Action  : Matched '[' with ']'\n");
@@ -89,7 +89,7 @@ int check_parantheses(char* s)
                     else
                         printStack(parantheses);
 
-                    destroyStack(parantheses);
+                    destroyStack(parantheses, NULL);
                     return EXPR_ERROR_UNMATCHED_PARENTHESES;
                 }
                 printf("Action  : Matched '{' with '}'\n");
@@ -116,9 +116,10 @@ int check_parantheses(char* s)
         printf("Stack   : ");
         printStack(parantheses);
     }
-    destroyStack(parantheses);
+    destroyStack(parantheses, NULL);
     return result ? EXPR_SUCCESS : EXPR_ERROR_UNMATCHED_PARENTHESES;
 }
+
 int get_validated_input_parantheses(char* buff, size_t size, const char* prompt)
 {
     if (prompt)
@@ -152,6 +153,7 @@ int get_validated_input_parantheses(char* buff, size_t size, const char* prompt)
     }
     return 1;
 }
+
 void parantheses_checker_demo(void)
 {
     char parantheses_expression[50];

--- a/src/expression_evaluation/postfix_evaluation.c
+++ b/src/expression_evaluation/postfix_evaluation.c
@@ -5,6 +5,7 @@
 #include "safe_input.h"
 #include <ctype.h>
 #include <stdio.h>
+#include <stdlib.h>
 
 // if postfix expression attempts to divide by zero or the stack doesnt get emptied at the end of
 // main while loop, it indicates malformed postfix expression and program exits with error code '-1'
@@ -33,7 +34,7 @@ int evaluate_postfix_expr(const char* postfix_expr, int* final_result)
         char ch = postfix_expr[i];
         if (isdigit((unsigned char)ch))
         {
-            push(operands, ch - '0');
+            push(operands, (void*)(intptr_t)(ch - '0'));
             snprintf(action_msg, sizeof(action_msg), "Pushed operand '%c' onto stack", ch);
             current_result = ch - '0';
 
@@ -53,19 +54,19 @@ int evaluate_postfix_expr(const char* postfix_expr, int* final_result)
                 printf("\n[Error] Invalid expression: Stack underflow (missing operands for "
                        "operator '%c')\n",
                        ch);
-                destroyStack(operands);
+                destroyStack(operands, NULL);
                 return EXPR_ERROR_STACK_UNDERFLOW;
             }
-            int right_operand = pop(operands);
+            int right_operand = (int)(intptr_t)pop(operands);
             if (isEmpty(operands))
             {
                 printf("\n[Error] Invalid expression: Stack underflow (missing operands for "
                        "operator '%c')\n",
                        ch);
-                destroyStack(operands);
+                destroyStack(operands, NULL);
                 return EXPR_ERROR_STACK_UNDERFLOW;
             }
-            int left_operand = pop(operands);
+            int left_operand = (int)(intptr_t)pop(operands);
             int result = 0;
             if (ch == '+')
             {
@@ -96,7 +97,7 @@ int evaluate_postfix_expr(const char* postfix_expr, int* final_result)
                 if (right_operand == 0)
                 {
                     printf("\n[Error] Division by zero encountered.\n");
-                    destroyStack(operands);
+                    destroyStack(operands, NULL);
                     return EXPR_ERROR_DIVIDE_BY_ZERO;
                 }
                 result = left_operand / right_operand;
@@ -105,7 +106,7 @@ int evaluate_postfix_expr(const char* postfix_expr, int* final_result)
                          "onto stack",
                          left_operand, right_operand, left_operand, right_operand, result);
             }
-            push(operands, result);
+            push(operands, (void*)(intptr_t)result);
             current_result = result;
 
             printf("Step    : %d\n", step);
@@ -119,7 +120,7 @@ int evaluate_postfix_expr(const char* postfix_expr, int* final_result)
         }
         else
         {
-            destroyStack(operands);
+            destroyStack(operands, NULL);
             return EXPR_ERROR_INVALID_CHAR;
         }
 
@@ -129,19 +130,19 @@ int evaluate_postfix_expr(const char* postfix_expr, int* final_result)
 
     if (isEmpty(operands))
     {
-        destroyStack(operands);
+        destroyStack(operands, NULL);
         return EXPR_ERROR_EMPTY;
     }
 
-    *final_result = pop(operands);
+    *final_result = (int)(intptr_t)pop(operands);
 
     if (!isEmpty(operands))
     {
-        destroyStack(operands);
+        destroyStack(operands, NULL);
         return EXPR_ERROR_MALFORMED;
     }
 
-    destroyStack(operands);
+    destroyStack(operands, NULL);
     return EXPR_SUCCESS;
 }
 

--- a/src/graph_traversals/bfs.c
+++ b/src/graph_traversals/bfs.c
@@ -72,7 +72,7 @@ void bfs(Graph* graph, int start)
 
         while (temp)
         {
-            int v = temp->data;
+            int v = (int)(intptr_t)temp->data;
 
             if (!visited[v])
             {
@@ -133,8 +133,8 @@ void add_edge_undirected(Graph* graph, int src, int dest)
         return;
     }
 
-    sll_insertAtEnd(&graph->array[src], dest);
-    sll_insertAtEnd(&graph->array[dest], src);
+    sll_insertAtEnd(&graph->array[src], (void*)(intptr_t)dest);
+    sll_insertAtEnd(&graph->array[dest], (void*)(intptr_t)src);
 }
 
 void free_graph(Graph* graph)
@@ -145,14 +145,7 @@ void free_graph(Graph* graph)
     }
     for (int i = 0; i < graph->V; i++)
     {
-        Node* temp = graph->array[i];
-
-        while (temp)
-        {
-            Node* next = temp->next;
-            free(temp);
-            temp = next;
-        }
+        delete_sll(graph->array[i], NULL);
     }
 
     free(graph->array);
@@ -170,5 +163,5 @@ void add_edge_directed_unweighted(Graph* graph, int src, int dest)
         return;
     }
 
-    sll_insertAtEnd(&graph->array[src], dest);
+    sll_insertAtEnd(&graph->array[src], (void*)(intptr_t)dest);
 }

--- a/src/graph_traversals/dfs.c
+++ b/src/graph_traversals/dfs.c
@@ -53,15 +53,11 @@ void dfs(Graph* graph, int start)
     visited[start] = 1;
     snprintf(msg, sizeof(msg), "DFS: Visited start node %d", start);
     algorithm_step_hook(msg);
-    push(nodes, start);
+    push(nodes, (void*)(intptr_t)start);
 
-    while (1)
+    while (!isEmpty(nodes))
     { // main loop which performs dfs
-        int curr = pop(nodes);
-        if (curr == -1)
-        {
-            break;
-        }
+        int curr = (int)(intptr_t)pop(nodes);
         snprintf(msg, sizeof(msg), "DFS: Popped node %d from stack", curr);
         algorithm_step_hook(msg);
         printf("%d->", curr);
@@ -70,13 +66,13 @@ void dfs(Graph* graph, int start)
 
         while (temp)
         {
-            int v = temp->data;
+            int v = (int)(intptr_t)temp->data;
             if (!visited[v])
             {
                 visited[v] = 1;
                 snprintf(msg, sizeof(msg), "DFS: Discovered node %d, pushing to stack", v);
                 algorithm_step_hook(msg);
-                push(nodes, v);
+                push(nodes, (void*)(intptr_t)v);
             }
             temp = temp->next;
         }
@@ -87,7 +83,7 @@ void dfs(Graph* graph, int start)
 
     printf("end\n");
     printf("\ntotal CPU time taken for DFS traversal:- %f seconds\n", total_t);
-    destroyStack(nodes);
+    destroyStack(nodes, NULL);
     telemetry_close();
     return;
 }

--- a/src/graph_traversals/graph_io.c
+++ b/src/graph_traversals/graph_io.c
@@ -302,11 +302,11 @@ void print_graph(const Graph* graph)
         }
         while (head->next != NULL)
         {
-            printf("%d, ", head->data);
+            printf("%d, ", (int)(intptr_t)head->data);
             head = head->next;
         }
 
-        printf("%d", head->data);
+        printf("%d", (int)(intptr_t)head->data);
 
         printf("\n");
     }

--- a/src/graph_traversals/topological_sort.c
+++ b/src/graph_traversals/topological_sort.c
@@ -26,7 +26,7 @@ void topological_sort_kahn(Graph* graph)
 
         while (temp)
         {
-            in_degree[temp->data]++;
+            in_degree[(int)(intptr_t)temp->data]++;
             temp = temp->next;
         }
     }
@@ -68,7 +68,7 @@ void topological_sort_kahn(Graph* graph)
 
         while (temp)
         {
-            int v = temp->data;
+            int v = (int)(intptr_t)temp->data;
 
             in_degree[v]--;
 

--- a/src/hashing/separate_chaining.c
+++ b/src/hashing/separate_chaining.c
@@ -4,6 +4,11 @@
 #include <stdio.h>
 #include <string.h>
 
+static void print_int(const void* data)
+{
+    printf("%d", (int)(intptr_t)data);
+}
+
 void separate_chaining_demo(void)
 {
     while (1)
@@ -39,7 +44,7 @@ void separate_chaining_demo(void)
                 printf("\nExiting separate chaining demo....");
                 for (int i = 0; i < hash_table_size; i++)
                 {
-                    delete_sll(table[i]);
+                    delete_sll(table[i], NULL);
                 }
                 return;
             }
@@ -55,13 +60,15 @@ void separate_chaining_demo(void)
                 continue;
             }
 
-            sll_insertAtEnd(&table[hash_location],
-                            value); // insert value by passing the address of the pointer to Node
+            sll_insertAtEnd(
+                &table[hash_location],
+                (void*)(intptr_t)
+                    value); // insert value by passing the address of the pointer to Node
 
             for (int i = 0; i < hash_table_size; i++)
             {
                 printf("bucket %d -> ", i);
-                sll_printlist(table[i]);
+                sll_printlist(table[i], print_int);
                 printf("\n");
             }
         }

--- a/tests/data_structures/test_sll.c
+++ b/tests/data_structures/test_sll.c
@@ -3,13 +3,20 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+static int compare_ints(const void* a, const void* b)
+{
+    return *(const int*)a - *(const int*)b;
+}
+
 /* Helper: build list from array */
 static Node* build_list(int arr[], int n)
 {
     Node* head = NULL;
     for (int i = 0; i < n; i++)
     {
-        assert(sll_insertAtEnd(&head, arr[i]) == 1);
+        int* val = malloc(sizeof(int));
+        *val = arr[i];
+        assert(sll_insertAtEnd(&head, val) == 1);
     }
     return head;
 }
@@ -20,7 +27,7 @@ static int list_to_array(Node* head, int arr[], int max)
     int i = 0;
     while (head != NULL && i < max)
     {
-        arr[i++] = head->data;
+        arr[i++] = *(int*)(head->data);
         head = head->next;
     }
     return i;
@@ -31,14 +38,18 @@ void test_insert()
 {
     Node* head = NULL;
 
-    assert(sll_insertAtEnd(&head, 10) == 1);
-    assert(head->data == 10);
+    int* val10 = malloc(sizeof(int));
+    *val10 = 10;
+    assert(sll_insertAtEnd(&head, val10) == 1);
+    assert(*(int*)(head->data) == 10);
 
-    assert(sll_insertAtBeginning(&head, 5) == 1);
-    assert(head->data == 5);
-    assert(head->next->data == 10);
+    int* val5 = malloc(sizeof(int));
+    *val5 = 5;
+    assert(sll_insertAtBeginning(&head, val5) == 1);
+    assert(*(int*)(head->data) == 5);
+    assert(*(int*)(head->next->data) == 10);
 
-    delete_sll(head);
+    delete_sll(head, free);
     printf("sll Insert tests passed\n");
 }
 
@@ -48,15 +59,15 @@ void test_delete_begin()
     int arr[] = {1, 2, 3};
     Node* head = build_list(arr, 3);
 
-    assert(sll_deleteAtBeginning(&head) == 1);
-    assert(head->data == 2);
+    assert(sll_deleteAtBeginning(&head, free) == 1);
+    assert(*(int*)(head->data) == 2);
 
     int out[3];
     int n = list_to_array(head, out, 3);
     assert(n == 2);
     assert(out[0] == 2 && out[1] == 3);
 
-    delete_sll(head);
+    delete_sll(head, free);
     printf("sll Delete at beginning tests passed\n");
 }
 
@@ -66,14 +77,14 @@ void test_delete_end()
     int arr[] = {1, 2, 3};
     Node* head = build_list(arr, 3);
 
-    assert(sll_deleteAtEnd(&head) == 1);
+    assert(sll_deleteAtEnd(&head, free) == 1);
 
     int out[3];
     int n = list_to_array(head, out, 3);
     assert(n == 2);
     assert(out[0] == 1 && out[1] == 2);
 
-    delete_sll(head);
+    delete_sll(head, free);
     printf("sll Delete at end tests passed\n");
 }
 
@@ -83,16 +94,18 @@ void test_delete_by_value()
     int arr[] = {1, 2, 3, 4};
     Node* head = build_list(arr, 4);
 
-    assert(sll_deleteByValue(&head, 2) == 1);
+    int key2 = 2;
+    assert(sll_deleteByValue(&head, &key2, compare_ints, free) == 1);
 
     int out[4];
     int n = list_to_array(head, out, 4);
     assert(n == 3);
     assert(out[0] == 1 && out[1] == 3 && out[2] == 4);
 
-    assert(sll_deleteByValue(&head, 99) == -1);
+    int key99 = 99;
+    assert(sll_deleteByValue(&head, &key99, compare_ints, free) == -1);
 
-    delete_sll(head);
+    delete_sll(head, free);
     printf("sll Delete by value tests passed\n");
 }
 
@@ -102,11 +115,14 @@ void test_search()
     int arr[] = {5, 10, 15};
     Node* head = build_list(arr, 3);
 
-    assert(sll_search(head, 5) == 0);
-    assert(sll_search(head, 15) == 2);
-    assert(sll_search(head, 100) == -1);
+    int key5 = 5;
+    int key15 = 15;
+    int key100 = 100;
+    assert(sll_search(head, &key5, compare_ints) == 0);
+    assert(sll_search(head, &key15, compare_ints) == 2);
+    assert(sll_search(head, &key100, compare_ints) == -1);
 
-    delete_sll(head);
+    delete_sll(head, free);
     printf("sll Search tests passed\n");
 }
 
@@ -123,7 +139,7 @@ void test_reverse()
     assert(n == 3);
     assert(out[0] == 4 && out[1] == 2 && out[2] == 1);
 
-    delete_sll(head);
+    delete_sll(head, free);
     printf("sll Reverse tests passed\n");
 }
 
@@ -133,15 +149,21 @@ void test_insert_at_position()
     Node* head = NULL;
 
     /* Insert at position 0 in empty list */
-    assert(sll_insertAtPosition(&head, 10, 0) == 1);
-    assert(head->data == 10);
+    int* val10 = malloc(sizeof(int));
+    *val10 = 10;
+    assert(sll_insertAtPosition(&head, val10, 0) == 1);
+    assert(*(int*)(head->data) == 10);
 
     /* Insert at position 1 (end) */
-    assert(sll_insertAtPosition(&head, 20, 1) == 1);
-    assert(head->next->data == 20);
+    int* val20 = malloc(sizeof(int));
+    *val20 = 20;
+    assert(sll_insertAtPosition(&head, val20, 1) == 1);
+    assert(*(int*)(head->next->data) == 20);
 
     /* Insert at position 1 (middle) */
-    assert(sll_insertAtPosition(&head, 15, 1) == 1);
+    int* val15 = malloc(sizeof(int));
+    *val15 = 15;
+    assert(sll_insertAtPosition(&head, val15, 1) == 1);
 
     int out[3];
     int n = list_to_array(head, out, 3);
@@ -149,10 +171,13 @@ void test_insert_at_position()
     assert(out[0] == 10 && out[1] == 15 && out[2] == 20);
 
     /* Test invalid position */
-    assert(sll_insertAtPosition(&head, 99, 10) == -2);
-    assert(sll_insertAtPosition(&head, 99, -1) == -2);
+    int* val99 = malloc(sizeof(int));
+    *val99 = 99;
+    assert(sll_insertAtPosition(&head, val99, 10) == -2);
+    assert(sll_insertAtPosition(&head, val99, -1) == -2);
+    free(val99);
 
-    delete_sll(head);
+    delete_sll(head, free);
     printf("sll Insert at position tests passed\n");
 }
 
@@ -163,7 +188,7 @@ void test_delete_at_position()
     Node* head = build_list(arr, 4);
 
     /* Delete at position 0 */
-    assert(sll_deleteAtPosition(&head, 0) == 1);
+    assert(sll_deleteAtPosition(&head, 0, free) == 1);
 
     int out[3];
     int n = list_to_array(head, out, 3);
@@ -171,17 +196,17 @@ void test_delete_at_position()
     assert(out[0] == 2 && out[1] == 3 && out[2] == 4);
 
     /* Delete at position 1 (middle) */
-    assert(sll_deleteAtPosition(&head, 1) == 1);
+    assert(sll_deleteAtPosition(&head, 1, free) == 1);
 
     n = list_to_array(head, out, 3);
     assert(n == 2);
     assert(out[0] == 2 && out[1] == 4);
 
     /* Test invalid position */
-    assert(sll_deleteAtPosition(&head, 10) == -2);
-    assert(sll_deleteAtPosition(&head, -1) == -2);
+    assert(sll_deleteAtPosition(&head, 10, free) == -2);
+    assert(sll_deleteAtPosition(&head, -1, free) == -2);
 
-    delete_sll(head);
+    delete_sll(head, free);
     printf("sll Delete at position tests passed\n");
 }
 
@@ -191,14 +216,17 @@ void test_edge_cases()
     Node* head = NULL;
 
     assert(sll_reverseList(&head) == -2);
-    assert(sll_deleteAtBeginning(&head) == -1);
-    assert(sll_deleteAtEnd(&head) == -1);
-    assert(sll_deleteByValue(&head, 10) == -2);
+    assert(sll_deleteAtBeginning(&head, free) == -1);
+    assert(sll_deleteAtEnd(&head, free) == -1);
+    int key10 = 10;
+    assert(sll_deleteByValue(&head, &key10, compare_ints, free) == -2);
 
-    assert(sll_insertAtEnd(&head, 42) == 1);
+    int* val42 = malloc(sizeof(int));
+    *val42 = 42;
+    assert(sll_insertAtEnd(&head, val42) == 1);
     assert(sll_reverseList(&head) == -1);
 
-    delete_sll(head);
+    delete_sll(head, free);
     printf("sll Edge case tests passed\n");
 }
 

--- a/tests/data_structures/test_stack.c
+++ b/tests/data_structures/test_stack.c
@@ -7,23 +7,23 @@ void test_printStack_empty(void)
     stack* s = createStack();
     printStack(s);
     assert(isEmpty(s) == 1);
-    destroyStack(s);
+    destroyStack(s, NULL);
     printf("test_printStack_empty passed.\n");
 }
 
 void test_printStack_nonempty(void)
 {
     stack* s = createStack();
-    push(s, 1);
-    push(s, 2);
-    push(s, 3);
-    assert(peek(s) == 3);
+    push(s, (void*)(intptr_t)1);
+    push(s, (void*)(intptr_t)2);
+    push(s, (void*)(intptr_t)3);
+    assert((int)(intptr_t)peek(s) == 3);
     assert(isEmpty(s) == 0);
-    assert(pop(s) == 3);
-    assert(pop(s) == 2);
-    assert(pop(s) == 1);
+    assert((int)(intptr_t)pop(s) == 3);
+    assert((int)(intptr_t)pop(s) == 2);
+    assert((int)(intptr_t)pop(s) == 1);
     assert(isEmpty(s) == 1);
-    destroyStack(s);
+    destroyStack(s, NULL);
     printf("test_printStack_nonempty passed.\n");
 }
 
@@ -32,62 +32,62 @@ void test_printStackAsInts_empty(void)
     stack* s = createStack();
     printStackAsInts(s);
     assert(isEmpty(s) == 1);
-    destroyStack(s);
+    destroyStack(s, NULL);
     printf("test_printStackAsInts_empty passed.\n");
 }
 
 void test_printStackAsInts_nonempty(void)
 {
     stack* s = createStack();
-    push(s, 5);
-    push(s, 11);
-    push(s, 99);
-    assert(peek(s) == 99);
+    push(s, (void*)(intptr_t)5);
+    push(s, (void*)(intptr_t)11);
+    push(s, (void*)(intptr_t)99);
+    assert((int)(intptr_t)peek(s) == 99);
     assert(isEmpty(s) == 0);
-    assert(pop(s) == 99);
-    assert(pop(s) == 11);
-    assert(pop(s) == 5);
+    assert((int)(intptr_t)pop(s) == 99);
+    assert((int)(intptr_t)pop(s) == 11);
+    assert((int)(intptr_t)pop(s) == 5);
     assert(isEmpty(s) == 1);
-    destroyStack(s);
+    destroyStack(s, NULL);
     printf("test_printStackAsInts_nonempty passed.\n");
 }
 
 void test_push_pop_lifo(void)
 {
     stack* s = createStack();
-    push(s, 10);
-    push(s, 20);
-    push(s, 30);
-    assert(pop(s) == 30);
-    assert(pop(s) == 20);
-    assert(pop(s) == 10);
-    assert(pop(s) == -1);
-    destroyStack(s);
+    push(s, (void*)(intptr_t)10);
+    push(s, (void*)(intptr_t)20);
+    push(s, (void*)(intptr_t)30);
+    assert((int)(intptr_t)pop(s) == 30);
+    assert((int)(intptr_t)pop(s) == 20);
+    assert((int)(intptr_t)pop(s) == 10);
+    assert(pop(s) == NULL);
+    destroyStack(s, NULL);
     printf("test_push_pop_lifo passed.\n");
 }
 
 void test_pop_empty(void)
 {
     stack* s = createStack();
-    assert(pop(s) == -1);
-    push(s, 7);
-    assert(pop(s) == 7);
-    assert(pop(s) == -1);
-    destroyStack(s);
+    assert(pop(s) == NULL);
+    push(s, (void*)(intptr_t)7);
+    assert((int)(intptr_t)pop(s) == 7);
+    assert(pop(s) == NULL);
+    destroyStack(s, NULL);
     printf("test_pop_empty passed.\n");
 }
 
 void test_peek_no_remove(void)
 {
     stack* s = createStack();
-    assert(peek(s) == -1);
-    push(s, 42);
-    assert(peek(s) == 42);
-    assert(peek(s) == 42);
+    assert(peek(s) == NULL);
+    push(s, (void*)(intptr_t)42);
+    assert((int)(intptr_t)peek(s) == 42);
+    assert((int)(intptr_t)peek(s) == 42);
     assert(isEmpty(s) == 0);
     pop(s);
-    assert(peek(s) == -1);
-    destroyStack(s);
+    assert(peek(s) == NULL);
+    destroyStack(s, NULL);
     printf("test_peek_no_remove passed.\n");
 }
 
@@ -95,25 +95,25 @@ void test_isEmpty(void)
 {
     stack* s = createStack();
     assert(isEmpty(s) == 1);
-    push(s, 5);
+    push(s, (void*)(intptr_t)5);
     assert(isEmpty(s) == 0);
-    push(s, 10);
+    push(s, (void*)(intptr_t)10);
     assert(isEmpty(s) == 0);
     pop(s);
     assert(isEmpty(s) == 0);
     pop(s);
     assert(isEmpty(s) == 1);
-    destroyStack(s);
+    destroyStack(s, NULL);
     printf("test_isEmpty passed.\n");
 }
 
 void test_destroy_nonEmpty(void)
 {
     stack* s = createStack();
-    push(s, 1);
-    push(s, 2);
-    push(s, 3);
-    destroyStack(s);
+    push(s, (void*)(intptr_t)1);
+    push(s, (void*)(intptr_t)2);
+    push(s, (void*)(intptr_t)3);
+    destroyStack(s, NULL);
     printf("test_destroy_nonEmpty passed.\n");
 }
 

--- a/tests/expression_evaluation/test_expression_evaluation.c
+++ b/tests/expression_evaluation/test_expression_evaluation.c
@@ -48,22 +48,22 @@ void test_stack_operations()
     assert(s != NULL);
     assert(isEmpty(s) == 1);
 
-    assert(push(s, '+') == 1);
+    assert(push(s, (void*)(intptr_t)'+') == 1);
     assert(isEmpty(s) == 0);
 
-    assert(push(s, '*') == 1);
+    assert(push(s, (void*)(intptr_t)'*') == 1);
 
-    assert(peek(s) == '*');
+    assert((char)(intptr_t)peek(s) == '*');
 
-    assert(pop(s) == '*');
-    assert(pop(s) == '+');
+    assert((char)(intptr_t)pop(s) == '*');
+    assert((char)(intptr_t)pop(s) == '+');
 
     assert(isEmpty(s) == 1);
 
-    assert(pop(s) == -1);
-    assert(peek(s) == -1);
+    assert(pop(s) == NULL);
+    assert(peek(s) == NULL);
 
-    destroyStack(s);
+    destroyStack(s, NULL);
     printf("--> test_stack_operations PASSED!\n");
 }
 


### PR DESCRIPTION
# PR Description:

## What is this PR about? 
This PR genericizes the Singly Linked List (`sll.h`/`sll.c`) and Stack (`stack.h`/`stack.c`) implementations, changing the node data payload from `int` to `void*`. It also refactors all downstream modules that depend on these data structures to ensure correct compilation and execution.

---

## Changes Made 

### 1. SLL Generic Library & Tests
* Converted the `data` field of `Node` to `void*`.
* Modified functions to take element-printing, deletion, and comparison callbacks.
* Updated SLL unit tests and interactive demos with dynamic integer allocations.

### 2. Stack Generic Library & Tests
* Refactored `stack` structure and methods (`push`, `pop`, `peek`, and `destroyStack`) to process generic pointers.
* Updated tests and demos to push/pop integers by pointer casting via `intptr_t`.

### 3. Downstream Refactoring
* **Expression Evaluation:** Updated parentheses checker, postfix/prefix evaluation, and infix-to-postfix routines to push/pop characters and operators using pointer casting.
* **Hashing & Sorting:** Modified bucket sort and separate chaining hash table to store integers via pointer casting.
* **Graph Traversals & Algorithms:** Refactored unweighted graph structures (which build adjacency lists using SLL nodes) to store vertex indices via pointer casting across BFS, DFS, Topological Sort, Eulerian Path, Tarjan/Kosaraju SCC, Bipartite Matching, and Hopcroft-Karp.
* **DFS Loop Safety:** Implemented `isEmpty` checks inside DFS to prevent vertex `0` (which casts to `(void*)0` / `NULL`) from falsely triggering an empty stack condition.


closes #859 