### PR TITLE
feat: Add graph algorithms stochastic fuzzing

### DIFF
--- a/src/utils/fuzzer.c
+++ b/src/utils/fuzzer.c
@@ -1,0 +1,99 @@
+#include "fuzzer.h"
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+void fuzzer_init(FuzzerState* fuzzer, unsigned int seed, int max_ops)
+{
+    fuzzer->seed = seed;
+    fuzzer->current_op = 0;
+    fuzzer->max_ops = max_ops;
+    fuzzer->log_capacity = 1000;
+    fuzzer->op_log = (char**)malloc(fuzzer->log_capacity * sizeof(char*));
+    if (fuzzer->op_log != NULL)
+    {
+        for (int i = 0; i < fuzzer->log_capacity; i++)
+        {
+            fuzzer->op_log[i] = NULL;
+        }
+    }
+}
+
+void fuzzer_free(FuzzerState* fuzzer)
+{
+    if (fuzzer->op_log != NULL)
+    {
+        for (int i = 0; i < fuzzer->current_op; i++)
+        {
+            if (fuzzer->op_log[i] != NULL)
+            {
+                free(fuzzer->op_log[i]);
+            }
+        }
+        free(fuzzer->op_log);
+        fuzzer->op_log = NULL;
+    }
+}
+
+void fuzzer_log_op(FuzzerState* fuzzer, const char* format, ...)
+{
+    if (fuzzer->op_log == NULL || fuzzer->current_op >= fuzzer->max_ops)
+    {
+        return;
+    }
+
+    if (fuzzer->current_op >= fuzzer->log_capacity)
+    {
+        int new_capacity = fuzzer->log_capacity * 2;
+        char** new_log = (char**)realloc(fuzzer->op_log, new_capacity * sizeof(char*));
+        if (new_log == NULL)
+        {
+            return;
+        }
+        fuzzer->op_log = new_log;
+        for (int i = fuzzer->log_capacity; i < new_capacity; i++)
+        {
+            fuzzer->op_log[i] = NULL;
+        }
+        fuzzer->log_capacity = new_capacity;
+    }
+
+    char buffer[256];
+    va_list args;
+    va_start(args, format);
+    vsnprintf(buffer, sizeof(buffer), format, args);
+    va_end(args);
+
+    fuzzer->op_log[fuzzer->current_op] = strdup(buffer);
+    fuzzer->current_op++;
+}
+
+void fuzzer_dump_log(const FuzzerState* fuzzer)
+{
+    printf("\n=== STOCHASTIC FUZZER REPLAY LOG ===\n");
+    printf("Seed: %u\n", fuzzer->seed);
+    printf("Total Operations executed: %d\n", fuzzer->current_op);
+    if (fuzzer->op_log != NULL)
+    {
+        for (int i = 0; i < fuzzer->current_op; i++)
+        {
+            if (fuzzer->op_log[i] != NULL)
+            {
+                printf("[%d] %s\n", i, fuzzer->op_log[i]);
+            }
+        }
+    }
+    printf("====================================\n\n");
+}
+
+int fuzzer_rand_int(FuzzerState* fuzzer, int min, int max)
+{
+    if (min >= max)
+    {
+        return min;
+    }
+    fuzzer->seed = fuzzer->seed * 1103515245 + 12345;
+    unsigned int val = (fuzzer->seed / 65536) % 32768;
+    return min + (int)(val % (unsigned int)(max - min + 1));
+}

--- a/src/utils/fuzzer.h
+++ b/src/utils/fuzzer.h
@@ -1,0 +1,19 @@
+#ifndef FUZZER_H
+#define FUZZER_H
+
+typedef struct
+{
+    unsigned int seed;
+    int current_op;
+    int max_ops;
+    char** op_log;
+    int log_capacity;
+} FuzzerState;
+
+void fuzzer_init(FuzzerState* fuzzer, unsigned int seed, int max_ops);
+void fuzzer_free(FuzzerState* fuzzer);
+void fuzzer_log_op(FuzzerState* fuzzer, const char* format, ...);
+void fuzzer_dump_log(const FuzzerState* fuzzer);
+int fuzzer_rand_int(FuzzerState* fuzzer, int min, int max);
+
+#endif // FUZZER_H

