### PR TITLE
feat: Implement Core Big-O Deduction Engine & Ratio Profiler Pr-1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,6 +82,8 @@ if(NOT WIN32)
     find_package(Curses REQUIRED)
     include_directories(${CURSES_INCLUDE_DIR})
     set(EXTRA_LIBS ${CURSES_LIBRARIES})
+    # Link math library for log(), pow(), etc. on POSIX systems
+    list(APPEND EXTRA_LIBS m)
 else()
     set(EXTRA_LIBS "")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,6 +52,7 @@ set(SRC_DIRS
     features/serialization
     features/dp_visualizer
     features/memory_inspector
+    features/bigo_verifier
 )
 
 # Header search paths

--- a/features/bigo_verifier/bigo_verifier.c
+++ b/features/bigo_verifier/bigo_verifier.c
@@ -1,0 +1,205 @@
+#include "bigo_verifier.h"
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+const char* bigo_complexity_to_string(BigOComplexity complexity)
+{
+    switch (complexity)
+    {
+        case BIGO_O1:
+            return "O(1)";
+        case BIGO_OLOGN:
+            return "O(log N)";
+        case BIGO_ON:
+            return "O(N)";
+        case BIGO_ONLOGN:
+            return "O(N log N)";
+        case BIGO_ON2:
+            return "O(N^2)";
+        case BIGO_ON3:
+            return "O(N^3)";
+        default:
+            return "O(Unknown)";
+    }
+}
+
+BigOComplexity deduce_bigo_from_ratio(double ratio, int n)
+{
+    if (ratio <= 0.0)
+    {
+        return BIGO_UNKNOWN;
+    }
+
+    // Expected theoretical growth ratios T(2N) / T(N):
+    // O(1)      => ~1.0
+    // O(log N)  => (log(2N) / log(N)) = 1 + (log 2 / log N)  => ~1.1 to 1.3
+    // O(N)      => ~2.0
+    // O(N log N)=> 2 * (1 + log 2 / log N)                   => ~2.2 to 2.5
+    // O(N^2)    => ~4.0
+    // O(N^3)    => ~8.0
+
+    double log_factor = (n > 1) ? (1.0 + (log(2.0) / log((double)n))) : 1.2;
+    double expected_onlogn_ratio = 2.0 * log_factor;
+
+    if (ratio < 1.15)
+    {
+        return BIGO_O1;
+    }
+    else if (ratio < 1.6)
+    {
+        return BIGO_OLOGN;
+    }
+    else if (ratio < (expected_onlogn_ratio - 0.15))
+    {
+        return BIGO_ON;
+    }
+    else if (ratio < 3.1)
+    {
+        return BIGO_ONLOGN;
+    }
+    else if (ratio < 6.0)
+    {
+        return BIGO_ON2;
+    }
+    else
+    {
+        return BIGO_ON3;
+    }
+}
+
+static double measure_execution_time_ms(AlgFunction func, int n)
+{
+    if (func == NULL || n <= 0)
+    {
+        return 0.0;
+    }
+
+    int* data = (int*)malloc((size_t)n * sizeof(int));
+    if (!data)
+    {
+        return 0.0;
+    }
+
+    // Populate with pseudorandom numbers
+    srand(42);
+    for (int i = 0; i < n; i++)
+    {
+        data[i] = rand() % (n * 10 + 1);
+    }
+
+    clock_t start = clock();
+    func(data, n);
+    clock_t end = clock();
+
+    free(data);
+
+    double duration_ms = ((double)(end - start) * 1000.0) / CLOCKS_PER_SEC;
+    return (duration_ms < 0.001) ? 0.001 : duration_ms;
+}
+
+bool run_bigo_profile(const char* alg_name, const char* theoretical_str, AlgFunction func,
+                      int base_n, int samples_to_run, BigOReport* report)
+{
+    if (!alg_name || !func || !report || base_n <= 0)
+    {
+        return false;
+    }
+
+    memset(report, 0, sizeof(BigOReport));
+    report->algorithm_name = alg_name;
+    report->theoretical_complexity = theoretical_str ? theoretical_str : "Unknown";
+
+    if (samples_to_run < 2)
+    {
+        samples_to_run = 2;
+    }
+    if (samples_to_run > MAX_BIGO_SAMPLES)
+    {
+        samples_to_run = MAX_BIGO_SAMPLES;
+    }
+
+    report->sample_count = samples_to_run;
+
+    int current_n = base_n;
+    for (int i = 0; i < samples_to_run; i++)
+    {
+        report->samples[i].n = current_n;
+
+        // Run 3 trials and average to reduce hardware noise
+        double t1 = measure_execution_time_ms(func, current_n);
+        double t2 = measure_execution_time_ms(func, current_n);
+        double t3 = measure_execution_time_ms(func, current_n);
+
+        report->samples[i].time_ms = (t1 + t2 + t3) / 3.0;
+        current_n *= 2;
+    }
+
+    report->ratio_count = samples_to_run - 1;
+    double sum_ratio = 0.0;
+
+    for (int i = 0; i < report->ratio_count; i++)
+    {
+        double prev_t = report->samples[i].time_ms;
+        double next_t = report->samples[i + 1].time_ms;
+        double ratio = (prev_t > 0.0) ? (next_t / prev_t) : 1.0;
+
+        report->ratios[i].n_start = report->samples[i].n;
+        report->ratios[i].n_end = report->samples[i + 1].n;
+        report->ratios[i].ratio = ratio;
+        report->ratios[i].deduced_class = deduce_bigo_from_ratio(ratio, report->samples[i].n);
+
+        sum_ratio += ratio;
+    }
+
+    double avg_ratio = sum_ratio / (double)report->ratio_count;
+    report->overall_empirical_class = deduce_bigo_from_ratio(avg_ratio, report->samples[0].n);
+    report->overall_empirical_str = bigo_complexity_to_string(report->overall_empirical_class);
+
+    report->matches_theoretical =
+        (strstr(report->overall_empirical_str, report->theoretical_complexity) != NULL ||
+         strstr(report->theoretical_complexity, report->overall_empirical_str) != NULL);
+
+    return true;
+}
+
+void print_bigo_report(const BigOReport* report)
+{
+    if (!report)
+    {
+        printf("(NULL BigOReport pointer)\n");
+        return;
+    }
+
+    printf("\n========================================================================\n");
+    printf("        EMPIRICAL ASYMPTOTIC COMPLEXITY VERIFIER (BIG-O ENGINE)        \n");
+    printf("========================================================================\n");
+    printf("Algorithm: %-25s | Theoretical: %s\n", report->algorithm_name,
+           report->theoretical_complexity);
+    printf("------------------------------------------------------------------------\n");
+    printf("  %-10s | %-16s | %-14s | %-12s\n", "Size (N)", "Time (ms)", "Ratio T(2N)/T(N)",
+           "Deduced Bound");
+    printf("  -----------+------------------+----------------+--------------\n");
+
+    for (int i = 0; i < report->sample_count; i++)
+    {
+        if (i < report->ratio_count)
+        {
+            printf("  N=%-8d | %-16.3f | %-14.2fx | %-12s\n", report->samples[i].n,
+                   report->samples[i].time_ms, report->ratios[i].ratio,
+                   bigo_complexity_to_string(report->ratios[i].deduced_class));
+        }
+        else
+        {
+            printf("  N=%-8d | %-16.3f | %-14s | %-12s\n", report->samples[i].n,
+                   report->samples[i].time_ms, "-", "-");
+        }
+    }
+
+    printf("========================================================================\n");
+    printf("Empirical Bound Deduced: %s\n", report->overall_empirical_str);
+    printf("Theoretical Match: %s\n", report->matches_theoretical ? "[MATCHED]" : "[DIVERGED]");
+    printf("========================================================================\n\n");
+}

