### PR TITLE
feat: Implement Data Structure Export Mapping Harness (SLL, DLL, BST, Queue, Stack) PR 2-4

### DIFF
--- a/features/file_exporter/exporter_data_structures.c
+++ b/features/file_exporter/exporter_data_structures.c
@@ -1,0 +1,21 @@
+#include "file_exporter.h"
+
+bool export_sll(const char* root_dir, const char* dest_dir)
+{
+    return export_file_pair(root_dir, "sll", "sll", dest_dir, NULL, NULL);
+}
+
+bool export_dll(const char* root_dir, const char* dest_dir)
+{
+    return export_file_pair(root_dir, "dll", "dll", dest_dir, NULL, NULL);
+}
+
+bool export_circular_queue(const char* root_dir, const char* dest_dir)
+{
+    return export_file_pair(root_dir, "circular_queue", "queue", dest_dir, NULL, NULL);
+}
+
+bool export_stack(const char* root_dir, const char* dest_dir)
+{
+    return export_file_pair(root_dir, "stack", "stack", dest_dir, NULL, NULL);
+}

--- a/features/file_exporter/exporter_trees.c
+++ b/features/file_exporter/exporter_trees.c
@@ -1,0 +1,6 @@
+#include "file_exporter.h"
+
+bool export_bst(const char* root_dir, const char* dest_dir)
+{
+    return export_file_pair(root_dir, "bst", "trees", dest_dir, NULL, NULL);
+}

--- a/features/file_exporter/file_exporter.c
+++ b/features/file_exporter/file_exporter.c
@@ -199,28 +199,3 @@ bool export_file_pair(const char* root_dir, const char* base_filename, const cha
 
     return (success_c && success_h);
 }
-
-bool export_sll(const char* root_dir, const char* dest_dir)
-{
-    return export_file_pair(root_dir, "sll", "sll", dest_dir, NULL, NULL);
-}
-
-bool export_dll(const char* root_dir, const char* dest_dir)
-{
-    return export_file_pair(root_dir, "dll", "dll", dest_dir, NULL, NULL);
-}
-
-bool export_bst(const char* root_dir, const char* dest_dir)
-{
-    return export_file_pair(root_dir, "bst", "trees", dest_dir, NULL, NULL);
-}
-
-bool export_circular_queue(const char* root_dir, const char* dest_dir)
-{
-    return export_file_pair(root_dir, "circular_queue", "queue", dest_dir, NULL, NULL);
-}
-
-bool export_stack(const char* root_dir, const char* dest_dir)
-{
-    return export_file_pair(root_dir, "stack", "stack", dest_dir, NULL, NULL);
-}

--- a/features/file_exporter/file_exporter.c
+++ b/features/file_exporter/file_exporter.c
@@ -217,7 +217,7 @@ bool export_bst(const char* root_dir, const char* dest_dir)
 
 bool export_circular_queue(const char* root_dir, const char* dest_dir)
 {
-    return export_file_pair(root_dir, "queue", "queue", dest_dir, NULL, NULL);
+    return export_file_pair(root_dir, "circular_queue", "queue", dest_dir, NULL, NULL);
 }
 
 bool export_stack(const char* root_dir, const char* dest_dir)

