### PR TITLE
feat: Implement Core DFS Recursive File Search & Standalone File Exporter Engine PR 1-4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,7 @@ set(SRC_DIRS
     features/dp_visualizer
     features/memory_inspector
     features/bigo_verifier
+    features/file_exporter
     src/bit_manipulation
 )
 

--- a/features/file_exporter/file_exporter.c
+++ b/features/file_exporter/file_exporter.c
@@ -168,7 +168,7 @@ bool export_file_pair(const char* root_dir, const char* base_filename, const cha
     bool found_c = dfs_search_file(start_dir, c_filename, found_c_src);
     bool found_h = dfs_search_file(start_dir, h_filename, found_h_src);
 
-    if (!found_c && !found_h)
+    if (!found_c || !found_h)
     {
         return false;
     }
@@ -200,5 +200,5 @@ bool export_file_pair(const char* root_dir, const char* base_filename, const cha
         }
     }
 
-    return (success_c || success_h);
+    return (success_c && success_h);
 }

--- a/features/file_exporter/file_exporter.c
+++ b/features/file_exporter/file_exporter.c
@@ -1,0 +1,204 @@
+#include "file_exporter.h"
+#include <dirent.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+
+static void ensure_dir_exists(const char* dirpath)
+{
+    if (!dirpath || strlen(dirpath) == 0)
+    {
+        return;
+    }
+    char tmp[1024];
+    snprintf(tmp, sizeof(tmp), "%s", dirpath);
+    size_t len = strlen(tmp);
+    if (len == 0)
+    {
+        return;
+    }
+    if (tmp[len - 1] == '/')
+    {
+        tmp[len - 1] = '\0';
+    }
+    for (char* p = tmp + 1; *p; p++)
+    {
+        if (*p == '/')
+        {
+            *p = '\0';
+            mkdir(tmp, 0755);
+            *p = '/';
+        }
+    }
+    mkdir(tmp, 0755);
+}
+
+bool dfs_search_file(const char* base_dir, const char* target_filename, char* found_path_out)
+{
+    if (!base_dir || !target_filename || !found_path_out)
+    {
+        return false;
+    }
+
+    const char* search_dir = base_dir;
+    struct stat st_src;
+    if (strcmp(base_dir, ".") == 0 && stat("src", &st_src) == -1 && stat("../src", &st_src) == 0)
+    {
+        search_dir = "..";
+    }
+
+    DIR* dir = opendir(search_dir);
+    if (!dir)
+    {
+        return false;
+    }
+
+    struct dirent* entry;
+    bool found = false;
+
+    while ((entry = readdir(dir)) != NULL)
+    {
+        // Skip . and .. and hidden/build/git directories
+        if (strcmp(entry->d_name, ".") == 0 || strcmp(entry->d_name, "..") == 0 ||
+            strcmp(entry->d_name, ".git") == 0 || strcmp(entry->d_name, "build") == 0 ||
+            strcmp(entry->d_name, "object_files") == 0 ||
+            strcmp(entry->d_name, "test_binaries") == 0 || entry->d_name[0] == '.')
+        {
+            continue;
+        }
+
+        char path[1024];
+        snprintf(path, sizeof(path), "%s/%s", search_dir, entry->d_name);
+
+        struct stat st;
+        if (stat(path, &st) == -1)
+        {
+            continue;
+        }
+
+        if (S_ISDIR(st.st_mode))
+        {
+            // Recurse into subdirectory (DFS)
+            if (dfs_search_file(path, target_filename, found_path_out))
+            {
+                found = true;
+                break;
+            }
+        }
+        else if (S_ISREG(st.st_mode))
+        {
+            if (strcmp(entry->d_name, target_filename) == 0)
+            {
+                strncpy(found_path_out, path, 512);
+                found_path_out[511] = '\0';
+                found = true;
+                break;
+            }
+        }
+    }
+
+    closedir(dir);
+    return found;
+}
+
+bool copy_file_contents(const char* src_path, const char* dest_path)
+{
+    if (!src_path || !dest_path)
+    {
+        return false;
+    }
+
+    FILE* src_fp = fopen(src_path, "rb");
+    if (!src_fp)
+    {
+        return false;
+    }
+
+    // Extract directory component from dest_path
+    char dest_dir[1024];
+    strncpy(dest_dir, dest_path, sizeof(dest_dir) - 1);
+    dest_dir[sizeof(dest_dir) - 1] = '\0';
+    char* last_slash = strrchr(dest_dir, '/');
+    if (last_slash != NULL)
+    {
+        *last_slash = '\0';
+        ensure_dir_exists(dest_dir);
+    }
+
+    FILE* dest_fp = fopen(dest_path, "wb");
+    if (!dest_fp)
+    {
+        fclose(src_fp);
+        return false;
+    }
+
+    char buffer[4096];
+    size_t bytes_read;
+    while ((bytes_read = fread(buffer, 1, sizeof(buffer), src_fp)) > 0)
+    {
+        fwrite(buffer, 1, bytes_read, dest_fp);
+    }
+
+    fclose(src_fp);
+    fclose(dest_fp);
+    return true;
+}
+
+bool export_file_pair(const char* root_dir, const char* base_filename, const char* header_basename,
+                      const char* dest_dir, char* exported_c_path, char* exported_h_path)
+{
+    if (!root_dir || !base_filename || !dest_dir)
+    {
+        return false;
+    }
+
+    const char* start_dir = (strlen(root_dir) > 0) ? root_dir : ".";
+    ensure_dir_exists(dest_dir);
+
+    char c_filename[256];
+    char h_filename[256];
+    snprintf(c_filename, sizeof(c_filename), "%s.c", base_filename);
+    snprintf(h_filename, sizeof(h_filename), "%s.h",
+             header_basename ? header_basename : base_filename);
+
+    char found_c_src[1024] = {0};
+    char found_h_src[1024] = {0};
+
+    bool found_c = dfs_search_file(start_dir, c_filename, found_c_src);
+    bool found_h = dfs_search_file(start_dir, h_filename, found_h_src);
+
+    if (!found_c && !found_h)
+    {
+        return false;
+    }
+
+    bool success_c = false;
+    bool success_h = false;
+
+    if (found_c)
+    {
+        char target_c_dest[1024];
+        snprintf(target_c_dest, sizeof(target_c_dest), "%s/%s", dest_dir, c_filename);
+        success_c = copy_file_contents(found_c_src, target_c_dest);
+        if (success_c && exported_c_path)
+        {
+            strncpy(exported_c_path, target_c_dest, 512);
+            exported_c_path[511] = '\0';
+        }
+    }
+
+    if (found_h)
+    {
+        char target_h_dest[1024];
+        snprintf(target_h_dest, sizeof(target_h_dest), "%s/%s", dest_dir, h_filename);
+        success_h = copy_file_contents(found_h_src, target_h_dest);
+        if (success_h && exported_h_path)
+        {
+            strncpy(exported_h_path, target_h_dest, 512);
+            exported_h_path[511] = '\0';
+        }
+    }
+
+    return (success_c || success_h);
+}

