### PR TITLE
fix(ci): fix graph serialization SLL integration and clean up legacy Windows code

### DIFF
--- a/features/serialization/serialization.c
+++ b/features/serialization/serialization.c
@@ -5,10 +5,6 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 
-#ifdef _WIN32
-#include <direct.h>
-#endif
-
 static void ensure_parent_dir_exists(const char* filepath)
 {
     char temp[512];
@@ -16,28 +12,17 @@ static void ensure_parent_dir_exists(const char* filepath)
     temp[sizeof(temp) - 1] = '\0';
 
     char* last_slash = strrchr(temp, '/');
-#ifdef _WIN32
-    char* last_backslash = strrchr(temp, '\\');
-    if (last_backslash > last_slash)
-    {
-        last_slash = last_backslash;
-    }
-#endif
 
     if (last_slash != NULL)
     {
         *last_slash = '\0';
         if (strlen(temp) > 0)
         {
-#ifdef _WIN32
-            _mkdir(temp);
-#else
             struct stat st;
             if (stat(temp, &st) == -1)
             {
                 mkdir(temp, 0755);
             }
-#endif
         }
     }
 }
@@ -206,7 +191,7 @@ bool serialize_graph_to_file(const Graph* graph, const char* filepath)
         Node* curr = graph->array[u];
         while (curr != NULL)
         {
-            if (u < curr->data)
+            if (u < (int)(intptr_t)curr->data)
             {
                 E++;
             }
@@ -222,9 +207,9 @@ bool serialize_graph_to_file(const Graph* graph, const char* filepath)
         Node* curr = graph->array[u];
         while (curr != NULL)
         {
-            if (u < curr->data)
+            if (u < (int)(intptr_t)curr->data)
             {
-                fprintf(fp, "%d,%d\n", u, curr->data);
+                fprintf(fp, "%d,%d\n", u, (int)(intptr_t)curr->data);
             }
             curr = curr->next;
         }

--- a/features/telemetry/telemetry.c
+++ b/features/telemetry/telemetry.c
@@ -4,9 +4,6 @@
 #include <string.h>
 #include <sys/stat.h>
 #include <sys/types.h>
-#ifdef _WIN32
-#include <direct.h>
-#endif
 
 static bool telemetry_enabled = false;
 static char telemetry_filepath[512] = "benchmarks/algo_trace.json";
@@ -19,28 +16,17 @@ static void ensure_parent_dir_exists(const char* filepath)
     temp[sizeof(temp) - 1] = '\0';
 
     char* last_slash = strrchr(temp, '/');
-#ifdef _WIN32
-    char* last_backslash = strrchr(temp, '\\');
-    if (last_backslash > last_slash)
-    {
-        last_slash = last_backslash;
-    }
-#endif
 
     if (last_slash != NULL)
     {
         *last_slash = '\0';
         if (strlen(temp) > 0)
         {
-#ifdef _WIN32
-            _mkdir(temp);
-#else
             struct stat st;
             if (stat(temp, &st) == -1)
             {
                 mkdir(temp, 0755);
             }
-#endif
         }
     }
 }

--- a/tests/serialization/test_serialization.c
+++ b/tests/serialization/test_serialization.c
@@ -74,9 +74,10 @@ static void test_graph_serialization(void)
     bool has_two = false;
     while (curr != NULL)
     {
-        if (curr->data == 0)
+        int val = (int)(intptr_t)curr->data;
+        if (val == 0)
             has_zero = true;
-        if (curr->data == 2)
+        if (val == 2)
             has_two = true;
         curr = curr->next;
     }

--- a/tests/telemetry/test_telemetry.c
+++ b/tests/telemetry/test_telemetry.c
@@ -5,21 +5,13 @@
 #include <string.h>
 #include <sys/stat.h>
 #include <sys/types.h>
-#ifdef _WIN32
-#include <direct.h>
-#endif
-
 static void ensure_dir_exists(const char* path)
 {
-#ifdef _WIN32
-    _mkdir(path);
-#else
     struct stat st;
     if (stat(path, &st) == -1)
     {
         mkdir(path, 0755);
     }
-#endif
 }
 
 static void test_telemetry_enable_disable(void)


### PR DESCRIPTION
## PR Description

### Overview
This PR resolves the current compilation failures on `main` caused by an integration mismatch between the SLL refactoring and the serialization engine, and cleans up deprecated Windows-specific headers.

### Details of Changes
1. **Generic SLL Payload Integration (`void*` to `int`)**:
   * Fixed compiler warnings/errors where SLL `Node` payload (`curr->data`) was compared directly to integer values or formatted as an integer without casting.
   * Cast `curr->data` to `int` via `intptr_t` in `features/serialization/serialization.c` and `tests/serialization/test_serialization.c`.

2. **Clean Up Legacy Windows Inclusions**:
   * Since Windows support has been deprecated, removed all instances of `#include <direct.h>` and `#ifdef _WIN32` / `_mkdir` conditional blocks.
   * Simplified directory verification in `serialization.c`, `telemetry.c`, and `test_telemetry.c` to use standard POSIX `mkdir(path, 0755)` directly.

### Verification Results
* Cleanly compiled using GCC on Linux environment (WSL).
* Ran all tests locally (TUI, serialization, compression, step debugger, and memory profiler integration tests) and all tests successfully passed.


closes #895 