### PR TITLE
feat(help): add Dynamic Programming help module and integrate into help menu (PR 3)

### DIFF
--- a/help/help.c
+++ b/help/help.c
@@ -45,13 +45,14 @@ void launch_help_page(void)
         printf("4. Graphs & Trees Help\n");
         printf("5. Hashing Help\n");
         printf("6. Advanced & Specialized Topics Help\n");
-        printf("7. Error Correction Help\n");
-        printf("8. Bit Manipulation Help\n");
-        printf("9. Navigation, CLI Flags & General Info\n");
-        printf("10. Backtracking Algorithms Help\n");
+        printf("7. Dynamic Programming Help\n");
+        printf("8. Error Correction Help\n");
+        printf("9. Bit Manipulation Help\n");
+        printf("10. Navigation, CLI Flags & General Info\n");
+        printf("11. Backtracking Algorithms Help\n");
         int choice;
         int status =
-            safe_input_int(&choice, "\nenter choice (\'-1\' to exit, or \'help\') : ", 1, 10);
+            safe_input_int(&choice, "\nenter choice (\'-1\' to exit, or \'help\') : ", 1, 11);
 
         if (status == INPUT_EXIT_SIGNAL)
         {
@@ -84,12 +85,15 @@ void launch_help_page(void)
                 help_advanced_topics_menu();
                 break;
             case 7:
-                help_error_correction_menu();
+                help_dynamic_programming_menu();
                 break;
             case 8:
-                bit_manipulation_help();
+                help_error_correction_menu();
                 break;
             case 9:
+                bit_manipulation_help();
+                break;
+            case 10:
                 display_header("General Navigation, CLI Flags & Commands");
                 printf("DESCRIPTION\n");
                 printf("    The C DSA Interactive Suite is a terminal-based application\n");
@@ -119,7 +123,7 @@ void launch_help_page(void)
                 printf("=================================================================\n");
                 press_enter_to_continue();
                 break;
-            case 10:
+            case 11:
                 help_backtracking_menu();
                 break;
         }

--- a/help/help.h
+++ b/help/help.h
@@ -28,6 +28,11 @@ void help_graphs_trees_menu(void);
 void help_advanced_topics_menu(void);
 
 /**
+ * @brief Sub-menu for Dynamic Programming help.
+ */
+void help_dynamic_programming_menu(void);
+
+/**
  * @brief Sub-menu for Expression Evaluation help.
  */
 void help_expression_evaluation_menu(void);

