### PR TITLE
Feature: Integrate File Export Prompts into DLL, Stack, Queue, and Deque TUI Demos (PR 3) (#878)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,7 @@ set(SRC_DIRS
     demos/string_algorithms
     features/telemetry
     features/serialization
+    features/export
 )
 
 # Header search paths

--- a/demos/data_structures/circular_queue_demo.c
+++ b/demos/data_structures/circular_queue_demo.c
@@ -1,7 +1,9 @@
+#include "export.h"
 #include "queue.h"
 #include "safe_input.h"
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 
 void circular_queue_demo(void)
 {
@@ -42,9 +44,7 @@ void circular_queue_demo(void)
 
             if (circ_queue_status == INPUT_EXIT_SIGNAL)
             {
-                printf("\nExiting circular queue demo\n");
-                destroy_circ_queue(&rollnos);
-                return;
+                break;
             }
 
             if (circ_queue_status == 0)
@@ -61,9 +61,7 @@ void circular_queue_demo(void)
 
                 if (enqueue_val_status == INPUT_EXIT_SIGNAL)
                 {
-                    printf("\nExiting circular queue demo\n");
-                    destroy_circ_queue(&rollnos);
-                    return;
+                    break;
                 }
 
                 if (enqueue_val_status == 0)
@@ -104,5 +102,46 @@ void circular_queue_demo(void)
                 display_circ_queue(&rollnos);
             }
         }
+
+        // Export option
+        int export_choice;
+        int export_status = safe_input_int(&export_choice,
+                                           "\nDo you want to export this Circular Queue to a file? "
+                                           "(1 for Yes, 2 for No, or '-1' to exit): ",
+                                           1, 2);
+        if (export_status != INPUT_EXIT_SIGNAL && export_status != 0 && export_choice == 1)
+        {
+            char path[256];
+            int path_status =
+                safe_input_string(path, "Enter filename to export (e.g. queue.json): ");
+            if (path_status != INPUT_EXIT_SIGNAL && strlen(path) > 0)
+            {
+                int format_val;
+                int format_status = safe_input_int(
+                    &format_val,
+                    "Select format (1 for Text, 2 for CSV, 3 for JSON, or '-1' to exit): ", 1, 3);
+                if (format_status != INPUT_EXIT_SIGNAL && format_status != 0)
+                {
+                    ExportFormat format = EXPORT_FORMAT_TEXT;
+                    if (format_val == 2)
+                        format = EXPORT_FORMAT_CSV;
+                    else if (format_val == 3)
+                        format = EXPORT_FORMAT_JSON;
+
+                    if (queue_export(&rollnos, QUEUE_TYPE_CIRCULAR, path, format, write_data_int))
+                    {
+                        printf("Exported successfully to %s\n", path);
+                    }
+                    else
+                    {
+                        printf("Failed to export to %s\n", path);
+                    }
+                }
+            }
+        }
+
+        printf("\nExiting circular queue demo\n");
+        destroy_circ_queue(&rollnos);
+        return;
     }
 }

--- a/demos/data_structures/deque_demo.c
+++ b/demos/data_structures/deque_demo.c
@@ -1,7 +1,9 @@
+#include "export.h"
 #include "queue.h"
 #include "safe_input.h"
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 
 void deque_demo(void)
 {
@@ -44,9 +46,7 @@ void deque_demo(void)
 
             if (choice_status == INPUT_EXIT_SIGNAL)
             {
-                printf("\nExiting deque demo\n");
-                destroy_deque(&dq);
-                return;
+                break;
             }
             if (choice_status == 0)
             {
@@ -60,9 +60,7 @@ void deque_demo(void)
                     &val, "\nEnter value to insert at front (1 to 100), '-1' to exit: ", 1, 100);
                 if (val_status == INPUT_EXIT_SIGNAL)
                 {
-                    printf("\nExiting deque demo\n");
-                    destroy_deque(&dq);
-                    return;
+                    break;
                 }
                 if (val_status == 0)
                     continue;
@@ -89,9 +87,7 @@ void deque_demo(void)
                     &val, "\nEnter value to insert at rear (1 to 100), '-1' to exit: ", 1, 100);
                 if (val_status == INPUT_EXIT_SIGNAL)
                 {
-                    printf("\nExiting deque demo\n");
-                    destroy_deque(&dq);
-                    return;
+                    break;
                 }
                 if (val_status == 0)
                     continue;
