### PR TITLE
Fix: Stack Buffer Overflow in Huffman Code Generation (Resolves #912 - Part 1)

### DIFF
--- a/src/compression/huffman.c
+++ b/src/compression/huffman.c
@@ -153,6 +153,11 @@ void generate_huffman_codes(const HuffmanNode* root, char codes[256][256], char*
         return;
     }
 
+    if (depth >= 255)
+    {
+        return;
+    }
+
     // Leaf node
     if (root->left == NULL && root->right == NULL)
     {


### PR DESCRIPTION
### Description
In `generate_huffman_codes()`, character codes are generated recursively and copied into `current_code`. The array `codes` is defined as `char codes[256][256]`, and `current_code` in the demo is allocated with a size of `256`. 
Resolves #912 
If a string contains many unique characters resulting in a highly skewed/deep Huffman tree, the depth of the tree can reach up to 256. The recursive function did not check the `depth` limit before writing `current_code[depth] = '0'`, leading to a stack buffer overflow.

### Changes
- Added a depth limit check in `generate_huffman_codes` (`depth >= 255`) to prevent recursion from exceeding and writing outside the bounds of the destination buffer.

### Verification
- Verified formatting using `clang-format` via CMake target `fmt`.
- Ran the test suite using `ctest` to ensure all existing compression and data structure tests pass successfully.