### PR TITLE
Feature: Implement Generic File Export Capabilities for Data Structures (PR 1) (#878)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,7 @@ set(SRC_DIRS
     demos/string_algorithms
     features/telemetry
     features/serialization
+    features/export
 )
 
 # Header search paths

--- a/features/export/export.c
+++ b/features/export/export.c
@@ -1,0 +1,108 @@
+#include "export.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+
+static void ensure_parent_dir_exists(const char* filepath)
+{
+    char temp[512];
+    strncpy(temp, filepath, sizeof(temp) - 1);
+    temp[sizeof(temp) - 1] = '\0';
+
+    char* last_slash = strrchr(temp, '/');
+
+    if (last_slash != NULL)
+    {
+        *last_slash = '\0';
+        if (strlen(temp) > 0)
+        {
+            struct stat st;
+            if (stat(temp, &st) == -1)
+            {
+                mkdir(temp, 0755);
+            }
+        }
+    }
+}
+
+void write_data_int(FILE* fp, const void* data)
+{
+    if (data != NULL)
+    {
+        fprintf(fp, "%d", *(const int*)data);
+    }
+}
+
+void write_data_string(FILE* fp, const void* data)
+{
+    if (data != NULL)
+    {
+        fprintf(fp, "%s", (const char*)data);
+    }
+}
+
+int dll_export(const doubly_ll_Node* head, const char* filepath, ExportFormat format,
+               void (*write_node_data)(FILE* fp, const void* data))
+{
+    if (filepath == NULL || strlen(filepath) == 0 || write_node_data == NULL)
+    {
+        return 0;
+    }
+
+    ensure_parent_dir_exists(filepath);
+    FILE* fp = fopen(filepath, "w");
+    if (fp == NULL)
+    {
+        return 0;
+    }
+
+    const doubly_ll_Node* curr = head;
+
+    if (format == EXPORT_FORMAT_TEXT)
+    {
+        while (curr != NULL)
+        {
+            write_node_data(fp, curr->data);
+            fprintf(fp, " -> ");
+            curr = curr->next;
+        }
+        fprintf(fp, "NULL\n");
+    }
+    else if (format == EXPORT_FORMAT_CSV)
+    {
+        fprintf(fp, "index,value\n");
+        int index = 0;
+        while (curr != NULL)
+        {
+            fprintf(fp, "%d,", index);
+            write_node_data(fp, curr->data);
+            fprintf(fp, "\n");
+            index++;
+            curr = curr->next;
+        }
+    }
+    else if (format == EXPORT_FORMAT_JSON)
+    {
+        fprintf(fp, "[\n");
+        while (curr != NULL)
+        {
+            fprintf(fp, "  ");
+            write_node_data(fp, curr->data);
+            if (curr->next != NULL)
+            {
+                fprintf(fp, ",\n");
+            }
+            else
+            {
+                fprintf(fp, "\n");
+            }
+            curr = curr->next;
+        }
+        fprintf(fp, "]\n");
+    }
+
+    fclose(fp);
+    return 1;
+}

--- a/features/export/export.h
+++ b/features/export/export.h
@@ -1,0 +1,22 @@
+#ifndef EXPORT_H
+#define EXPORT_H
+
+#include "dll.h"
+#include <stdio.h>
+
+typedef enum
+{
+    EXPORT_FORMAT_TEXT,
+    EXPORT_FORMAT_CSV,
+    EXPORT_FORMAT_JSON
+} ExportFormat;
+
+// Pre-defined formatter helpers
+void write_data_int(FILE* fp, const void* data);
+void write_data_string(FILE* fp, const void* data);
+
+// Generic export function for Doubly Linked List
+int dll_export(const doubly_ll_Node* head, const char* filepath, ExportFormat format,
+               void (*write_node_data)(FILE* fp, const void* data));
+
+#endif // EXPORT_H

