### PR TITLE
docs(help): add Cache Simulator help module and expand Bitwise Help PR 1-2

### DIFF
--- a/help/help.h
+++ b/help/help.h
@@ -72,4 +72,9 @@ void help_advanced_graphs_menu(void);
  */
 void help_system_utilities_menu(void);
 
+/**
+ * @brief Sub-menu for Cache Replacement Simulator help.
+ */
+void help_cache_simulator_menu(void);
+
 #endif // HELP_H

--- a/help/help_bits.c
+++ b/help/help_bits.c
@@ -44,6 +44,11 @@ void bit_manipulation_help(void)
     printf("      loop counter's bits as include flags generates\n");
     printf("      all combinations (Power Set).\n\n");
 
+    printf("INTERACTIVE 32-BIT VISUALIZER:\n");
+    printf("    • Bit Grid Display: Renders 32-bit integers as formatted 4-byte grids.\n");
+    printf("    • Interactive Bit Toggling: Interactively flip individual bit positions.\n");
+    printf("    • Real-time Formats: View signed/unsigned decimal, hex (0x), and binary.\n\n");
+
     printf("HOW TO RUN IN THIS SUITE:\n");
     printf("    1. Exit to the main menu and select option 18.\n");
     printf("    2. Choose from the sub-menu to visualize algorithms.\n\n");

--- a/help/help_cache_simulator.c
+++ b/help/help_cache_simulator.c
@@ -1,0 +1,53 @@
+#include "display_header.h"
+#include "help.h"
+#include "safe_input.h"
+#include <stdio.h>
+
+void help_cache_simulator_menu(void)
+{
+    display_header("Help - Cache Replacement Simulator");
+
+    printf("CACHE REPLACEMENT ALGORITHMS:\n");
+    printf("    Cache replacement policies decide which memory page/block to evict\n");
+    printf("    when a cache hit fails (cache miss) and the cache has reached full capacity.\n\n");
+
+    printf("IMPLEMENTED EVICTION POLICIES:\n");
+    printf("    • First-In, First-Out (FIFO): Evicts the oldest loaded block using a circular "
+           "queue.\n");
+    printf("    • Least Recently Used (LRU): Evicts the block with the oldest last access "
+           "timestamp.\n");
+    printf("    • Most Recently Used (MRU): Evicts the block accessed most recently (useful for "
+           "looping scans).\n");
+    printf("    • Least Frequently Used (LFU): Evicts the block with minimum hit count; features "
+           "periodic aging/decay.\n");
+    printf("    • Belady's Optimal (OPT): Lookahead policy evicting page accessed furthest in the "
+           "future.\n");
+    printf("    • Second-Chance (Clock): Circular buffer maintaining reference bits to approximate "
+           "LRU.\n");
+    printf("    • Enhanced Second-Chance: Classifies blocks using (reference_bit, dirty_bit) "
+           "tuples.\n\n");
+
+    printf("TIME & SPACE COMPLEXITY CHEATSHEET:\n");
+    printf("    +-------------------+----------------+----------------+----------------+\n");
+    printf("    | Policy            | Lookup Time    | Eviction Time  | Space Overhead |\n");
+    printf("    +-------------------+----------------+----------------+----------------+\n");
+    printf("    | FIFO              | O(1)           | O(1)           | O(1)           |\n");
+    printf("    | LRU               | O(1)           | O(1)           | O(N)           |\n");
+    printf("    | MRU               | O(1)           | O(1)           | O(N)           |\n");
+    printf("    | LFU (with Aging)  | O(1)           | O(N)           | O(N)           |\n");
+    printf("    | Belady's OPT      | O(1)           | O(N * K)       | O(K)           |\n");
+    printf("    | Clock             | O(1)           | O(N) worst     | O(N)           |\n");
+    printf("    | Enhanced Clock    | O(1)           | O(N) worst     | O(N)           |\n");
+    printf("    +-------------------+----------------+----------------+----------------+\n\n");
+
+    printf("INTERACTIVE FEATURES & TUI ANIMATOR:\n");
+    printf("    • Grid Visualization: Color-coded frames (Green = Hit, Red = Miss/Evict).\n");
+    printf("    • Workload Benchmarking: Compares hit ratios across Zipfian, Looping, and Random "
+           "traces.\n");
+    printf("    • Step-by-Step Debugger: Step through page reference strings interactively.\n\n");
+
+    printf("========================================================\n");
+    printf("Press [ENTER] to return...\n");
+    printf("========================================================\n");
+    press_enter_to_continue();
+}


### PR DESCRIPTION
Resolves #1136 (PR 1 of 2)

### Summary
Adds new interactive help topics and walkthroughs:
- **Cache Replacement Simulator (`help/help_cache_simulator.c`)**: Created dedicated help guide detailing FIFO, LRU, MRU, LFU (with frequency aging), Clock (Second-Chance), and Belady's OPT eviction policies along with a full Time/Space Complexity Cheatsheet table.
- **Bit Manipulation & 32-Bit Visualizer (`help/help_bits.c`)**: Expanded help text with interactive 32-Bit Visualizer walkthroughs, binary grid displays, and real-time formatting options.
- **Header Exposure (`help/help.h`)**: Declared `help_cache_simulator_menu()` prototype.

### Testing
- Formatted with `cmake --build build --target fmt`.
- Compiled static library `dsa_lib` cleanly without warnings.