### PR TITLE
Fix: Add root_ref safety checks to AVL insert and delete

### DIFF
--- a/src/trees/avl.c
+++ b/src/trees/avl.c
@@ -132,6 +132,10 @@ static avlNode* avl_insert_helper(avlNode* node, int value, int* status)
 /* Public API: Inserts a value into the AVL tree */
 int avl_insert(avlNode** root_ref, int value)
 {
+    if (root_ref == NULL)
+    {
+        return 0;
+    }
     int status = 0;
     *root_ref = avl_insert_helper(*root_ref, value, &status);
     return status;
@@ -225,6 +229,10 @@ static avlNode* avl_delete_helper(avlNode* root, int value, int* status)
 /* Public API: Deletes a value from the AVL tree */
 int avl_delete(avlNode** root_ref, int value)
 {
+    if (root_ref == NULL)
+    {
+        return 0;
+    }
     int status = 0;
     *root_ref = avl_delete_helper(*root_ref, value, &status);
     return status;

--- a/src/trees/bplus_tree.c
+++ b/src/trees/bplus_tree.c
@@ -34,7 +34,7 @@ static BPlusNode* find_leaf(BPlusNode* root, int key)
     if (!root)
         return NULL;
     BPlusNode* curr = root;
-    while (!curr->is_leaf)
+    while (curr && !curr->is_leaf)
     {
         int idx = 0;
         while (idx < curr->num_keys && key >= curr->keys[idx])


### PR DESCRIPTION
Resolves #915

### Description
In `find_leaf()`, the traversal loop traversed the tree down to the leaves. If any allocation failure or restructuring resulted in a null child pointer, the loop condition `!curr->is_leaf` would dereference `NULL`.

### Changes
- Added a null guard check (`curr && !curr->is_leaf`) to the traversal loop in `find_leaf()`.