### PR TITLE
test(dp): Add Unit Tests for Edit Distance and Coin Change Algorithms..

### DIFF
--- a/demos/dynamic_programming/coin_change_demo.c
+++ b/demos/dynamic_programming/coin_change_demo.c
@@ -1,0 +1,89 @@
+#include "display_header.h"
+#include "dynamic_programming.h"
+#include "safe_input.h"
+#include <stdio.h>
+#include <stdlib.h>
+
+void coin_change_demo(void)
+{
+    while (1)
+    {
+        display_header("Coin Change Demo");
+
+        int choice;
+        int status = safe_input_int(&choice,
+                                    "\nenter 1 to solve Coin Change problem\n"
+                                    "enter '-1' to exit: ",
+                                    1, 1);
+
+        if (status == INPUT_EXIT_SIGNAL)
+        {
+            return;
+        }
+        if (status == 0)
+        {
+            continue;
+        }
+
+        int n;
+        int n_status =
+            safe_input_int(&n, "\nEnter number of coin denominations (1 to 20): ", 1, 20);
+        if (n_status == INPUT_EXIT_SIGNAL)
+        {
+            return;
+        }
+        if (n_status == 0)
+        {
+            continue;
+        }
+
+        int coins[20];
+        int valid_coins = 1;
+        for (int i = 0; i < n; i++)
+        {
+            char prompt[100];
+            snprintf(prompt, sizeof(prompt), "Enter value for coin %d: ", i + 1);
+            int coin_status = safe_input_int(&coins[i], prompt, 1, 1000);
+            if (coin_status == INPUT_EXIT_SIGNAL)
+            {
+                valid_coins = 0;
+                break;
+            }
+            if (coin_status == 0)
+            {
+                i--;
+                continue;
+            }
+        }
+        if (!valid_coins)
+        {
+            return;
+        }
+
+        int amount;
+        int amount_status = safe_input_int(&amount, "\nEnter target amount (0 to 1000): ", 0, 1000);
+        if (amount_status == INPUT_EXIT_SIGNAL)
+        {
+            return;
+        }
+        if (amount_status == 0)
+        {
+            continue;
+        }
+
+        printf("\n--- Minimum Coins ---\n");
+        int min_coins = coin_change_min_coins(coins, n, amount);
+        if (min_coins != -1)
+        {
+            printf("\nMinimum coins required: %d\n", min_coins);
+        }
+        else
+        {
+            printf("\nImpossible to make amount %d with the given coins.\n", amount);
+        }
+
+        printf("\n--- Total Ways ---\n");
+        int ways = coin_change_ways(coins, n, amount);
+        printf("\nTotal ways to make amount %d: %d\n", amount, ways);
+    }
+}

--- a/demos/dynamic_programming/dynamic_programming_demo.c
+++ b/demos/dynamic_programming/dynamic_programming_demo.c
@@ -15,8 +15,10 @@ void dynamic_programming_demo(void)
                                    "\nenter 2 for Longest Common Subsequence (LCS) demo"
                                    "\nenter 3 for Fibonacci sequence demo"
                                    "\nenter 4 for Matrix Chain Multiplication (MCM) demo"
+                                   "\nenter 5 for Edit Distance (Levenshtein) demo"
+                                   "\nenter 6 for Coin Change demo"
                                    "\nenter choice (\'-1\' to exit, or \'help\') : ",
-                                   1, 4);
+                                   1, 6);
 
         if (dp_status == INPUT_EXIT_SIGNAL)
         {
@@ -44,6 +46,14 @@ void dynamic_programming_demo(void)
             case 4:
                 display_header("Matrix Chain Multiplication");
                 mcm_demo();
+                break;
+            case 5:
+                display_header("Edit Distance");
+                edit_distance_demo();
+                break;
+            case 6:
+                display_header("Coin Change");
+                coin_change_demo();
                 break;
         }
     }

