### PR TITLE
feat: add ASCII renderer for Binary Search Tree

### DIFF
--- a/demos/trees/bst_demo.c
+++ b/demos/trees/bst_demo.c
@@ -46,6 +46,8 @@ void binary_search_tree_demo(void)
                 continue;
             }
             printf("\nBST loaded successfully from '%s'.\n", path);
+            printf("\nBST shape:\n");
+            bst_print_ascii(head);
         }
         else
         {
@@ -100,6 +102,8 @@ void binary_search_tree_demo(void)
                 }
                 i++;
                 total_bst_nodes--;
+                printf("\nBST shape after insertion:\n");
+                bst_print_ascii(head);
             }
         }
 
@@ -168,6 +172,8 @@ void binary_search_tree_demo(void)
                 printf("\nnode deleted. updated inorder traversal: ");
                 bst_inorder(head);
                 printf("\n");
+                printf("BST shape after deletion:\n");
+                bst_print_ascii(head);
             }
             else if (bst_traversal_choice == 6)
             {

--- a/src/trees/bst.c
+++ b/src/trees/bst.c
@@ -2,9 +2,134 @@
 #include "safe_input.h"
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 int deletionStrategy = 1;
 #define SUCCESSOR 1
 #define PREDECESSOR 2
+#define BST_ASCII_MAX_HEIGHT 6
+
+static int bst_max_int(int a, int b)
+{
+    return (a > b) ? a : b;
+}
+
+static int bst_value_width(const bstNode* root)
+{
+    if (root == NULL)
+        return 1;
+
+    char buffer[32];
+    int width = snprintf(buffer, sizeof(buffer), "%d", root->data);
+    if (width < 1)
+        width = 1;
+
+    return bst_max_int(width, bst_max_int(bst_value_width(root->left), bst_value_width(root->right)));
+}
+
+static void bst_fill_row(char* row, int width)
+{
+    memset(row, ' ', (size_t)width);
+    row[width] = '\0';
+}
+
+static void bst_place_text(char* row, int width, int center, const char* text)
+{
+    int text_width = (int)strlen(text);
+    int start = center - (text_width / 2);
+
+    if (start < 0)
+        start = 0;
+    if (start + text_width > width)
+        start = width - text_width;
+
+    for (int i = 0; i < text_width && start + i < width; i++)
+        row[start + i] = text[i];
+}
+
+static void bst_render_ascii(const bstNode* node, int level, int left, int right,
+                             char** rows, int row_count, int width)
+{
+    if (node == NULL || level * 2 >= row_count || left > right)
+        return;
+
+    int center = (left + right) / 2;
+    char buffer[32];
+    snprintf(buffer, sizeof(buffer), "%d", node->data);
+    bst_place_text(rows[level * 2], width, center, buffer);
+
+    int connector_row = level * 2 + 1;
+    if (connector_row < row_count)
+    {
+        if (node->left != NULL)
+        {
+            int left_center = (left + center - 1) / 2;
+            int slash_position = (center + left_center) / 2;
+            if (slash_position >= 0 && slash_position < width)
+                rows[connector_row][slash_position] = '/';
+        }
+        if (node->right != NULL)
+        {
+            int right_center = (center + 1 + right) / 2;
+            int slash_position = (center + right_center) / 2;
+            if (slash_position >= 0 && slash_position < width)
+                rows[connector_row][slash_position] = '\\';
+        }
+    }
+
+    bst_render_ascii(node->left, level + 1, left, center - 1, rows, row_count, width);
+    bst_render_ascii(node->right, level + 1, center + 1, right, rows, row_count, width);
+}
+
+void bst_print_ascii(const bstNode* root)
+{
+    if (root == NULL)
+    {
+        printf("Tree is empty\n");
+        return;
+    }
+
+    int height = tree_height(root);
+    if (height > BST_ASCII_MAX_HEIGHT)
+    {
+        printf("Tree is too tall to render as ASCII (max supported height: %d)\n",
+               BST_ASCII_MAX_HEIGHT);
+        return;
+    }
+
+    int value_width = bst_value_width(root) + 2;
+    int row_count = (height * 2) - 1;
+    int width = (1 << height) * value_width;
+
+    char** rows = malloc((size_t)row_count * sizeof(char*));
+    if (rows == NULL)
+    {
+        printf("Tree is too large to render\n");
+        return;
+    }
+
+    for (int i = 0; i < row_count; i++)
+    {
+        rows[i] = malloc((size_t)width + 1);
+        if (rows[i] == NULL)
+        {
+            for (int j = 0; j < i; j++)
+                free(rows[j]);
+            free(rows);
+            printf("Tree is too large to render\n");
+            return;
+        }
+        bst_fill_row(rows[i], width);
+    }
+
+    bst_render_ascii(root, 0, 0, width - 1, rows, row_count, width);
+
+    for (int i = 0; i < row_count; i++)
+    {
+        printf("%s\n", rows[i]);
+        free(rows[i]);
+    }
+    free(rows);
+}
 
 // insert function returns -1 on malloc failure, 0 when value already exists in the tree and 1 on
 // successful insertion

--- a/src/trees/bst.c
+++ b/src/trees/bst.c
@@ -23,7 +23,8 @@ static int bst_value_width(const bstNode* root)
     if (width < 1)
         width = 1;
 
-    return bst_max_int(width, bst_max_int(bst_value_width(root->left), bst_value_width(root->right)));
+    return bst_max_int(width,
+                       bst_max_int(bst_value_width(root->left), bst_value_width(root->right)));
 }
 
 static void bst_fill_row(char* row, int width)