@@ -164,5 +160,46 @@ void deque_demo(void)
                 }
             }
         }
+
+        // Export option
+        int export_choice;
+        int export_status = safe_input_int(&export_choice,
+                                           "\nDo you want to export this Deque to a file? (1 for "
+                                           "Yes, 2 for No, or '-1' to exit): ",
+                                           1, 2);
+        if (export_status != INPUT_EXIT_SIGNAL && export_status != 0 && export_choice == 1)
+        {
+            char path[256];
+            int path_status =
+                safe_input_string(path, "Enter filename to export (e.g. deque.json): ");
+            if (path_status != INPUT_EXIT_SIGNAL && strlen(path) > 0)
+            {
+                int format_val;
+                int format_status = safe_input_int(
+                    &format_val,
+                    "Select format (1 for Text, 2 for CSV, 3 for JSON, or '-1' to exit): ", 1, 3);
+                if (format_status != INPUT_EXIT_SIGNAL && format_status != 0)
+                {
+                    ExportFormat format = EXPORT_FORMAT_TEXT;
+                    if (format_val == 2)
+                        format = EXPORT_FORMAT_CSV;
+                    else if (format_val == 3)
+                        format = EXPORT_FORMAT_JSON;
+
+                    if (queue_export(&dq, QUEUE_TYPE_DEQUE, path, format, write_data_int))
+                    {
+                        printf("Exported successfully to %s\n", path);
+                    }
+                    else
+                    {
+                        printf("Failed to export to %s\n", path);
+                    }
+                }
+            }
+        }
+
+        printf("\nExiting deque demo\n");
+        destroy_deque(&dq);
+        return;
     }
 }

--- a/demos/data_structures/dll_demo.c
+++ b/demos/data_structures/dll_demo.c
@@ -1,7 +1,9 @@
 #include "dll.h"
+#include "export.h"
 #include "safe_input.h"
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 
 static void print_int(const void* data)
 {
@@ -265,9 +267,7 @@ start_dll:
 
         if (dll_delete_status == INPUT_EXIT_SIGNAL)
         {
-            printf("\nExiting dll demo.\n");
-            delete_dll(head, free);
-            return;
+            break;
         }
         if (dll_delete_status == 0)
         {
@@ -284,9 +284,7 @@ start_dll:
 
             if (dll_delete_status == INPUT_EXIT_SIGNAL)
             {
-                printf("\nExiting dll demo.\n");
-                delete_dll(head, free);
-                return;
+                break;
             }
             if (dll_delete_status == 0)
             {
@@ -323,9 +321,7 @@ start_dll:
 
             if (dll_pos_delete_status == INPUT_EXIT_SIGNAL)
             {
-                printf("\nExiting dll demo.\n");
-                delete_dll(head, free);
-                return;
+                break;
             }
 
             if (dll_pos_delete_status == 0)
@@ -349,4 +345,43 @@ start_dll:
             }
         }
     }
