### PR TITLE
docs: Document Fuzz Testing, Big-O Verifier, and File Exporter in Help Manual.

### DIFF
--- a/help/help_system_utilities.c
+++ b/help/help_system_utilities.c
@@ -9,21 +9,20 @@ static void display_telemetry_help(void)
 {
     clear_screen();
     display_header("MANUAL: Telemetry & Memory Profiler Engine");
-    printf(
-        "\n"
-        "================================================================================\n"
-        " 1. SORTING TELEMETRY DASHBOARD\n"
-        "================================================================================\n"
-        " Concept:\n"
-        "   Tracks real-time algorithmic operations, comparisons, swaps, and execution timers.\n"
-        "   - Features: Real-time swap counters, time-series metrics, comparative dashboards.\n\n"
-        "================================================================================\n"
-        " 2. MEMORY INSPECTOR & PROFILER\n"
-        "================================================================================\n"
-        " Concept:\n"
-        "   Intercepts malloc/free allocations to audit heap usage and detect memory leaks.\n"
-        "   - Features: Active allocation tracking, byte leakage alerts, pointer inspection.\n\n"
-        " Press [ENTER] to return to System Utilities Help Menu...");
+    printf("\n"
+           "================================================================================\n"
+           " 1. SORTING TELEMETRY DASHBOARD\n"
+           "================================================================================\n"
+           " Concept:\n"
+           "   Tracks real-time algorithmic operations, comparisons, swaps, and execution timers.\n"
+           "   - Features: Real-time swap counters, time-series metrics, comparative dashboards.\n\n"
+           "================================================================================\n"
+           " 2. MEMORY INSPECTOR & PROFILER\n"
+           "================================================================================\n"
+           " Concept:\n"
+           "   Intercepts malloc/free allocations to audit heap usage and detect memory leaks.\n"
+           "   - Features: Active allocation tracking, byte leakage alerts, pointer inspection.\n\n"
+           " Press [ENTER] to return to System Utilities Help Menu...");
     getchar();
 }
 
@@ -31,17 +30,45 @@ static void display_serialization_help(void)
 {
     clear_screen();
     display_header("MANUAL: State Serialization & Persistence Engine");
-    printf(
-        "\n"
-        "================================================================================\n"
-        " STATE SERIALIZATION & DESERIALIZATION\n"
-        "================================================================================\n"
-        " Concept:\n"
-        "   Serializes live in-memory data structures (BST, AVL Trees, Graphs) to binary payload\n"
-        "   files on disk and restores exact state during application execution.\n"
-        "   - Supported Structures: Binary Search Trees, AVL Trees, Weighted Graphs.\n"
-        "   - Data Integrity: Checksum-verified binary payloads.\n\n"
-        " Press [ENTER] to return to System Utilities Help Menu...");
+    printf("\n"
+           "================================================================================\n"
+           " STATE SERIALIZATION & DESERIALIZATION\n"
+           "================================================================================\n"
+           " Concept:\n"
+           "   Serializes live in-memory data structures (BST, AVL Trees, Graphs) to binary payload\n"
+           "   files on disk and restores exact state during application execution.\n"
+           "   - Supported Structures: Binary Search Trees, AVL Trees, Weighted Graphs.\n"
+           "   - Data Integrity: Checksum-verified binary payloads.\n\n"
+           " Press [ENTER] to return to System Utilities Help Menu...");
+    getchar();
+}
+
+static void display_diagnostics_help(void)
+{
+    clear_screen();
+    display_header("MANUAL: Developer Utilities & Diagnostics");
+    printf("\n"
+           "================================================================================\n"
+           " 1. STOCHASTIC FUZZ TESTING ENGINE\n"
+           "================================================================================\n"
+           " Concept:\n"
+           "   Bombards algorithms with randomized, edge-case inputs to verify robust constraint\n"
+           "   handling and uncover unexpected segfaults.\n\n"
+           "================================================================================\n"
+           " 2. EMPIRICAL BIG-O VERIFIER\n"
+           "================================================================================\n"
+           " Concept:\n"
+           "   Runs algorithms against scaling dataset sizes (e.g., 10^2 to 10^6) and curves\n"
+           "   the runtime mathematically to empirically prove O(N log N), O(N^2), etc.\n\n"
+           "================================================================================\n"
+           " 3. STANDALONE FILE EXPORTER\n"
+           "================================================================================\n"
+           " Concept:\n"
+           "   Exports internal arrays, graphs, or trees to .csv or .md files for external\n"
+           "   analysis and cross-referencing.\n\n"
+           " HOW TO RUN IN THIS SUITE:\n"
+           "   Main Menu ➔ Option 19 (System Utilities & Diagnostics)\n\n"
+           " Press [ENTER] to return to System Utilities Help Menu...");
     getchar();
 }
 
@@ -58,8 +85,9 @@ void help_system_utilities_menu(void)
                                     "------------------------\n"
                                     "1. Sorting Telemetry & Memory Profiler Engine\n"
                                     "2. State Serialization & Binary Disk Persistence\n"
+                                    "3. Developer Diagnostics (Fuzzing, Big-O, Exporter)\n"
                                     "\nenter choice ('-1' to return): ",
-                                    1, 2);
+                                    1, 3);
 
         if (status == INPUT_EXIT_SIGNAL)
         {
@@ -78,6 +106,9 @@ void help_system_utilities_menu(void)
                 break;
             case 2:
                 display_serialization_help();
+                break;
+            case 3:
+                display_diagnostics_help();
                 break;
         }
     }


### PR DESCRIPTION
 Docs: Document Fuzz Testing, Big-O Verifier, and File Exporter in Help Manual

Labels: documentation, good first issue

Description: While the help_system_utilities.c file was recently updated to cover the Memory Inspector and State Serialization, several critical Developer Utilities are still completely undocumented in our TUI/CLI Help Manual.

We need to expand the help system to include comprehensive documentation for:

Stochastic Fuzz Testing Engine: Document how it bombards algorithms with randomized edge-case inputs to verify robust constraint handling.
Empirical Big-O Verifier: Document how it runs algorithms at scaling dataset sizes ($N=10^2$ up to $10^6$) and mathematically curves the runtime to prove $O(N \log N)$, $O(N^2)$, etc.
Standalone File Exporter: Document the ability to export internal arrays/graphs/trees to .csv or .md files for external analysis.