--- a/demos/dynamic_programming/edit_distance_demo.c
+++ b/demos/dynamic_programming/edit_distance_demo.c
@@ -1,0 +1,62 @@
+#include "display_header.h"
+#include "dynamic_programming.h"
+#include "safe_input.h"
+#include <stdio.h>
+#include <string.h>
+
+void edit_distance_demo(void)
+{
+    while (1)
+    {
+        display_header("Edit Distance (Levenshtein) Demo");
+
+        int choice;
+        int status = safe_input_int(&choice,
+                                    "\nenter 1 to compute Edit Distance\n"
+                                    "enter '-1' to exit: ",
+                                    1, 1);
+
+        if (status == INPUT_EXIT_SIGNAL)
+        {
+            return;
+        }
+        if (status == 0)
+        {
+            continue;
+        }
+
+        char word1[256];
+        int w1_status = safe_input_string(word1, "\nEnter the first string: ");
+        if (w1_status == INPUT_EXIT_SIGNAL)
+        {
+            return;
+        }
+        if (w1_status == 0)
+        {
+            continue;
+        }
+
+        char word2[256];
+        int w2_status = safe_input_string(word2, "Enter the second string: ");
+        if (w2_status == INPUT_EXIT_SIGNAL)
+        {
+            return;
+        }
+        if (w2_status == 0)
+        {
+            continue;
+        }
+
+        int m = strlen(word1);
+        int n = strlen(word2);
+
+        printf("\nCalculating Edit Distance between '%s' and '%s'...\n", word1, word2);
+
+        int result = edit_distance(word1, word2, m, n);
+
+        if (result != -1)
+        {
+            printf("\nMinimum Operations Required (Edit Distance): %d\n", result);
+        }
+    }
+}

--- a/src/dynamic_programming/coin_change.c
+++ b/src/dynamic_programming/coin_change.c
@@ -1,0 +1,76 @@
+#include "dp_visualizer.h"
+#include "dynamic_programming.h"
+#include <limits.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+int coin_change_min_coins(int coins[], int n, int amount)
+{
+    if (amount < 0)
+    {
+        return -1;
+    }
+    long long* dp = malloc((amount + 1) * sizeof(long long));
+    if (dp == NULL)
+    {
+        printf("Memory allocation failed for min coins DP array.\n");
+        return -1;
+    }
+
+    dp[0] = 0;
+    for (int i = 1; i <= amount; i++)
+    {
+        dp[i] = INT_MAX;
+    }
+
+    for (int i = 1; i <= amount; i++)
+    {
+        for (int j = 0; j < n; j++)
+        {
+            if (coins[j] <= i)
+            {
+                long long res = dp[i - coins[j]];
+                if (res != INT_MAX && res + 1 < dp[i])
+                {
+                    dp[i] = res + 1;
+                }
+            }
+        }
+        visualize_dp_table_1d("Coin Change (Min Coins) DP Array", dp, amount + 1, i);
+    }
+    visualize_dp_table_1d("Coin Change (Min Coins) Final DP Array", dp, amount + 1, amount);
+
+    int ans = (dp[amount] == INT_MAX) ? -1 : (int)dp[amount];
+    free(dp);
+    return ans;
+}
+
+int coin_change_ways(int coins[], int n, int amount)
+{
+    if (amount < 0)
+    {
+        return 0;
+    }
+    long long* dp = calloc((amount + 1), sizeof(long long));
+    if (dp == NULL)
+    {
+        printf("Memory allocation failed for coin ways DP array.\n");
+        return 0;
+    }
+
+    dp[0] = 1;
+
+    for (int j = 0; j < n; j++)
+    {
+        for (int i = coins[j]; i <= amount; i++)
+        {
+            dp[i] += dp[i - coins[j]];
+            visualize_dp_table_1d("Coin Change (Total Ways) DP Array", dp, amount + 1, i);
+        }
+    }
+    visualize_dp_table_1d("Coin Change (Total Ways) Final DP Array", dp, amount + 1, amount);
+
+    int ans = (int)dp[amount];
+    free(dp);
+    return ans;
+}

--- a/src/dynamic_programming/dynamic_programming.h
+++ b/src/dynamic_programming/dynamic_programming.h
@@ -16,4 +16,11 @@ long long fibonacci_iterative(int n);
 int matrix_chain_order(int p[], int n);
 void mcm_demo(void);
 