+
+    // Export option
+    int export_choice;
+    int export_status = safe_input_int(&export_choice,
+                                       "\nDo you want to export this Doubly Linked List to a file? "
+                                       "(1 for Yes, 2 for No, or '-1' to exit): ",
+                                       1, 2);
+    if (export_status != INPUT_EXIT_SIGNAL && export_status != 0 && export_choice == 1)
+    {
+        char path[256];
+        int path_status = safe_input_string(path, "Enter filename to export (e.g. list.json): ");
+        if (path_status != INPUT_EXIT_SIGNAL && strlen(path) > 0)
+        {
+            int format_val;
+            int format_status = safe_input_int(
+                &format_val,
+                "Select format (1 for Text, 2 for CSV, 3 for JSON, or '-1' to exit): ", 1, 3);
+            if (format_status != INPUT_EXIT_SIGNAL && format_status != 0)
+            {
+                ExportFormat format = EXPORT_FORMAT_TEXT;
+                if (format_val == 2)
+                    format = EXPORT_FORMAT_CSV;
+                else if (format_val == 3)
+                    format = EXPORT_FORMAT_JSON;
+
+                if (dll_export(head, path, format, write_data_int))
+                {
+                    printf("Exported successfully to %s\n", path);
+                }
+                else
+                {
+                    printf("Failed to export to %s\n", path);
+                }
+            }
+        }
+    }
+
+    printf("\nExiting dll demo.\n");
+    delete_dll(head, free);
 }

--- a/demos/data_structures/simple_queue_demo.c
+++ b/demos/data_structures/simple_queue_demo.c
@@ -1,7 +1,9 @@
+#include "export.h"
 #include "queue.h"
 #include "safe_input.h"
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 
 void simple_queue_demo(void)
 {
@@ -46,9 +48,7 @@ void simple_queue_demo(void)
 
             if (simple_queue_status == INPUT_EXIT_SIGNAL)
             {
-                printf("\nExiting simple queue demo\n");
-                destroy_simple_queue(&q);
-                return;
+                break;
             }
 
             if (simple_queue_status == 0)
@@ -65,9 +65,7 @@ void simple_queue_demo(void)
 
                 if (enqueue_val_status == INPUT_EXIT_SIGNAL)
                 {
-                    printf("\nExiting simple queue demo\n");
-                    destroy_simple_queue(&q);
-                    return;
+                    break;
                 }
 
                 if (enqueue_val_status == 0)
@@ -110,5 +108,46 @@ void simple_queue_demo(void)
                 display_simple_queue(&q);
             }
         }
+
+        // Export option
+        int export_choice;
+        int export_status = safe_input_int(&export_choice,
+                                           "\nDo you want to export this Simple Queue to a file? "
+                                           "(1 for Yes, 2 for No, or '-1' to exit): ",
+                                           1, 2);
+        if (export_status != INPUT_EXIT_SIGNAL && export_status != 0 && export_choice == 1)
+        {
+            char path[256];
+            int path_status =
+                safe_input_string(path, "Enter filename to export (e.g. queue.json): ");
+            if (path_status != INPUT_EXIT_SIGNAL && strlen(path) > 0)
+            {
+                int format_val;
+                int format_status = safe_input_int(
+                    &format_val,
+                    "Select format (1 for Text, 2 for CSV, 3 for JSON, or '-1' to exit): ", 1, 3);
+                if (format_status != INPUT_EXIT_SIGNAL && format_status != 0)
+                {
+                    ExportFormat format = EXPORT_FORMAT_TEXT;
+                    if (format_val == 2)
+                        format = EXPORT_FORMAT_CSV;
+                    else if (format_val == 3)
+                        format = EXPORT_FORMAT_JSON;
+
+                    if (queue_export(&q, QUEUE_TYPE_SIMPLE, path, format, write_data_int))
+                    {
+                        printf("Exported successfully to %s\n", path);
+                    }
+                    else
+                    {
+                        printf("Failed to export to %s\n", path);
+                    }
+                }
+            }
+        }
+
+        printf("\nExiting simple queue demo\n");
+        destroy_simple_queue(&q);
+        return;
     }
 }

--- a/demos/data_structures/stack_demo.c
+++ b/demos/data_structures/stack_demo.c
@@ -1,8 +1,10 @@
 #include "display_header.h"
+#include "export.h"
 #include "safe_input.h"
 #include "stack.h"
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 
 void stack_demo(void)
 {
@@ -85,6 +87,42 @@ void stack_demo(void)
                 printf("\nTop element: %d\n", val);
             }
             printStackAsInts(s);