--- a/features/file_exporter/file_exporter.h
+++ b/features/file_exporter/file_exporter.h
@@ -1,0 +1,44 @@
+#ifndef FILE_EXPORTER_H
+#define FILE_EXPORTER_H
+
+#include <stdbool.h>
+#include <stddef.h>
+
+/**
+ * Recursively search for a target filename starting from `base_dir` using DFS algorithm.
+ * Skips `.git`, `build`, `object_files`, `test_binaries`, and hidden directories.
+ *
+ * @param base_dir Directory path to start search from (e.g. ".").
+ * @param target_filename Exact name of file to find (e.g. "sll.c").
+ * @param found_path_out Output buffer to store full path if found (min 512 bytes).
+ * @return True if file found, false otherwise.
+ */
+bool dfs_search_file(const char* base_dir, const char* target_filename, char* found_path_out);
+
+/**
+ * Copy entire contents of source file to destination file path.
+ * Creates parent directory if it does not exist.
+ *
+ * @param src_path Source file path.
+ * @param dest_path Target destination file path.
+ * @return True on successful copy, false on failure.
+ */
+bool copy_file_contents(const char* src_path, const char* dest_path);
+
+/**
+ * Find `<base_filename>.c` and `<base_filename>.h` via recursive DFS from `root_dir`
+ * and export both files into `dest_dir`.
+ *
+ * @param root_dir Project root directory to start DFS search from.
+ * @param base_filename Base file name without extension (e.g. "sll", "dll", "queue", "stack").
+ * @param header_basename Base header file name without extension (e.g. "sll", "trees", "queue",
+ * "stack").
+ * @param dest_dir User-specified destination directory path.
+ * @param exported_c_path Output buffer for exported .c file path (optional, can be NULL).
+ * @param exported_h_path Output buffer for exported .h file path (optional, can be NULL).
+ * @return True if both source and header files were found and exported successfully.
+ */
+bool export_file_pair(const char* root_dir, const char* base_filename, const char* header_basename,
+                      const char* dest_dir, char* exported_c_path, char* exported_h_path);
+
+#endif /* FILE_EXPORTER_H */

--- a/tests/features/test_file_exporter.c
+++ b/tests/features/test_file_exporter.c
@@ -1,0 +1,49 @@
+#include "file_exporter.h"
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+void test_dfs_search(void)
+{
+    char found_path[512] = {0};
+    bool found = dfs_search_file(".", "sll.c", found_path);
+    assert(found == true);
+    assert(strstr(found_path, "sll.c") != NULL);
+    printf("test_dfs_search passed! Found: %s\n", found_path);
+}
+
+void test_copy_file_contents(void)
+{
+    char found_path[512] = {0};
+    assert(dfs_search_file(".", "sll.c", found_path) == true);
+
+    const char* test_dest = "./test_export/sll.c";
+    bool copied = copy_file_contents(found_path, test_dest);
+    assert(copied == true);
+
+    FILE* fp = fopen(test_dest, "r");
+    assert(fp != NULL);
+    fclose(fp);
+
+    printf("test_copy_file_contents passed!\n");
+}
+
+void test_export_file_pair(void)
+{
+    char c_path[512] = {0};
+    char h_path[512] = {0};
+    bool res = export_file_pair(".", "sll", "sll", "./test_export", c_path, h_path);
+    assert(res == true);
+    assert(strstr(c_path, "sll.c") != NULL);
+    assert(strstr(h_path, "sll.h") != NULL);
+    printf("test_export_file_pair passed!\n");
+}
+
+int main(void)
+{
+    test_dfs_search();
+    test_copy_file_contents();
+    test_export_file_pair();
+    return 0;
+}


### PR DESCRIPTION
Resolves #1001

### Description
Introduces the core recursive DFS directory search engine (`dfs_search_file`), file content reader and copier (`copy_file_contents`), and file pair exporter (`export_file_pair`) in `features/file_exporter/file_exporter.c` & `features/file_exporter/file_exporter.h`.

### Changes
- Registered `features/file_exporter` in `CMakeLists.txt`.
- Implemented `features/file_exporter/file_exporter.h` and `features/file_exporter/file_exporter.c`.
- Added unit test suite in `tests/features/test_file_exporter.c`.