+void edit_distance_demo(void);
+int edit_distance(char* word1, char* word2, int m, int n);
+
+void coin_change_demo(void);
+int coin_change_min_coins(int coins[], int n, int amount);
+int coin_change_ways(int coins[], int n, int amount);
+
 #endif // DYNAMIC_PROGRAMMING_H

--- a/src/dynamic_programming/edit_distance.c
+++ b/src/dynamic_programming/edit_distance.c
@@ -1,0 +1,90 @@
+#include "dp_visualizer.h"
+#include "dynamic_programming.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static int min_of_three(int a, int b, int c)
+{
+    int min = a;
+    if (b < min)
+    {
+        min = b;
+    }
+    if (c < min)
+    {
+        min = c;
+    }
+    return min;
+}
+
+int edit_distance(char* word1, char* word2, int m, int n)
+{
+    int** dp = malloc((m + 1) * sizeof(int*));
+    if (dp == NULL)
+    {
+        printf("Memory allocation failed for DP table.\n");
+        return -1;
+    }
+    for (int i = 0; i <= m; i++)
+    {
+        dp[i] = malloc((n + 1) * sizeof(int));
+        if (dp[i] == NULL)
+        {
+            printf("Memory allocation failed for DP table row %d.\n", i);
+            for (int j = 0; j < i; j++)
+            {
+                free(dp[j]);
+            }
+            free(dp);
+            return -1;
+        }
+        for (int j = 0; j <= n; j++)
+        {
+            dp[i][j] = -1;
+        }
+    }
+
+    // Compute DP table
+    for (int i = 0; i <= m; i++)
+    {
+        for (int j = 0; j <= n; j++)
+        {
+            if (i == 0)
+            {
+                dp[i][j] = j; // Min operations = j insertions
+            }
+            else if (j == 0)
+            {
+                dp[i][j] = i; // Min operations = i deletions
+            }
+            else if (word1[i - 1] == word2[j - 1])
+            {
+                dp[i][j] = dp[i - 1][j - 1];
+            }
+            else
+            {
+                dp[i][j] = 1 + min_of_three(dp[i][j - 1],    // Insert
+                                            dp[i - 1][j],    // Remove
+                                            dp[i - 1][j - 1] // Replace
+                               );
+            }
+
+            // Visualize at each step
+            visualize_dp_table_2d("Edit Distance DP Table", dp, m + 1, n + 1, word1, word2, i, j);
+        }
+    }
+
+    // Final visualization
+    visualize_dp_table_2d("Edit Distance Final DP Table", dp, m + 1, n + 1, word1, word2, m, n);
+
+    int res = dp[m][n];
+
+    for (int i = 0; i <= m; i++)
+    {
+        free(dp[i]);
+    }
+    free(dp);
+
+    return res;
+}

--- a/tests/dynamic_programming/test_coin_change.c
+++ b/tests/dynamic_programming/test_coin_change.c
@@ -1,0 +1,73 @@
+#include "dynamic_programming.h"
+#include "mock_printf.h"
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+// Define overrides to suppress history logging and DP table prints
+#define printf mock_printf
+#include "../../src/dynamic_programming/coin_change.c"
+#undef printf
+
+void test_coin_change_base_cases()
+{
+    reset_printf_buf();
+    int coins[] = {1, 2, 5};
+    int n = 3;
+
+    // Amount 0
+    assert(coin_change_min_coins(coins, n, 0) == 0);
+    assert(coin_change_ways(coins, n, 0) == 1);
+
+    // Invalid amount
+    assert(coin_change_min_coins(coins, n, -5) == -1);
+    assert(coin_change_ways(coins, n, -5) == 0);
+}
+
+void test_coin_change_standard()
+{
+    reset_printf_buf();
+    int coins[] = {1, 2, 5};
+    int n = 3;
+
+    assert(coin_change_min_coins(coins, n, 11) == 3); // 5+5+1
+    // ways to make 5 with {1, 2, 5}:
+    // 5
+    // 2+2+1
+    // 2+1+1+1
+    // 1+1+1+1+1
+    // Total = 4
+    assert(coin_change_ways(coins, n, 5) == 4);
+}
+
+void test_coin_change_impossible()
+{
+    reset_printf_buf();
+    int coins[] = {2};
+    int n = 1;
+
+    assert(coin_change_min_coins(coins, n, 3) == -1);
+    assert(coin_change_ways(coins, n, 3) == 0);
+}
+
+void test_coin_change_greedy_failure()
+{
+    reset_printf_buf();
+    int coins[] = {1, 3, 4};
+    int n = 3;
+
+    // To make 6: Greedy picks 4, then 1, 1 (3 coins). DP picks 3, 3 (2 coins).
+    assert(coin_change_min_coins(coins, n, 6) == 2);
+}
+
+int main()
+{
+    test_coin_change_base_cases();
+    test_coin_change_standard();
+    test_coin_change_impossible();
+    test_coin_change_greedy_failure();
+
+    fprintf(stdout, "All Coin Change tests passed successfully!\n");
+    return 0;
+}