+        }
+    }
+
+    // Export option
+    int export_choice;
+    int export_status = safe_input_int(
+        &export_choice,
+        "\nDo you want to export this Stack to a file? (1 for Yes, 2 for No, or '-1' to exit): ", 1,
+        2);
+    if (export_status != INPUT_EXIT_SIGNAL && export_status != 0 && export_choice == 1)
+    {
+        char path[256];
+        int path_status = safe_input_string(path, "Enter filename to export (e.g. stack.json): ");
+        if (path_status != INPUT_EXIT_SIGNAL && strlen(path) > 0)
+        {
+            int format_val;
+            int format_status = safe_input_int(
+                &format_val,
+                "Select format (1 for Text, 2 for CSV, 3 for JSON, or '-1' to exit): ", 1, 3);
+            if (format_status != INPUT_EXIT_SIGNAL && format_status != 0)
+            {
+                ExportFormat format = EXPORT_FORMAT_TEXT;
+                if (format_val == 2)
+                    format = EXPORT_FORMAT_CSV;
+                else if (format_val == 3)
+                    format = EXPORT_FORMAT_JSON;
+
+                if (stack_export(s, path, format, write_data_int))
+                {
+                    printf("Exported successfully to %s\n", path);
+                }
+                else
+                {
+                    printf("Failed to export to %s\n", path);
+                }
+            }
         }
     }
 

--- a/features/export/export.c
+++ b/features/export/export.c
@@ -106,3 +106,169 @@ int dll_export(const doubly_ll_Node* head, const char* filepath, ExportFormat fo
     fclose(fp);
     return 1;
 }
+
+int stack_export(const stack* s, const char* filepath, ExportFormat format,
+                 void (*write_node_data)(FILE* fp, const void* data))
+{
+    if (s == NULL || filepath == NULL || strlen(filepath) == 0 || write_node_data == NULL)
+    {
+        return 0;
+    }
+
+    ensure_parent_dir_exists(filepath);
+    FILE* fp = fopen(filepath, "w");
+    if (fp == NULL)
+    {
+        return 0;
+    }
+
+    const Node* curr = s->top;
+
+    if (format == EXPORT_FORMAT_TEXT)
+    {
+        while (curr != NULL)
+        {
+            write_node_data(fp, curr->data);
+            fprintf(fp, " -> ");
+            curr = curr->next;
+        }
+        fprintf(fp, "NULL\n");
+    }
+    else if (format == EXPORT_FORMAT_CSV)
+    {
+        fprintf(fp, "index,value\n");
+        int index = 0;
+        while (curr != NULL)
+        {
+            fprintf(fp, "%d,", index);
+            write_node_data(fp, curr->data);
+            fprintf(fp, "\n");
+            index++;
+            curr = curr->next;
+        }
+    }
+    else if (format == EXPORT_FORMAT_JSON)
+    {
+        fprintf(fp, "[\n");
+        while (curr != NULL)
+        {
+            fprintf(fp, "  ");
+            write_node_data(fp, curr->data);
+            if (curr->next != NULL)
+            {
+                fprintf(fp, ",\n");
+            }
+            else
+            {
+                fprintf(fp, "\n");
+            }
+            curr = curr->next;
+        }
+        fprintf(fp, "]\n");
+    }
+
+    fclose(fp);
+    return 1;
+}
+
+int queue_export(const Queue* q, QueueType type, const char* filepath, ExportFormat format,
+                 void (*write_node_data)(FILE* fp, const void* data))
+{
+    if (q == NULL || q->arr == NULL || filepath == NULL || strlen(filepath) == 0 ||
+        write_node_data == NULL)
+    {
+        return 0;
+    }
+
+    // Collect elements in order
+    int count = 0;
+    void** temp_arr = malloc(sizeof(void*) * q->N);
+    if (temp_arr == NULL)
+    {
+        return 0;
+    }
+
+    if (type == QUEUE_TYPE_CIRCULAR)
+    {
+        int i = q->front;
+        while (i != q->rear)
+        {
+            temp_arr[count++] = q->arr[i];
+            i = (i + 1) % q->N;
+        }
+    }
+    else if (type == QUEUE_TYPE_SIMPLE)
+    {
+        if (q->front != -1)
+        {
+            for (int i = q->front; i <= q->rear; i++)
+            {
+                temp_arr[count++] = q->arr[i];
+            }
+        }
+    }
+    else if (type == QUEUE_TYPE_DEQUE)
+    {
+        if (q->front != -1)
+        {
+            int i = q->front;
+            while (1)
+            {
+                temp_arr[count++] = q->arr[i];
+                if (i == q->rear)
+                    break;
+                i = (i + 1) % q->N;
+            }
+        }
+    }
+
+    ensure_parent_dir_exists(filepath);
+    FILE* fp = fopen(filepath, "w");
+    if (fp == NULL)
+    {
+        free(temp_arr);
+        return 0;
+    }
+
+    if (format == EXPORT_FORMAT_TEXT)
+    {
+        for (int i = 0; i < count; i++)
+        {
+            write_node_data(fp, temp_arr[i]);
+            fprintf(fp, " -> ");
+        }
+        fprintf(fp, "NULL\n");
+    }
+    else if (format == EXPORT_FORMAT_CSV)
+    {
+        fprintf(fp, "index,value\n");
+        for (int i = 0; i < count; i++)
+        {
+            fprintf(fp, "%d,", i);
+            write_node_data(fp, temp_arr[i]);
+            fprintf(fp, "\n");
+        }
+    }
+    else if (format == EXPORT_FORMAT_JSON)
+    {
+        fprintf(fp, "[\n");
+        for (int i = 0; i < count; i++)
+        {
+            fprintf(fp, "  ");
+            write_node_data(fp, temp_arr[i]);
+            if (i < count - 1)
+            {
+                fprintf(fp, ",\n");
+            }
+            else
+            {
+                fprintf(fp, "\n");
+            }
+        }
+        fprintf(fp, "]\n");
+    }
+
+    fclose(fp);
+    free(temp_arr);
+    return 1;
+}