--- a/features/file_exporter/file_exporter.c
+++ b/features/file_exporter/file_exporter.c
@@ -59,7 +59,6 @@ bool dfs_search_file(const char* base_dir, const char* target_filename, char* fo
 
     while ((entry = readdir(dir)) != NULL)
     {
-        // Skip . and .. and hidden/build/git directories
         if (strcmp(entry->d_name, ".") == 0 || strcmp(entry->d_name, "..") == 0 ||
             strcmp(entry->d_name, ".git") == 0 || strcmp(entry->d_name, "build") == 0 ||
             strcmp(entry->d_name, "object_files") == 0 ||
@@ -79,7 +78,6 @@ bool dfs_search_file(const char* base_dir, const char* target_filename, char* fo
 
         if (S_ISDIR(st.st_mode))
         {
-            // Recurse into subdirectory (DFS)
             if (dfs_search_file(path, target_filename, found_path_out))
             {
                 found = true;
@@ -115,7 +113,6 @@ bool copy_file_contents(const char* src_path, const char* dest_path)
         return false;
     }
 
-    // Extract directory component from dest_path
     char dest_dir[1024];
     strncpy(dest_dir, dest_path, sizeof(dest_dir) - 1);
     dest_dir[sizeof(dest_dir) - 1] = '\0';
@@ -201,4 +198,29 @@ bool export_file_pair(const char* root_dir, const char* base_filename, const cha
     }
 
     return (success_c || success_h);
+}
+
+bool export_sll(const char* root_dir, const char* dest_dir)
+{
+    return export_file_pair(root_dir, "sll", "sll", dest_dir, NULL, NULL);
+}
+
+bool export_dll(const char* root_dir, const char* dest_dir)
+{
+    return export_file_pair(root_dir, "dll", "dll", dest_dir, NULL, NULL);
+}
+
+bool export_bst(const char* root_dir, const char* dest_dir)
+{
+    return export_file_pair(root_dir, "bst", "trees", dest_dir, NULL, NULL);
+}
+
+bool export_circular_queue(const char* root_dir, const char* dest_dir)
+{
+    return export_file_pair(root_dir, "queue", "queue", dest_dir, NULL, NULL);
+}
+
+bool export_stack(const char* root_dir, const char* dest_dir)
+{
+    return export_file_pair(root_dir, "stack", "stack", dest_dir, NULL, NULL);
 }

--- a/features/file_exporter/file_exporter.h
+++ b/features/file_exporter/file_exporter.h
@@ -41,4 +41,11 @@ bool copy_file_contents(const char* src_path, const char* dest_path);
 bool export_file_pair(const char* root_dir, const char* base_filename, const char* header_basename,
                       const char* dest_dir, char* exported_c_path, char* exported_h_path);
 
+// Core Data Structure Exporters
+bool export_sll(const char* root_dir, const char* dest_dir);
+bool export_dll(const char* root_dir, const char* dest_dir);
+bool export_bst(const char* root_dir, const char* dest_dir);
+bool export_circular_queue(const char* root_dir, const char* dest_dir);
+bool export_stack(const char* root_dir, const char* dest_dir);
+
 #endif /* FILE_EXPORTER_H */

--- a/tests/features/test_file_exporter.c
+++ b/tests/features/test_file_exporter.c
@@ -40,10 +40,22 @@ void test_export_file_pair(void)
     printf("test_export_file_pair passed!\n");
 }
 
+void test_structure_exporters(void)
+{
+    assert(export_sll(".", "./test_export/sll_out") == true);
+    assert(export_dll(".", "./test_export/dll_out") == true);
+    assert(export_bst(".", "./test_export/bst_out") == true);
+    assert(export_circular_queue(".", "./test_export/queue_out") == true);
+    assert(export_stack(".", "./test_export/stack_out") == true);
+
+    printf("test_structure_exporters passed!\n");
+}
+
 int main(void)
 {
     test_dfs_search();
     test_copy_file_contents();
     test_export_file_pair();
+    test_structure_exporters();
     return 0;
 }


### PR DESCRIPTION
Resolves #1001

### Description
Adds export helper functions for Singly-Linked List (`sll.c`/`sll.h`), Doubly-Linked List (`dll.c`/`dll.h`), Binary Search Tree (`bst.c`/`trees.h`), Circular Queue (`queue.c`/`queue.h`), and Stack (`stack.c`/`stack.h`).

### Changes
- Extended `features/file_exporter/file_exporter.h` and `features/file_exporter/file_exporter.c`.
- Added data structure export test assertions in `tests/features/test_file_exporter.c`.