--- a/tests/advanced_heaps/test_heaps_fuzz.c
+++ b/tests/advanced_heaps/test_heaps_fuzz.c
@@ -1,0 +1,219 @@
+#include "advanced_heaps.h"
+#include "fuzzer.h"
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+
+void run_binomial_fuzz(FuzzerState* fuzzer, int ops)
+{
+    BinomialNode* root = NULL;
+    for (int i = 0; i < ops; i++)
+    {
+        int key = fuzzer_rand_int(fuzzer, 1, 1000);
+        int val = fuzzer_rand_int(fuzzer, 1, 1000);
+        int op = fuzzer_rand_int(fuzzer, 0, 2);
+        if (op == 0)
+        {
+            fuzzer_log_op(fuzzer, "Binomial insert %d:%d", key, val);
+            root = binomial_heap_insert(root, key, val);
+        }
+        else if (op == 1 && root != NULL)
+        {
+            int mk, mv;
+            fuzzer_log_op(fuzzer, "Binomial extract min");
+            root = binomial_heap_extract_min(root, &mk, &mv);
+        }
+        else
+        {
+            fuzzer_log_op(fuzzer, "Binomial find %d", key);
+            binomial_heap_find_node(root, key);
+        }
+    }
+    destroy_binomial_heap(root);
+}
+
+void run_fibonacci_fuzz(FuzzerState* fuzzer, int ops)
+{
+    FibonacciNode* root = NULL;
+    for (int i = 0; i < ops; i++)
+    {
+        int key = fuzzer_rand_int(fuzzer, 1, 1000);
+        int val = fuzzer_rand_int(fuzzer, 1, 1000);
+        int op = fuzzer_rand_int(fuzzer, 0, 2);
+        if (op == 0)
+        {
+            fuzzer_log_op(fuzzer, "Fibonacci insert %d:%d", key, val);
+            root = fib_heap_insert(root, key, val);
+        }
+        else if (op == 1 && root != NULL)
+        {
+            int mk, mv;
+            fuzzer_log_op(fuzzer, "Fibonacci extract min");
+            root = fib_heap_extract_min(root, &mk, &mv);
+        }
+        else if (op == 2 && root != NULL)
+        {
+            fuzzer_log_op(fuzzer, "Fibonacci delete %d", key);
+            FibonacciNode* target = fib_heap_find_node(root, key);
+            if (target != NULL)
+            {
+                root = fib_heap_delete(root, target);
+            }
+        }
+    }
+    destroy_fibonacci_heap(root);
+}
+
+void run_minmax_fuzz(FuzzerState* fuzzer, int ops)
+{
+    MinMaxHeap* heap = create_min_max_heap(ops + 10);
+    assert(heap != NULL);
+    for (int i = 0; i < ops; i++)
+    {
+        int key = fuzzer_rand_int(fuzzer, 1, 1000);
+        int val = fuzzer_rand_int(fuzzer, 1, 1000);
+        int op = fuzzer_rand_int(fuzzer, 0, 2);
+        if (op == 0)
+        {
+            fuzzer_log_op(fuzzer, "MinMax insert %d:%d", key, val);
+            min_max_heap_insert(heap, key, val);
+        }
+        else if (op == 1)
+        {
+            int mk, mv;
+            fuzzer_log_op(fuzzer, "MinMax extract min");
+            min_max_heap_extract_min(heap, &mk, &mv);
+        }
+        else
+        {
+            int mk, mv;
+            fuzzer_log_op(fuzzer, "MinMax extract max");
+            min_max_heap_extract_max(heap, &mk, &mv);
+        }
+    }
+    destroy_min_max_heap(heap);
+}
+
+void run_leftist_fuzz(FuzzerState* fuzzer, int ops)
+{
+    LeftistNode* root = NULL;
+    for (int i = 0; i < ops; i++)
+    {
+        int key = fuzzer_rand_int(fuzzer, 1, 1000);
+        int val = fuzzer_rand_int(fuzzer, 1, 1000);
+        int op = fuzzer_rand_int(fuzzer, 0, 1);
+        if (op == 0)
+        {
+            fuzzer_log_op(fuzzer, "Leftist insert %d:%d", key, val);
+            root = leftist_heap_insert(root, key, val);
+        }
+        else if (op == 1 && root != NULL)
+        {
+            int mk, mv;
+            fuzzer_log_op(fuzzer, "Leftist extract min");
+            root = leftist_heap_extract_min(root, &mk, &mv);
+        }
+    }
+    destroy_leftist_heap(root);
+}
+
+void run_skew_fuzz(FuzzerState* fuzzer, int ops)
+{
+    SkewNode* root = NULL;
+    for (int i = 0; i < ops; i++)
+    {
+        int key = fuzzer_rand_int(fuzzer, 1, 1000);
+        int val = fuzzer_rand_int(fuzzer, 1, 1000);
+        int op = fuzzer_rand_int(fuzzer, 0, 1);
+        if (op == 0)
+        {
+            fuzzer_log_op(fuzzer, "Skew insert %d:%d", key, val);
+            root = skew_heap_insert(root, key, val);
+        }
+        else if (op == 1 && root != NULL)
+        {
+            int mk, mv;
+            fuzzer_log_op(fuzzer, "Skew extract min");
+            root = skew_heap_extract_min(root, &mk, &mv);
+        }
+    }
+    destroy_skew_heap(root);
+}
+
+void run_dary_fuzz(FuzzerState* fuzzer, int ops)
+{
+    DAryHeap* heap = create_dary_heap(ops + 10, 3);
+    assert(heap != NULL);
+    for (int i = 0; i < ops; i++)
+    {
+        int key = fuzzer_rand_int(fuzzer, 1, 1000);
+        int val = fuzzer_rand_int(fuzzer, 1, 1000);
+        int op = fuzzer_rand_int(fuzzer, 0, 2);
+        if (op == 0)
+        {
+            fuzzer_log_op(fuzzer, "d-Ary insert %d:%d", key, val);
+            dary_heap_insert(heap, key, val);
+        }
+        else if (op == 1)
+        {
+            int mk, mv;
+            fuzzer_log_op(fuzzer, "d-Ary extract min");
+            dary_heap_extract_min(heap, &mk, &mv);
+        }
+        else
+        {
+            fuzzer_log_op(fuzzer, "d-Ary find index %d", key);
+            dary_heap_find_index(heap, key);
+        }
+    }
+    destroy_dary_heap(heap);
+}
+
+void run_treap_fuzz(FuzzerState* fuzzer, int ops)
+{
+    TreapNode* root = NULL;
+    for (int i = 0; i < ops; i++)
+    {
+        int key = fuzzer_rand_int(fuzzer, 1, 1000);
+        int val = fuzzer_rand_int(fuzzer, 1, 1000);
+        int pri = fuzzer_rand_int(fuzzer, 1, 1000);
+        int op = fuzzer_rand_int(fuzzer, 0, 2);
+        if (op == 0)
+        {
+            fuzzer_log_op(fuzzer, "Treap insert %d:%d:%d", key, val, pri);
+            root = treap_insert(root, key, val, pri);
+        }
+        else if (op == 1)
+        {
+            fuzzer_log_op(fuzzer, "Treap delete %d", key);
+            root = treap_delete(root, key);
+        }
+        else
+        {
+            fuzzer_log_op(fuzzer, "Treap find %d", key);
+            treap_find_node(root, key);
+        }
+    }
+    destroy_treap(root);
+}
+
+int main(void)
+{
+    unsigned int seed = (unsigned int)time(NULL);
+    FuzzerState fuzzer;
+    printf("Starting Heap Fuzzing with seed: %u\n", seed);
+
+    fuzzer_init(&fuzzer, seed, 5000);
+    run_binomial_fuzz(&fuzzer, 500);
+    run_fibonacci_fuzz(&fuzzer, 500);
+    run_minmax_fuzz(&fuzzer, 500);
+    run_leftist_fuzz(&fuzzer, 500);
+    run_skew_fuzz(&fuzzer, 500);
+    run_dary_fuzz(&fuzzer, 500);
+    run_treap_fuzz(&fuzzer, 500);
+    fuzzer_free(&fuzzer);
+
+    printf("Heap Fuzzing completed successfully!\n");
+    return 0;
+}

