### PR TITLE
fix(flow): add validation check for source == sink in ford_fulkerson

### DIFF
--- a/src/advanced_graph_algorithms/ford_fulkerson.c
+++ b/src/advanced_graph_algorithms/ford_fulkerson.c
@@ -25,7 +25,8 @@ static bool dfs_augmenting_path(int V, int** residual, int u, int sink, bool* vi
 
 int ford_fulkerson(weightedGraph* graph, int source, int sink)
 {
-    if (graph == NULL || source < 0 || source >= graph->V || sink < 0 || sink >= graph->V)
+    if (graph == NULL || source < 0 || source >= graph->V || sink < 0 || sink >= graph->V ||
+        source == sink)
         return 0;
 
     int V = graph->V;

--- a/tests/advanced_graph_algorithms/test_ford_fulkerson.c
+++ b/tests/advanced_graph_algorithms/test_ford_fulkerson.c
@@ -18,6 +18,9 @@ void test_ff_simple()
     int flow = ford_fulkerson(g, 0, 3);
     assert(flow == 5);
 
+    int same_src_sink_flow = ford_fulkerson(g, 0, 0);
+    assert(same_src_sink_flow == 0);
+
     free_weightedGraph(g);
     printf("test_ff_simple passed.\n");
 }


### PR DESCRIPTION
Resolves #984

### Description
Adds a validation guard check at the beginning of `ford_fulkerson()` (`src/advanced_graph_algorithms/ford_fulkerson.c`) to immediately return 0 when `source == sink`. This prevents infinite recursive execution of `dfs_augmenting_path()` and signed integer overflow (`max_flow += INT_MAX`).

### Changes
- `src/advanced_graph_algorithms/ford_fulkerson.c`: Added `source == sink` validation check.
- `tests/advanced_graph_algorithms/test_ford_fulkerson.c`: Added test assertion for `source == sink`.