--- a/help/help_dynamic_programming.c
+++ b/help/help_dynamic_programming.c
@@ -1,0 +1,170 @@
+#include "display_header.h"
+#include "help.h"
+#include "safe_input.h"
+#include <stdio.h>
+
+static void print_dp_basics(void)
+{
+    display_header("Help - Dynamic Programming Basics");
+    printf("WHAT DYNAMIC PROGRAMMING SOLVES:\n");
+    printf("    Dynamic Programming (DP) is used when a problem can be split into\n");
+    printf("    smaller subproblems whose answers can be reused. It is ideal when the\n");
+    printf("    same states appear repeatedly during the search.\n\n");
+
+    printf("CORE PROPERTIES:\n");
+    printf("    • Optimal substructure: an optimal solution can be built from optimal\n");
+    printf("      solutions to subproblems.\n");
+    printf("    • Overlapping subproblems: the same subproblem is solved many times\n");
+    printf("      in a naive recursive solution.\n\n");
+
+    printf("MEMOIZATION VS TABULATION:\n");
+    printf("    Memoization (top-down):\n");
+    printf("      - Start with recursion and cache results after first computation.\n");
+    printf("      - Best when not every state needs to be visited.\n");
+    printf("      - Easier to write when the recursive relation is already clear.\n\n");
+    printf("    Tabulation (bottom-up):\n");
+    printf("      - Build the answer iteratively from the smallest states upward.\n");
+    printf("      - Best when the state order is easy to determine.\n");
+    printf("      - Usually avoids recursion depth and often has tighter control over\n");
+    printf("        memory layout.\n\n");
+
+    printf("WHEN TO USE EACH:\n");
+    printf("    • Use memoization when the state space is sparse or the recursive\n");
+    printf("      structure is easier to express than an iterative table.\n");
+    printf("    • Use tabulation when you know the dependency order and want a\n");
+    printf("      predictable iterative implementation.\n\n");
+
+    printf("TIME & SPACE PATTERN:\n");
+    printf("    • Naive recursion on DP problems is often exponential.\n");
+    printf("    • Memoization and tabulation usually reduce the runtime to polynomial\n");
+    printf("      time by solving each state once.\n");
+    printf("    • Space is typically O(state count) for the table, plus recursion\n");
+    printf("      stack only in memoized top-down solutions.\n\n");
+
+    printf("=================================================================\n");
+    printf("Press [ENTER] to return...\n");
+    printf("=================================================================\n");
+    press_enter_to_continue();
+}
+
+static void print_fibonacci_and_knapsack(void)
+{
+    display_header("Help - Fibonacci & 0/1 Knapsack");
+    printf("1) FIBONACCI SEQUENCE\n");
+    printf("PROBLEM DEFINITION:\n");
+    printf("    Compute F(n), where F(n) = F(n-1) + F(n-2), F(0)=0, F(1)=1.\n\n");
+    printf("RECURRENCE:\n");
+    printf("    F(n) = F(n-1) + F(n-2)\n");
+    printf("    Base cases: F(0)=0, F(1)=1\n\n");
+    printf("DP TABLE WALKTHROUGH:\n");
+    printf("    • Memoization stores previously computed F(i) values in a cache.\n");
+    printf("    • Tabulation fills dp[0], dp[1], then dp[i] = dp[i-1] + dp[i-2].\n");
+    printf("    • Each entry depends only on the two previous entries.\n\n");
+    printf("COMPLEXITY:\n");
+    printf("    • Naive recursion: O(2^n) time, O(n) stack.\n");
+    printf("    • Memoization: O(n) time, O(n) space.\n");
+    printf("    • Tabulation: O(n) time, O(n) space, reducible to O(1) auxiliary\n");
+    printf("      space with two variables.\n\n");
+
+    printf("2) 0/1 KNAPSACK\n");
+    printf("PROBLEM DEFINITION:\n");
+    printf("    Choose a subset of items with weights wt[i] and values val[i] so the\n");
+    printf("    total weight does not exceed capacity W, while maximizing total value.\n\n");
+    printf("RECURRENCE:\n");
+    printf("    dp[i][w] = max(dp[i-1][w], val[i-1] + dp[i-1][w-wt[i-1]])\n");
+    printf("    when wt[i-1] <= w, otherwise dp[i][w] = dp[i-1][w].\n\n");
+    printf("DP TABLE WALKTHROUGH:\n");
+    printf("    • Rows represent how many items are considered.\n");
+    printf("    • Columns represent the current capacity from 0 to W.\n");
+    printf("    • The first row and first column are zero because no items or no\n");
+    printf("      capacity means zero value.\n");
+    printf("    • Each cell compares taking the item vs skipping it.\n\n");
+    printf("COMPLEXITY:\n");
+    printf("    • Naive recursion: O(2^n) time.\n");
+    printf("    • DP table: O(nW) time, O(nW) space.\n");
+    printf("    • A 1D optimization can reduce the space to O(W).\n\n");
+
+    printf("=================================================================\n");
+    printf("Press [ENTER] to return...\n");
+    printf("=================================================================\n");
+    press_enter_to_continue();
+}
+
+static void print_lcs_and_mcm(void)
+{
+    display_header("Help - LCS & Matrix Chain Multiplication");
+    printf("3) LONGEST COMMON SUBSEQUENCE (LCS)\n");
+    printf("PROBLEM DEFINITION:\n");
+    printf("    Find the longest sequence that appears in both strings in the same\n");
+    printf("    relative order, but not necessarily contiguously.\n\n");
+    printf("RECURRENCE:\n");
+    printf("    If X[i-1] == Y[j-1], dp[i][j] = 1 + dp[i-1][j-1].\n");
+    printf("    Otherwise dp[i][j] = max(dp[i-1][j], dp[i][j-1]).\n\n");
+    printf("DP TABLE WALKTHROUGH:\n");
+    printf("    • Rows index prefixes of the first string.\n");
+    printf("    • Columns index prefixes of the second string.\n");
+    printf("    • The first row and column are zeros for empty-string prefixes.\n");
+    printf("    • The traceback from dp[m][n] reconstructs the subsequence.\n\n");
+    printf("COMPLEXITY:\n");
+    printf("    • Naive recursion: exponential time.\n");
+    printf("    • DP: O(mn) time, O(mn) space.\n\n");
+
+    printf("4) MATRIX CHAIN MULTIPLICATION (MCM)\n");
+    printf("PROBLEM DEFINITION:\n");
+    printf("    Given matrices A1..An with compatible dimensions, find the parenthesization\n");
+    printf("    that minimizes scalar multiplications.\n\n");
+    printf("RECURRENCE:\n");
+    printf("    m[i][j] = min over k in [i, j-1] of\n");
+    printf("              m[i][k] + m[k+1][j] + p[i-1] * p[k] * p[j]\n\n");
+    printf("DP TABLE WALKTHROUGH:\n");
+    printf("    • dp[i][j] stores the best cost for multiplying Ai..Aj.\n");
+    printf("    • The table is filled by increasing chain length.\n");
+    printf("    • The split table records the k value that produced the best cost.\n\n");
+    printf("COMPLEXITY:\n");
+    printf("    • Naive recursion: exponential.\n");
+    printf("    • DP: O(n^3) time, O(n^2) space.\n\n");
+
+    printf("=================================================================\n");
+    printf("Press [ENTER] to return...\n");
+    printf("=================================================================\n");
+    press_enter_to_continue();
+}
+
+void help_dynamic_programming_menu(void)
+{
+    while (1)
+    {
+        display_header("Help - Dynamic Programming");
+
+        printf("Select a sub-topic:\n\n");
+        printf("1. DP Fundamentals (memoization vs tabulation)\n");
+        printf("2. Fibonacci + 0/1 Knapsack\n");
+        printf("3. LCS + Matrix Chain Multiplication\n");
+
+        int choice;
+        int status = safe_input_int(&choice, "\nenter choice ('-1' to exit, or 'help') : ", 1, 3);
+
+        if (status == INPUT_EXIT_SIGNAL)
+        {
+            break;
+        }
+
+        if (status == 0)
+        {
+            continue;
+        }
+
+        switch (choice)
+        {
+            case 1:
+                print_dp_basics();
+                break;
+            case 2:
+                print_fibonacci_and_knapsack();
+                break;
+            case 3:
+                print_lcs_and_mcm();
+                break;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Adds a new `help_dynamic_programming.c` module and integrates it as
entry #7 in the interactive help menu, shifting all subsequent entries
down by one.

## Changes

### New File — `help/help_dynamic_programming.c`
A 170-line interactive help module covering:
- **DP Basics** — optimal substructure, overlapping subproblems,
  memoization vs. tabulation, time & space complexity patterns
- **Fibonacci & Knapsack** — canonical DP examples with explanation
- **LCS & MCM** — Longest Common Subsequence and Matrix Chain
  Multiplication walkthroughs

### Modified — `help/help.h`
- Declared `help_dynamic_programming_menu()` with a Doxygen docstring

### Modified — `help/help.c`
- Inserted **"7. Dynamic Programming Help"** in the menu display
- Updated input range from `1–10` → `1–11`
- Wired `case 7` to `help_dynamic_programming_menu()`
- Re-numbered cases 8–11 for Error Correction, Bit Manipulation,
  Navigation, and Backtracking accordingly


closes #1076 