--- a/features/export/export.c
+++ b/features/export/export.c
@@ -1,0 +1,108 @@
+#include "export.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+
+static void ensure_parent_dir_exists(const char* filepath)
+{
+    char temp[512];
+    strncpy(temp, filepath, sizeof(temp) - 1);
+    temp[sizeof(temp) - 1] = '\0';
+
+    char* last_slash = strrchr(temp, '/');
+
+    if (last_slash != NULL)
+    {
+        *last_slash = '\0';
+        if (strlen(temp) > 0)
+        {
+            struct stat st;
+            if (stat(temp, &st) == -1)
+            {
+                mkdir(temp, 0755);
+            }
+        }
+    }
+}
+
+void write_data_int(FILE* fp, const void* data)
+{
+    if (data != NULL)
+    {
+        fprintf(fp, "%d", *(const int*)data);
+    }
+}
+
+void write_data_string(FILE* fp, const void* data)
+{
+    if (data != NULL)
+    {
+        fprintf(fp, "%s", (const char*)data);
+    }
+}
+
+int dll_export(const doubly_ll_Node* head, const char* filepath, ExportFormat format,
+               void (*write_node_data)(FILE* fp, const void* data))
+{
+    if (filepath == NULL || strlen(filepath) == 0 || write_node_data == NULL)
+    {
+        return 0;
+    }
+
+    ensure_parent_dir_exists(filepath);
+    FILE* fp = fopen(filepath, "w");
+    if (fp == NULL)
+    {
+        return 0;
+    }
+
+    const doubly_ll_Node* curr = head;
+
+    if (format == EXPORT_FORMAT_TEXT)
+    {
+        while (curr != NULL)
+        {
+            write_node_data(fp, curr->data);
+            fprintf(fp, " -> ");
+            curr = curr->next;
+        }
+        fprintf(fp, "NULL\n");
+    }
+    else if (format == EXPORT_FORMAT_CSV)
+    {
+        fprintf(fp, "index,value\n");
+        int index = 0;
+        while (curr != NULL)
+        {
+            fprintf(fp, "%d,", index);
+            write_node_data(fp, curr->data);
+            fprintf(fp, "\n");
+            index++;
+            curr = curr->next;
+        }
+    }
+    else if (format == EXPORT_FORMAT_JSON)
+    {
+        fprintf(fp, "[\n");
+        while (curr != NULL)
+        {
+            fprintf(fp, "  ");
+            write_node_data(fp, curr->data);
+            if (curr->next != NULL)
+            {
+                fprintf(fp, ",\n");
+            }
+            else
+            {
+                fprintf(fp, "\n");
+            }
+            curr = curr->next;
+        }
+        fprintf(fp, "]\n");
+    }
+
+    fclose(fp);
+    return 1;
+}

