### PR TITLE
Fix: Add root_ref safety checks to AVL insert and delete

### DIFF
--- a/src/trees/avl.c
+++ b/src/trees/avl.c
@@ -132,6 +132,10 @@ static avlNode* avl_insert_helper(avlNode* node, int value, int* status)
 /* Public API: Inserts a value into the AVL tree */
 int avl_insert(avlNode** root_ref, int value)
 {
+    if (root_ref == NULL)
+    {
+        return 0;
+    }
     int status = 0;
     *root_ref = avl_insert_helper(*root_ref, value, &status);
     return status;
@@ -225,6 +229,10 @@ static avlNode* avl_delete_helper(avlNode* root, int value, int* status)
 /* Public API: Deletes a value from the AVL tree */
 int avl_delete(avlNode** root_ref, int value)
 {
+    if (root_ref == NULL)
+    {
+        return 0;
+    }
     int status = 0;
     *root_ref = avl_delete_helper(*root_ref, value, &status);
     return status;


### PR DESCRIPTION
Resolves #915

### Description
The public AVL insertion and deletion APIs did not validate if `root_ref` is `NULL` before dereferencing, exposing callers to potential crashes.

### Changes
- Added safety checks in `avl_insert()` and `avl_delete()` to return early if `root_ref` is `NULL`.