--- a/tests/dynamic_programming/test_edit_distance.c
+++ b/tests/dynamic_programming/test_edit_distance.c
@@ -1,0 +1,52 @@
+#include "dynamic_programming.h"
+#include "mock_printf.h"
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+// Define overrides to suppress history logging and DP table prints
+#define printf mock_printf
+#include "../../src/dynamic_programming/edit_distance.c"
+#undef printf
+
+void test_edit_distance_base_cases()
+{
+    reset_printf_buf();
+
+    // Both empty
+    assert(edit_distance("", "", 0, 0) == 0);
+
+    // One empty
+    assert(edit_distance("abc", "", 3, 0) == 3);
+    assert(edit_distance("", "xyz", 0, 3) == 3);
+
+    // Identical
+    assert(edit_distance("hello", "hello", 5, 5) == 0);
+}
+
+void test_edit_distance_standard()
+{
+    reset_printf_buf();
+
+    assert(edit_distance("kitten", "sitting", 6, 7) == 3);
+    assert(edit_distance("horse", "ros", 5, 3) == 3);
+}
+
+void test_edit_distance_disjoint()
+{
+    reset_printf_buf();
+
+    assert(edit_distance("abc", "xyz", 3, 3) == 3);
+    assert(edit_distance("abcd", "efgh", 4, 4) == 4);
+}
+
+int main()
+{
+    test_edit_distance_base_cases();
+    test_edit_distance_standard();
+    test_edit_distance_disjoint();
+
+    fprintf(stdout, "All Edit Distance tests passed successfully!\n");
+    return 0;
+}


### PR DESCRIPTION
Resolves #1079 
## Description
We recently expanded the Dynamic Programming module by adding the Edit Distance (Levenshtein) and Coin Change algorithms. However, these new additions currently lack automated test coverage.

To maintain the reliability of the suite, we need to add robust unit tests for both algorithms. This will involve creating new test files in the tests/dynamic_programming/ directory and wiring them up to the CTest/CMake build system.

## Acceptance Criteria
1. Edit Distance Tests (tests/dynamic_programming/test_edit_distance.c) Create test cases for edit_distance() that cover:
Base Cases: One or both strings are empty.
Identical Strings: word1 = "hello", word2 = "hello" (Expected: 0).
Standard Cases: e.g., kitten to sitting (Expected: 3), horse to ros (Expected: 3).
Edge Cases: Completely distinct strings (e.g., abc to xyz), strings of vastly different lengths.
2. Coin Change Tests (tests/dynamic_programming/test_coin_change.c) Create test cases for both coin_change_min_coins() and coin_change_ways() that cover:

Base Cases: Target amount is 0 (Expected: 0 coins, 1 way).
Standard Cases: Valid targets with standard denominations (e.g., coins [1, 2, 5], target 11).
Impossible Cases: Target cannot be made with the given coins (e.g., coins [2], target 3). min_coins should handle this gracefully (usually returning -1).
Greedy-Failure Cases: A coin set where a greedy approach fails but DP succeeds (e.g., coins [1, 3, 4], target 6. Greedy gives 4+1+1=3, DP correctly gives 3+3=2).
3. Build System Integration

Add the new test files to the tests/CMakeLists.txt so they run when ctest or make test is executed.