--- a/features/export/export.h
+++ b/features/export/export.h
@@ -2,6 +2,8 @@
 #define EXPORT_H
 
 #include "dll.h"
+#include "queue.h"
+#include "stack.h"
 #include <stdio.h>
 
 typedef enum
@@ -11,6 +13,13 @@ typedef enum
     EXPORT_FORMAT_JSON
 } ExportFormat;
 
+typedef enum
+{
+    QUEUE_TYPE_SIMPLE,
+    QUEUE_TYPE_CIRCULAR,
+    QUEUE_TYPE_DEQUE
+} QueueType;
+
 // Pre-defined formatter helpers
 void write_data_int(FILE* fp, const void* data);
 void write_data_string(FILE* fp, const void* data);
@@ -18,5 +27,13 @@ void write_data_string(FILE* fp, const void* data);
 // Generic export function for Doubly Linked List
 int dll_export(const doubly_ll_Node* head, const char* filepath, ExportFormat format,
                void (*write_node_data)(FILE* fp, const void* data));
+
+// Generic export function for Stack
+int stack_export(const stack* s, const char* filepath, ExportFormat format,
+                 void (*write_node_data)(FILE* fp, const void* data));
+
+// Generic export function for Queue (simple, circular, and deque)
+int queue_export(const Queue* q, QueueType type, const char* filepath, ExportFormat format,
+                 void (*write_node_data)(FILE* fp, const void* data));
 
 #endif // EXPORT_H

--- a/features/export/export.h
+++ b/features/export/export.h
@@ -1,0 +1,22 @@
+#ifndef EXPORT_H
+#define EXPORT_H
+
+#include "dll.h"
+#include <stdio.h>
+
+typedef enum
+{
+    EXPORT_FORMAT_TEXT,
+    EXPORT_FORMAT_CSV,
+    EXPORT_FORMAT_JSON
+} ExportFormat;
+
+// Pre-defined formatter helpers
+void write_data_int(FILE* fp, const void* data);
+void write_data_string(FILE* fp, const void* data);
+
+// Generic export function for Doubly Linked List
+int dll_export(const doubly_ll_Node* head, const char* filepath, ExportFormat format,
+               void (*write_node_data)(FILE* fp, const void* data));
+
+#endif // EXPORT_H

--- a/tests/export/test_export.c
+++ b/tests/export/test_export.c
@@ -67,11 +67,96 @@ static void test_dll_export_string(void)
     delete_dll(head, NULL);
 }
 