--- a/features/bigo_verifier/bigo_verifier.h
+++ b/features/bigo_verifier/bigo_verifier.h
@@ -1,0 +1,84 @@
+#ifndef BIGO_VERIFIER_H
+#define BIGO_VERIFIER_H
+
+#include <stdbool.h>
+#include <stddef.h>
+
+#define MAX_BIGO_SAMPLES 6
+
+typedef enum
+{
+    BIGO_O1,
+    BIGO_OLOGN,
+    BIGO_ON,
+    BIGO_ONLOGN,
+    BIGO_ON2,
+    BIGO_ON3,
+    BIGO_UNKNOWN
+} BigOComplexity;
+
+typedef struct
+{
+    int n;
+    double time_ms;
+} BigOSample;
+
+typedef struct
+{
+    int n_start;
+    int n_end;
+    double ratio;
+    BigOComplexity deduced_class;
+} BigORatio;
+
+typedef struct
+{
+    const char* algorithm_name;
+    const char* theoretical_complexity;
+    int sample_count;
+    BigOSample samples[MAX_BIGO_SAMPLES];
+    int ratio_count;
+    BigORatio ratios[MAX_BIGO_SAMPLES - 1];
+    BigOComplexity overall_empirical_class;
+    const char* overall_empirical_str;
+    bool matches_theoretical;
+} BigOReport;
+
+typedef void (*AlgFunction)(int* data, int n);
+
+/**
+ * Get string representation of BigOComplexity enum.
+ */
+const char* bigo_complexity_to_string(BigOComplexity complexity);
+
+/**
+ * Deduce empirical Big-O complexity class from growth ratio T(2N) / T(N) at problem size N.
+ *
+ * @param ratio Observed execution time ratio T(2N) / T(N).
+ * @param n Current base problem size N.
+ * @return Deduced BigOComplexity enum.
+ */
+BigOComplexity deduce_bigo_from_ratio(double ratio, int n);
+
+/**
+ * Run empirical Big-O profiling on a given algorithm function across scaling input sizes.
+ *
+ * @param alg_name Human readable algorithm name.
+ * @param theoretical_str Theoretical complexity string (e.g. "O(N^2)").
+ * @param func Function pointer to the algorithm under test.
+ * @param base_n Starting problem size N.
+ * @param samples_to_run Number of scaling samples (e.g. 4 for N, 2N, 4N, 8N).
+ * @param report Output report struct to populate.
+ * @return True on success, false on error.
+ */
+bool run_bigo_profile(const char* alg_name, const char* theoretical_str, AlgFunction func,
+                      int base_n, int samples_to_run, BigOReport* report);
+
+/**
+ * Print a formatted text-based Big-O empirical verification report table.
+ *
+ * @param report Pointer to the populated BigOReport.
+ */
+void print_bigo_report(const BigOReport* report);
+
+#endif /* BIGO_VERIFIER_H */