@@ -46,8 +47,8 @@ static void bst_place_text(char* row, int width, int center, const char* text)
         row[start + i] = text[i];
 }
 
-static void bst_render_ascii(const bstNode* node, int level, int left, int right,
-                             char** rows, int row_count, int width)
+static void bst_render_ascii(const bstNode* node, int level, int left, int right, char** rows,
+                             int row_count, int width)
 {
     if (node == NULL || level * 2 >= row_count || left > right)
         return;

--- a/src/trees/bst.h
+++ b/src/trees/bst.h
@@ -14,6 +14,7 @@ typedef struct bstNode
 
 void binary_search_tree_demo(void);
 void bst_level_order(struct bstNode* head);
+void bst_print_ascii(const bstNode* root);
 int bst_insert(bstNode** head_ref, int value);
 void bst_inorder(const bstNode* head);
 void bst_preorder(const bstNode* head);


### PR DESCRIPTION
**Description**
Closes #1077

## Summary
This PR adds a new `bst_print_ascii()` function that renders a Binary Search Tree as a 2D ASCII diagram in the terminal. This makes the tree structure easier to understand compared to the existing level-order output, because users can now visually inspect parent-child relationships, subtree shape, and rough balance at a glance.

## Changes Made
- Added the public function declaration:
  ```c
  void bst_print_ascii(const bstNode* root);
  ```
- Implemented `bst_print_ascii()` in `src/trees/bst.c`.
- Added helper logic to:
  - calculate display width for node values
  - center node values in their expected tree positions
  - render `/` and `\` connector rows between levels
  - preserve spacing for missing children
  - handle empty trees gracefully
- Added a height guard for ASCII rendering, limiting output to height `6`, since wider trees quickly exceed practical terminal width.
- Updated the BST demo to display the ASCII tree:
  - after loading a BST from file
  - after each successful insertion
  - after deleting a node

## Why
The existing `bst_level_order()` output prints nodes level by level, but it does not visually show how nodes are connected. The new ASCII renderer gives users a clearer, immediate view of the actual tree shape while interacting with the BST demo.

Example output:
```text
              50
           /       \
      30              70
     /   \           /   \
  20      40      60      80
```