+static void test_stack_export_int(void)
+{
+    stack* s = createStack();
+    assert(s != NULL);
+
+    int val1 = 30, val2 = 20, val3 = 10;
+    push(s, &val1);
+    push(s, &val2);
+    push(s, &val3);
+
+    // Text Export Test
+    assert(stack_export(s, "test_binaries/stack.txt", EXPORT_FORMAT_TEXT, write_data_int));
+    verify_file_content("test_binaries/stack.txt", "10 -> 20 -> 30 -> NULL\n");
+
+    // CSV Export Test
+    assert(stack_export(s, "test_binaries/stack.csv", EXPORT_FORMAT_CSV, write_data_int));
+    verify_file_content("test_binaries/stack.csv", "index,value\n0,10\n1,20\n2,30\n");
+
+    // JSON Export Test
+    assert(stack_export(s, "test_binaries/stack.json", EXPORT_FORMAT_JSON, write_data_int));
+    verify_file_content("test_binaries/stack.json", "[\n  10,\n  20,\n  30\n]\n");
+
+    destroyStack(s, NULL);
+}
+
+static void test_queue_export_int(void)
+{
+    Queue q_simple;
+    init_simple_queue(5, &q_simple);
+    int* val1 = malloc(sizeof(int));
+    int* val2 = malloc(sizeof(int));
+    *val1 = 100;
+    *val2 = 200;
+    enqueue_simple(&q_simple, val1);
+    enqueue_simple(&q_simple, val2);
+
+    printf("  Starting simple queue export test...\n");
+    assert(queue_export(&q_simple, QUEUE_TYPE_SIMPLE, "test_binaries/queue_simple.txt",
+                        EXPORT_FORMAT_TEXT, write_data_int));
+    verify_file_content("test_binaries/queue_simple.txt", "100 -> 200 -> NULL\n");
+    printf("  Simple queue export passed.\n");
+
+    destroy_simple_queue(&q_simple);
+
+    Queue q_circ;
+    init_circ_queue(5, &q_circ);
+    int* cval1 = malloc(sizeof(int));
+    int* cval2 = malloc(sizeof(int));
+    *cval1 = 10;
+    *cval2 = 20;
+    enqueue(&q_circ, cval1);
+    enqueue(&q_circ, cval2);
+
+    printf("  Starting circular queue export test...\n");
+    assert(queue_export(&q_circ, QUEUE_TYPE_CIRCULAR, "test_binaries/queue_circ.csv",
+                        EXPORT_FORMAT_CSV, write_data_int));
+    verify_file_content("test_binaries/queue_circ.csv", "index,value\n0,10\n1,20\n");
+    printf("  Circular queue export passed.\n");
+
+    destroy_circ_queue(&q_circ);
+
+    Queue dq;
+    init_deque(5, &dq);
+    int* dval1 = malloc(sizeof(int));
+    int* dval2 = malloc(sizeof(int));
+    *dval1 = 5;
+    *dval2 = 15;
+    deque_insert_rear(&dq, dval1);
+    deque_insert_front(&dq, dval2);
+
+    printf("  Starting deque export test...\n");
+    assert(queue_export(&dq, QUEUE_TYPE_DEQUE, "test_binaries/deque.json", EXPORT_FORMAT_JSON,
+                        write_data_int));
+    verify_file_content("test_binaries/deque.json", "[\n  15,\n  5\n]\n");
+    printf("  Deque export passed.\n");
+
+    destroy_deque(&dq);
+}
+
 int main(void)
 {
     printf("Starting Generic File Export unit tests...\n");
     test_dll_export_int();
+    printf("test_dll_export_int passed\n");
     test_dll_export_string();
+    printf("test_dll_export_string passed\n");
+    test_stack_export_int();
+    printf("test_stack_export_int passed\n");
+    test_queue_export_int();
+    printf("test_queue_export_int passed\n");
     printf("All Generic File Export unit tests passed successfully!\n");
     return 0;
 }