--- a/tests/export/test_export.c
+++ b/tests/export/test_export.c
@@ -1,0 +1,77 @@
+#include "dll.h"
+#include "export.h"
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static void verify_file_content(const char* filepath, const char* expected)
+{
+    FILE* fp = fopen(filepath, "r");
+    assert(fp != NULL);
+
+    char buffer[4096];
+    size_t bytes_read = fread(buffer, 1, sizeof(buffer) - 1, fp);
+    buffer[bytes_read] = '\0';
+    fclose(fp);
+
+    assert(strcmp(buffer, expected) == 0);
+    remove(filepath);
+}
+
+static void test_dll_export_int(void)
+{
+    doubly_ll_Node* head = NULL;
+    int val1 = 10, val2 = 20, val3 = 30;
+
+    dll_insertAtEnd(&head, &val1);
+    dll_insertAtEnd(&head, &val2);
+    dll_insertAtEnd(&head, &val3);
+
+    // Text Export Test
+    assert(dll_export(head, "test_binaries/dll_int.txt", EXPORT_FORMAT_TEXT, write_data_int));
+    verify_file_content("test_binaries/dll_int.txt", "10 -> 20 -> 30 -> NULL\n");
+
+    // CSV Export Test
+    assert(dll_export(head, "test_binaries/dll_int.csv", EXPORT_FORMAT_CSV, write_data_int));
+    verify_file_content("test_binaries/dll_int.csv", "index,value\n0,10\n1,20\n2,30\n");
+
+    // JSON Export Test
+    assert(dll_export(head, "test_binaries/dll_int.json", EXPORT_FORMAT_JSON, write_data_int));
+    verify_file_content("test_binaries/dll_int.json", "[\n  10,\n  20,\n  30\n]\n");
+
+    delete_dll(head, NULL);
+}
+
+static void test_dll_export_string(void)
+{
+    doubly_ll_Node* head = NULL;
+    char* val1 = "apple";
+    char* val2 = "banana";
+
+    dll_insertAtEnd(&head, val1);
+    dll_insertAtEnd(&head, val2);
+
+    // Text Export Test
+    assert(dll_export(head, "test_binaries/dll_str.txt", EXPORT_FORMAT_TEXT, write_data_string));
+    verify_file_content("test_binaries/dll_str.txt", "apple -> banana -> NULL\n");
+
+    // CSV Export Test
+    assert(dll_export(head, "test_binaries/dll_str.csv", EXPORT_FORMAT_CSV, write_data_string));
+    verify_file_content("test_binaries/dll_str.csv", "index,value\n0,apple\n1,banana\n");
+
+    // JSON Export Test
+    assert(dll_export(head, "test_binaries/dll_str.json", EXPORT_FORMAT_JSON, write_data_string));
+    verify_file_content("test_binaries/dll_str.json", "[\n  apple,\n  banana\n]\n");
+
+    delete_dll(head, NULL);
+}
+
+int main(void)
+{
+    printf("Starting Generic File Export unit tests...\n");
+    test_dll_export_int();
+    test_dll_export_string();
+    printf("All Generic File Export unit tests passed successfully!\n");
+    return 0;
+}


### PR DESCRIPTION
### Description
This PR implements the core serialization/export engine and adds export capabilities for Doubly Linked Lists (DLL) with no Windows-specific compatibility code.

### Resolves
* Resolves #878 (Core and DLL export)

### Changes
- **[CMakeLists.txt](file:///Users/akshatshukla/Library/Mobile%20Documents/com~apple~CloudDocs/Work/open/C_DSA_interactive_suite.git/CMakeLists.txt)**: Exposes `features/export` to CMake build directories.
- **[export.h](file:///Users/akshatshukla/Library/Mobile%20Documents/com~apple~CloudDocs/Work/open/C_DSA_interactive_suite.git/features/export/export.h)** & **[export.c](file:///Users/akshatshukla/Library/Mobile%20Documents/com~apple~CloudDocs/Work/open/C_DSA_interactive_suite.git/features/export/export.c)**: Core file exporting pipeline supporting Text, CSV, and JSON formats (fully cleaned of Windows dependencies).
- **[test_export.c](file:///Users/akshatshukla/Library/Mobile%20Documents/com~apple~CloudDocs/Work/open/C_DSA_interactive_suite.git/tests/export/test_export.c)**: Adds test coverage for Doubly Linked List serialization.

### Verification & Testing
- Clean compilation and test verification using CMake (`cmake -B build && cmake --build build && ctest --test-dir build`).