--- a/tests/graph_traversals/test_graphs_fuzz.c
+++ b/tests/graph_traversals/test_graphs_fuzz.c
@@ -1,0 +1,90 @@
+#include "fuzzer.h"
+#include "graph_traversals.h"
+#include "step_debugger.h"
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+
+void run_unweighted_graph_fuzz(FuzzerState* fuzzer, int num_nodes, int num_edges)
+{
+    Graph* graph = create_graph(num_nodes);
+    assert(graph != NULL);
+
+    for (int i = 0; i < num_edges; i++)
+    {
+        int u = fuzzer_rand_int(fuzzer, 0, num_nodes - 1);
+        int v = fuzzer_rand_int(fuzzer, 0, num_nodes - 1);
+        int dir = fuzzer_rand_int(fuzzer, 0, 1);
+        if (dir == 0)
+        {
+            fuzzer_log_op(fuzzer, "Add undirected edge %d-%d", u, v);
+            add_edge_undirected(graph, u, v);
+        }
+        else
+        {
+            fuzzer_log_op(fuzzer, "Add directed edge %d->%d", u, v);
+            add_edge_directed_unweighted(graph, u, v);
+        }
+    }
+
+    int start = fuzzer_rand_int(fuzzer, 0, num_nodes - 1);
+    fuzzer_log_op(fuzzer, "BFS traversal from %d", start);
+    bfs(graph, start);
+
+    fuzzer_log_op(fuzzer, "DFS traversal from %d", start);
+    dfs(graph, start);
+
+    fuzzer_log_op(fuzzer, "Topological sort Kahn");
+    topological_sort_kahn(graph);
+
+    free_graph(graph);
+}
+
+void run_weighted_graph_fuzz(FuzzerState* fuzzer, int num_nodes, int num_edges)
+{
+    weightedGraph* graph = create_weightedGraph(num_nodes);
+    assert(graph != NULL);
+
+    for (int i = 0; i < num_edges; i++)
+    {
+        int u = fuzzer_rand_int(fuzzer, 0, num_nodes - 1);
+        int v = fuzzer_rand_int(fuzzer, 0, num_nodes - 1);
+        int w = fuzzer_rand_int(fuzzer, 1, 100);
+        fuzzer_log_op(fuzzer, "Add weighted edge %d->%d weight %d", u, v, w);
+        add_edge_directed(graph, u, v, w);
+    }
+
+    int start = fuzzer_rand_int(fuzzer, 0, num_nodes - 1);
+    fuzzer_log_op(fuzzer, "Dijkstra from %d", start);
+    dijkstra(graph, start);
+
+    fuzzer_log_op(fuzzer, "Bellman-Ford from %d", start);
+    bellman_ford(graph, start);
+
+    fuzzer_log_op(fuzzer, "Kruskal MST");
+    kruskal_mst(graph);
+
+    fuzzer_log_op(fuzzer, "Prim MST from %d", start);
+    prim_mst(graph, start);
+
+    free_weightedGraph(graph);
+}
+
+int main(void)
+{
+    setenv("DSA_TEST_MODE", "1", 1);
+    set_step_mode(0);
+    set_paused(0);
+    unsigned int seed = (unsigned int)time(NULL);
+    FuzzerState fuzzer;
+    printf("Starting Graph Fuzzing with seed: %u\n", seed);
+
+    fuzzer_init(&fuzzer, seed, 5000);
+    run_unweighted_graph_fuzz(&fuzzer, 30, 80);
+    run_weighted_graph_fuzz(&fuzzer, 30, 80);
+    fuzzer_free(&fuzzer);
+
+    printf("Graph Fuzzing completed successfully!\n");
+    return 0;
+}