--- a/tests/export/test_export.c
+++ b/tests/export/test_export.c
@@ -1,0 +1,77 @@
+#include "dll.h"
+#include "export.h"
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static void verify_file_content(const char* filepath, const char* expected)
+{
+    FILE* fp = fopen(filepath, "r");
+    assert(fp != NULL);
+
+    char buffer[4096];
+    size_t bytes_read = fread(buffer, 1, sizeof(buffer) - 1, fp);
+    buffer[bytes_read] = '\0';
+    fclose(fp);
+
+    assert(strcmp(buffer, expected) == 0);
+    remove(filepath);
+}
+
+static void test_dll_export_int(void)
+{
+    doubly_ll_Node* head = NULL;
+    int val1 = 10, val2 = 20, val3 = 30;
+
+    dll_insertAtEnd(&head, &val1);
+    dll_insertAtEnd(&head, &val2);
+    dll_insertAtEnd(&head, &val3);
+
+    // Text Export Test
+    assert(dll_export(head, "test_binaries/dll_int.txt", EXPORT_FORMAT_TEXT, write_data_int));
+    verify_file_content("test_binaries/dll_int.txt", "10 -> 20 -> 30 -> NULL\n");
+
+    // CSV Export Test
+    assert(dll_export(head, "test_binaries/dll_int.csv", EXPORT_FORMAT_CSV, write_data_int));
+    verify_file_content("test_binaries/dll_int.csv", "index,value\n0,10\n1,20\n2,30\n");
+
+    // JSON Export Test
+    assert(dll_export(head, "test_binaries/dll_int.json", EXPORT_FORMAT_JSON, write_data_int));
+    verify_file_content("test_binaries/dll_int.json", "[\n  10,\n  20,\n  30\n]\n");
+
+    delete_dll(head, NULL);
+}
+
+static void test_dll_export_string(void)
+{
+    doubly_ll_Node* head = NULL;
+    char* val1 = "apple";
+    char* val2 = "banana";
+
+    dll_insertAtEnd(&head, val1);
+    dll_insertAtEnd(&head, val2);
+
+    // Text Export Test
+    assert(dll_export(head, "test_binaries/dll_str.txt", EXPORT_FORMAT_TEXT, write_data_string));
+    verify_file_content("test_binaries/dll_str.txt", "apple -> banana -> NULL\n");
+
+    // CSV Export Test
+    assert(dll_export(head, "test_binaries/dll_str.csv", EXPORT_FORMAT_CSV, write_data_string));
+    verify_file_content("test_binaries/dll_str.csv", "index,value\n0,apple\n1,banana\n");
+
+    // JSON Export Test
+    assert(dll_export(head, "test_binaries/dll_str.json", EXPORT_FORMAT_JSON, write_data_string));
+    verify_file_content("test_binaries/dll_str.json", "[\n  apple,\n  banana\n]\n");
+
+    delete_dll(head, NULL);
+}
+
+int main(void)
+{
+    printf("Starting Generic File Export unit tests...\n");
+    test_dll_export_int();
+    test_dll_export_string();
+    printf("All Generic File Export unit tests passed successfully!\n");
+    return 0;
+}


### PR DESCRIPTION
### Description
This PR integrates interactive file export prompts directly into the interactive demos for DLL, Stack, Queues, and Deque.

### Resolves
* Resolves #878 (TUI Demo integrations)

### Changes
- **[dll_demo.c](file:///Users/akshatshukla/Library/Mobile%20Documents/com~apple~CloudDocs/Work/open/C_DSA_interactive_suite.git/demos/data_structures/dll_demo.c)**
- **[stack_demo.c](file:///Users/akshatshukla/Library/Mobile%20Documents/com~apple~CloudDocs/Work/open/C_DSA_interactive_suite.git/demos/data_structures/stack_demo.c)**
- **[circular_queue_demo.c](file:///Users/akshatshukla/Library/Mobile%20Documents/com~apple~CloudDocs/Work/open/C_DSA_interactive_suite.git/demos/data_structures/circular_queue_demo.c)**
- **[simple_queue_demo.c](file:///Users/akshatshukla/Library/Mobile%20Documents/com~apple~CloudDocs/Work/open/C_DSA_interactive_suite.git/demos/data_structures/simple_queue_demo.c)**
- **[deque_demo.c](file:///Users/akshatshukla/Library/Mobile%20Documents/com~apple~CloudDocs/Work/open/C_DSA_interactive_suite.git/demos/data_structures/deque_demo.c)**:
  - Updates all exit routes to redirect control flows through an export menu block instead of abruptly returning.
  - Adds interactive prompts asking the user if they want to export, requesting a file path, and offering a choice of format (Text, CSV, JSON).

### Verification & Testing
- Clean compilation and test verification using CMake (`cmake -B build && cmake --build build && ctest --test-dir build`).