--- a/tests/features/test_bigo_verifier.c
+++ b/tests/features/test_bigo_verifier.c
@@ -1,0 +1,68 @@
+#include "bigo_verifier.h"
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+
+// Sample O(N^2) dummy algorithm (Bubble Sort variant)
+static void dummy_on2_alg(int* data, int n)
+{
+    for (int i = 0; i < n; i++)
+    {
+        for (int j = 0; j < n - 1; j++)
+        {
+            if (data[j] > data[j + 1])
+            {
+                int temp = data[j];
+                data[j] = data[j + 1];
+                data[j + 1] = temp;
+            }
+        }
+    }
+}
+
+// Sample O(N) dummy algorithm (Linear Scan)
+static void dummy_on_alg(int* data, int n)
+{
+    long long sum = 0;
+    for (int i = 0; i < n; i++)
+    {
+        sum += data[i];
+    }
+    (void)sum;
+}
+
+void test_ratio_deduction(void)
+{
+    assert(deduce_bigo_from_ratio(1.0, 1000) == BIGO_O1);
+    assert(deduce_bigo_from_ratio(1.3, 1000) == BIGO_OLOGN);
+    assert(deduce_bigo_from_ratio(2.0, 1000) == BIGO_ON);
+    assert(deduce_bigo_from_ratio(4.0, 1000) == BIGO_ON2);
+    assert(deduce_bigo_from_ratio(8.0, 1000) == BIGO_ON3);
+    printf("test_ratio_deduction passed!\n");
+}
+
+void test_bigo_profiler_execution(void)
+{
+    BigOReport report;
+    bool success = run_bigo_profile("Dummy O(N^2) Alg", "O(N^2)", dummy_on2_alg, 200, 3, &report);
+    assert(success == true);
+    assert(report.sample_count == 3);
+    assert(report.ratio_count == 2);
+    assert(strcmp(report.algorithm_name, "Dummy O(N^2) Alg") == 0);
+
+    print_bigo_report(&report);
+
+    BigOReport report_on;
+    success = run_bigo_profile("Dummy O(N) Alg", "O(N)", dummy_on_alg, 1000, 3, &report_on);
+    assert(success == true);
+    print_bigo_report(&report_on);
+
+    printf("test_bigo_profiler_execution passed!\n");
+}
+
+int main(void)
+{
+    test_ratio_deduction();
+    test_bigo_profiler_execution();
+    return 0;
+}


### PR DESCRIPTION
Resolves #676

### Description
Introduces the core empirical Big-O deduction engine (`deduce_bigo_from_ratio`, `run_bigo_profile`) that measures execution times across scaling problem sizes (N, 2N, 4N, 8N), calculates empirical growth ratios T(2N)/T(N), and classifies growth curves into O(1), O(log N), O(N), O(N log N), O(N^2), O(N^3).

### Changes
- Registered `features/bigo_verifier` in `CMakeLists.txt`.
- Implemented `features/bigo_verifier/bigo_verifier.h` and `features/bigo_verifier/bigo_verifier.c`.
- Added unit test suite in `tests/features/test_bigo_verifier.c`.