--- a/tests/trees/test_trees_fuzz.c
+++ b/tests/trees/test_trees_fuzz.c
@@ -1,0 +1,119 @@
+#include "fuzzer.h"
+#include "trees.h"
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+
+void run_bst_fuzz(FuzzerState* fuzzer, int ops)
+{
+    bstNode* root = NULL;
+    for (int i = 0; i < ops; i++)
+    {
+        int val = fuzzer_rand_int(fuzzer, 1, 1000);
+        int op = fuzzer_rand_int(fuzzer, 0, 2);
+        if (op == 0)
+        {
+            fuzzer_log_op(fuzzer, "BST insert %d", val);
+            bst_insert(&root, val);
+        }
+        else if (op == 1)
+        {
+            fuzzer_log_op(fuzzer, "BST delete %d", val);
+            root = bst_delete(root, val);
+        }
+        else
+        {
+            fuzzer_log_op(fuzzer, "BST height check");
+            tree_height(root);
+        }
+    }
+    destroy_bst(root);
+}
+
+void run_avl_fuzz(FuzzerState* fuzzer, int ops)
+{
+    avlNode* root = NULL;
+    for (int i = 0; i < ops; i++)
+    {
+        int val = fuzzer_rand_int(fuzzer, 1, 1000);
+        int op = fuzzer_rand_int(fuzzer, 0, 2);
+        if (op == 0)
+        {
+            fuzzer_log_op(fuzzer, "AVL insert %d", val);
+            avl_insert(&root, val);
+        }
+        else if (op == 1)
+        {
+            fuzzer_log_op(fuzzer, "AVL delete %d", val);
+            avl_delete(&root, val);
+        }
+        else
+        {
+            fuzzer_log_op(fuzzer, "AVL balance check");
+            avl_balance_factor(root);
+        }
+    }
+    destroy_avl(root);
+}
+
+void run_trie_fuzz(FuzzerState* fuzzer, int ops)
+{
+    TrieNode* root = trie_create_node();
+    assert(root != NULL);
+
+    char word[12];
+    for (int i = 0; i < ops; i++)
+    {
+        int len = fuzzer_rand_int(fuzzer, 1, 10);
+        for (int j = 0; j < len; j++)
+        {
+            word[j] = 'a' + fuzzer_rand_int(fuzzer, 0, 25);
+        }
+        word[len] = '\0';
+
+        int op = fuzzer_rand_int(fuzzer, 0, 2);
+        if (op == 0)
+        {
+            fuzzer_log_op(fuzzer, "Trie insert %s", word);
+            trie_insert(root, word);
+        }
+        else if (op == 1)
+        {
+            fuzzer_log_op(fuzzer, "Trie search %s", word);
+            trie_search(root, word);
+        }
+        else
+        {
+            fuzzer_log_op(fuzzer, "Trie delete %s", word);
+            trie_delete(root, word);
+        }
+    }
+    trie_free(root);
+}
+
+int main(void)
+{
+    unsigned int seed = (unsigned int)time(NULL);
+    FuzzerState fuzzer;
+
+    printf("Starting Tree Fuzzing with seed: %u\n", seed);
+
+    // BST
+    fuzzer_init(&fuzzer, seed, 5000);
+    run_bst_fuzz(&fuzzer, 1000);
+    fuzzer_free(&fuzzer);
+
+    // AVL
+    fuzzer_init(&fuzzer, seed, 5000);
+    run_avl_fuzz(&fuzzer, 1000);
+    fuzzer_free(&fuzzer);
+
+    // Trie
+    fuzzer_init(&fuzzer, seed, 5000);
+    run_trie_fuzz(&fuzzer, 1000);
+    fuzzer_free(&fuzzer);
+
+    printf("Tree Fuzzing completed successfully!\n");
+    return 0;
+}


### PR DESCRIPTION
Resolves #674

### Description
Applies the stochastic fuzzing engine to graph traversal, shortest path, and Minimum Spanning Tree algorithms.

### Changes
- Created `tests/graph_traversals/test_graphs_fuzz.c` containing random edge-stress and pathfinder traversals for BFS, DFS, Dijkstra, Bellman-Ford, Kahn's Topological Sort, Kruskal's, and Prim's MST.