### PR TITLE
refactor(style): standardize section headers using display_header() utility (PR 4)

### DIFF
--- a/demos/error_correction_algorithms/parity_bit_demo.c
+++ b/demos/error_correction_algorithms/parity_bit_demo.c
@@ -1,3 +1,4 @@
+#include "display_header.h"
 #include "error_correction_algorithms.h"
 #include "safe_input.h"
 #include <stdbool.h>
@@ -25,7 +26,7 @@ void parity_bit_demo(void)
     char received[CHECKSUM_MAX_BITS + 2];
     int choice;
 
-    printf("\n--- Parity Bit Error Detection Demo ---\n");
+    display_header("Parity Bit Error Detection");
 
     /* INPUT DATA */
     while (1)

--- a/demos/trees/fenwick_tree_demo.c
+++ b/demos/trees/fenwick_tree_demo.c
@@ -1,3 +1,4 @@
+#include "display_header.h"
 #include "safe_input.h"
 #include "trees.h"
 #include <stdio.h>
@@ -5,7 +6,7 @@
 
 void fenwick_tree_demo(void)
 {
-    printf("\n--- Fenwick Tree (Dual-BIT) Range Update / Range Query Demo ---\n");
+    display_header("Fenwick Tree (Dual-BIT) Range Update / Range Query");
     int n = 5;
     printf("Created Fenwick Tree of size %d initialized to 0.\n", n);
     FenwickTree* ft = create_fenwick_tree(n);

--- a/demos/trees/red_black_tree_demo.c
+++ b/demos/trees/red_black_tree_demo.c
@@ -1,10 +1,11 @@
+#include "display_header.h"
 #include "trees.h"
 #include <stdio.h>
 #include <stdlib.h>
 
 void red_black_tree_demo(void)
 {
-    printf("\n--- Red-Black Tree (Self-Balancing BST) Demo ---\n");
+    display_header("Red-Black Tree (Self-Balancing BST)");
     rbTree* tree = create_rb_tree();
     if (tree == NULL)
     {

--- a/demos/trees/splay_tree_demo.c
+++ b/demos/trees/splay_tree_demo.c
@@ -1,3 +1,4 @@
+#include "display_header.h"
 #include "trees.h"
 #include <stdio.h>
 #include <stdlib.h>
@@ -5,7 +6,7 @@
 void splay_tree_demo(void)
 {
     splayNode* root = NULL;
-    printf("\n--- Splay Tree (Amortized O(log n)) Demo ---\n");
+    display_header("Splay Tree (Amortized O(log n))");
     printf("Action: Inserting 10, 20, 30, 40, 50, 25...\n");
     root = splay_tree_insert(root, 10);
     root = splay_tree_insert(root, 20);


### PR DESCRIPTION
## PR Description

This PR standardizes visual section headers across algorithm sub-demo files by replacing inconsistent raw `printf` border/title calls with the centralized `display_header()` utility, ensuring a uniform terminal output style across the entire codebase.

### 🚀 Key Changes

**Files Modified** — replaced manual `printf("\n--- ... ---\n")` title lines with `display_header()` and added the missing `#include "display_header.h"` where needed:

| File | Before | After |
|---|---|---|
| `demos/trees/splay_tree_demo.c` | `printf("\n--- Splay Tree ... ---\n")` | `display_header("Splay Tree (Amortized O(log n))")` |
| `demos/trees/red_black_tree_demo.c` | `printf("\n--- Red-Black Tree ... ---\n")` | `display_header("Red-Black Tree (Self-Balancing BST)")` |
| `demos/trees/fenwick_tree_demo.c` | `printf("\n--- Fenwick Tree ... ---\n")` | `display_header("Fenwick Tree (Dual-BIT) Range Update / Range Query")` |
| `demos/error_correction_algorithms/parity_bit_demo.c` | `printf("\n--- Parity Bit Error Detection Demo ---\n")` | `display_header("Parity Bit Error Detection")` |


closes #998 