### PR TITLE
docs(doxygen): add Doxygen docstrings to core data structures, trees, and cache headers PR 1-3

### DIFF
--- a/src/bit_manipulation/bit_manipulation.h
+++ b/src/bit_manipulation/bit_manipulation.h
@@ -1,36 +1,128 @@
 #ifndef BIT_MANIPULATION_H
 #define BIT_MANIPULATION_H
 
+/**
+ * @brief Sets the k-th bit of integer n to 1.
+ * @param n Target 32-bit integer.
+ * @param k 0-based bit position (0 to 31).
+ * @return Value with k-th bit set.
+ */
 int set_bit(int n, int k);
+
+/**
+ * @brief Clears the k-th bit of integer n to 0.
+ * @param n Target 32-bit integer.
+ * @param k 0-based bit position (0 to 31).
+ * @return Value with k-th bit cleared.
+ */
 int clear_bit(int n, int k);
+
+/**
+ * @brief Toggles (flips) the k-th bit of integer n.
+ * @param n Target 32-bit integer.
+ * @param k 0-based bit position (0 to 31).
+ * @return Value with k-th bit toggled.
+ */
 int toggle_bit(int n, int k);
+
+/**
+ * @brief Checks if the k-th bit of integer n is set.
+ * @param n Target 32-bit integer.
+ * @param k 0-based bit position (0 to 31).
+ * @return 1 if k-th bit is set, 0 otherwise.
+ */
 int check_bit(int n, int k);
 
+/**
+ * @brief Counts the total number of set bits (1s) using Brian Kernighan's algorithm.
+ * @param n Target integer.
+ * @return Total set bit count.
+ */
 int count_set_bits(int n);
+
+/**
+ * @brief Determines if integer n is a positive power of two.
+ * @param n Target integer.
+ * @return 1 if power of two, 0 otherwise.
+ */
 int is_power_of_two(int n);
+
+/**
+ * @brief Swaps values of two integers in-place using bitwise XOR without temporary variable.
+ * @param a Pointer to first integer.
+ * @param b Pointer to second integer.
+ */
 void xor_swap(int* a, int* b);
 
+/**
+ * @brief Isolates the rightmost set bit (lowest 1 bit) of n.
+ * @param n Target integer.
+ * @return Power of two representing the lowest set bit.
+ */
 int get_rightmost_set_bit(int n);
+
+/**
+ * @brief Turns off the rightmost set bit of n.
+ * @param n Target integer.
+ * @return Value with lowest set bit cleared.
+ */
 int turn_off_rightmost_set_bit(int n);
+
+/**
+ * @brief Reverses the 32 bits of an unsigned integer.
+ * @param n Unsigned 32-bit integer.
+ * @return Bit-reversed value.
+ */
 unsigned int reverse_bits(unsigned int n);
 
+/**
+ * @brief Finds the single non-repeating element in an array where all other elements appear twice.
+ * @param arr Array of integers.
+ * @param n Array length.
+ * @return The unique element value.
+ */
 int find_unique(int arr[], int n);
 
+/**
+ * @brief Generates and prints all 2^N subsets of an array using bit masking.
+ * @param arr Array of integers.
+ * @param n Array length.
+ */
 void generate_subsets(int arr[], int n);
 
+/** @brief Interactive CLI demo menu for Bit Manipulation. */
 void bit_manipulation_demo(void);
+/** @brief Interactive sub-demo for basic bitwise operations (set, clear, toggle, check). */
 void basic_bit_ops_demo(void);
+/** @brief Interactive sub-demo for set bit counting. */
 void count_set_bits_demo(void);
+/** @brief Interactive sub-demo for power-of-two validation. */
 void power_of_two_demo(void);
+/** @brief Interactive sub-demo for in-place XOR swap. */
 void xor_swap_demo(void);
+/** @brief Interactive sub-demo for rightmost set bit operations. */
 void rightmost_set_bit_demo(void);
+/** @brief Interactive sub-demo for bit reversal. */
 void reverse_bits_demo(void);
+/** @brief Interactive sub-demo for unique element finding. */
 void find_unique_demo(void);
+/** @brief Interactive sub-demo for power-set subset generation. */
 void generate_subsets_demo(void);
+/** @brief Interactive 32-bit terminal grid visualizer demo. */
 void bitwise_visualizer_demo(void);
 
-/* Utils */
+/**
+ * @brief Prints binary 32-bit representation of an unsigned integer to stdout.
+ * @param n Unsigned 32-bit integer.
+ */
 void print_binary_32(unsigned int n);
+
+/**
+ * @brief Prints 32-bit binary string with specified mask bits highlighted in terminal color.
+ * @param n Unsigned 32-bit integer.
+ * @param highlight_mask Bitmask indicating which bits to highlight.
+ * @param color_code ANSI escape color code string.
+ */
 void print_binary_32_highlight(unsigned int n, unsigned int highlight_mask, const char* color_code);
 
 #endif /* BIT_MANIPULATION_H */

--- a/src/cache_simulator/cache.h
+++ b/src/cache_simulator/cache.h
@@ -3,44 +3,135 @@
 
 #include <stdbool.h>
 
+/** Maximum supported frame capacity for the Cache Simulator. */
 #define CACHE_MAX_CAPACITY 10
 
+/**
+ * @brief Represents an individual cache frame block.
+ */
 typedef struct
 {
-    int page_id;
-    bool is_valid;
-    bool is_dirty;
-    int reference_bit;
-    int frequency;
-    int last_access_time;
+    int page_id;          /**< Page identifier stored in the block (-1 if empty). */
+    bool is_valid;        /**< True if the block contains valid data. */
+    bool is_dirty;        /**< True if the block has unwritten modifications. */
+    int reference_bit;    /**< Reference bit used by Clock replacement algorithms. */
+    int frequency;        /**< Access frequency counter for LFU replacement. */
+    int last_access_time; /**< Timestamp of the last access for LRU/MRU. */
 } CacheBlock;
 
+/**
+ * @brief Main Cache Simulator data structure.
+ */
 typedef struct
 {
-    CacheBlock blocks[CACHE_MAX_CAPACITY];
-    int capacity;
-    int size;
-    int fifo_index;
-    int access_counter;
-    int last_accessed_slot;
+    CacheBlock blocks[CACHE_MAX_CAPACITY]; /**< Fixed array of cache blocks. */
+    int capacity;                          /**< Configured cache frame capacity. */
+    int size;                              /**< Current number of occupied frames. */
+    int fifo_index;                        /**< Index pointer for FIFO and Clock policies. */
+    int access_counter;                    /**< Monotonic logical clock counter. */
+    int last_accessed_slot;                /**< Index of the most recently accessed slot. */
 
-    // Statistics
-    int hits;
-    int misses;
+    int hits;   /**< Cumulative hit counter. */
+    int misses; /**< Cumulative miss counter. */
 } Cache;
 
+/**
+ * @brief Initializes a Cache instance with specified capacity.
+ * @param cache Pointer to Cache structure.
+ * @param capacity Number of cache frames (bounded by CACHE_MAX_CAPACITY).
+ */
 void cache_init(Cache* cache, int capacity);
+
+/**
+ * @brief Accesses a page in cache using First-In, First-Out (FIFO) eviction.
+ * @param cache Pointer to Cache structure.
+ * @param page_id Target page ID.
+ * @param is_write True if write operation.
+ * @return True on cache hit, false on cache miss.
+ */
 bool cache_access_fifo(Cache* cache, int page_id, bool is_write);
+
+/**
+ * @brief Accesses a page in cache using Least Recently Used (LRU) eviction.
+ * @param cache Pointer to Cache structure.
+ * @param page_id Target page ID.
+ * @param is_write True if write operation.
+ * @return True on cache hit, false on cache miss.
+ */
 bool cache_access_lru(Cache* cache, int page_id, bool is_write);
+
+/**
+ * @brief Accesses a page in cache using Most Recently Used (MRU) eviction.
+ * @param cache Pointer to Cache structure.
+ * @param page_id Target page ID.
+ * @param is_write True if write operation.
+ * @return True on cache hit, false on cache miss.
+ */
 bool cache_access_mru(Cache* cache, int page_id, bool is_write);
+
+/**
+ * @brief Accesses a page using Least Frequently Used (LFU) eviction with aging.
+ * @param cache Pointer to Cache structure.
+ * @param page_id Target page ID.
+ * @param is_write True if write operation.
+ * @return True on cache hit, false on cache miss.
+ */
 bool cache_access_lfu(Cache* cache, int page_id, bool is_write);
+
+/**
+ * @brief Accesses a page using Belady's Optimal (OPT) lookahead replacement algorithm.
+ * @param cache Pointer to Cache structure.
+ * @param page_id Target page ID.
+ * @param ref_str Array of full reference string sequence.
+ * @param ref_len Total length of reference string.
+ * @current_idx Index of the current operation in ref_str.
+ * @param is_write True if write operation.
+ * @return True on cache hit, false on cache miss.
+ */
 bool cache_access_opt(Cache* cache, int page_id, const int* ref_str, int ref_len, int current_idx,
                       bool is_write);
+
+/**
+ * @brief Accesses a page using the Second-Chance (Clock) replacement algorithm.
+ * @param cache Pointer to Cache structure.
+ * @param page_id Target page ID.
+ * @param is_write True if write operation.
+ * @return True on cache hit, false on cache miss.
+ */
 bool cache_access_clock(Cache* cache, int page_id, bool is_write);
+
+/**
+ * @brief Accesses a page using the Enhanced Second-Chance algorithm (using reference & dirty bits).
+ * @param cache Pointer to Cache structure.
+ * @param page_id Target page ID.
+ * @param is_write True if write operation.
+ * @return True on cache hit, false on cache miss.
+ */
 bool cache_access_enhanced_clock(Cache* cache, int page_id, bool is_write);
+
+/**
+ * @brief Prints current cache slots and statistics to stdout.
+ * @param cache Pointer to Cache instance.
+ */
 void cache_print_status(const Cache* cache);
+
+/**
+ * @brief Renders terminal grid visualizer for cache blocks.
+ * @param cache Pointer to Cache instance.
+ * @param highlighted_slot Target slot index to highlight.
+ * @param is_hit True if highlight color should indicate hit (green), else miss (red).
+ */
 void cache_visualize(const Cache* cache, int highlighted_slot, bool is_hit);
+
+/**
+ * @brief Normalizes access counter to prevent integer overflow during prolonged runs.
+ * @param cache Pointer to Cache instance.
+ */
 void cache_normalize_access_counter(Cache* cache);
+
+/**
+ * @brief Interactive CLI demo subroutine for the Cache Simulator Suite.
+ */
 void cache_simulator_demo(void);
 
 #endif // CACHE_H

--- a/src/data_structures/sll.h
+++ b/src/data_structures/sll.h
@@ -3,57 +3,114 @@
 
 #include <stdint.h>
 
+/**
+ * @brief Node structure for generic Singly Linked List.
+ */
 typedef struct Node
 {
-    void* data;
-    struct Node* next;
+    void* data;        /**< Pointer to payload data. */
+    struct Node* next; /**< Pointer to the next node in the list. */
 } Node;
 
-// Print the elements of a singly linked list.
+/**
+ * @brief Prints the elements of a singly linked list.
+ * @param head Pointer to the head node.
+ * @param print_element Callback function to format and print a single element payload.
+ */
 void sll_printlist(const Node* head, void (*print_element)(const void*));
 
-// Insert a value at the end of a singly linked list. Returns 1 on success, -1 on allocation
-// failure.
+/**
+ * @brief Inserts a value at the end of a singly linked list.
+ * @param head_ref Double pointer to the head node.
+ * @param value Pointer to the value payload to insert.
+ * @return 1 on success, -1 on allocation failure.
+ */
 int sll_insertAtEnd(Node** head_ref, void* value);
 
-// Delete the first element from a singly linked list. Returns 1 on success, -1 if the list is
-// empty.
+/**
+ * @brief Deletes the first element from a singly linked list.
+ * @param head_ref Double pointer to the head node.
+ * @param free_data Callback function to free payload memory (can be NULL).
+ * @return 1 on success, -1 if list is empty.
+ */
 int sll_deleteAtBeginning(Node** head_ref, void (*free_data)(void*));
 
-// Delete the last element from a singly linked list. Returns 1 on success, -1 if the list is empty.
+/**
+ * @brief Deletes the last element from a singly linked list.
+ * @param head_ref Double pointer to the head node.
+ * @param free_data Callback function to free payload memory (can be NULL).
+ * @return 1 on success, -1 if list is empty.
+ */
 int sll_deleteAtEnd(Node** head_ref, void (*free_data)(void*));
 
-// Delete the first occurrence of a value from a singly linked list. Returns 1 on success, -2 if the
-// list is empty, -1 if not found.
+/**
+ * @brief Deletes the first occurrence of a value from a singly linked list.
+ * @param head_ref Double pointer to the head node.
+ * @param value Pointer to the target comparison value.
+ * @param compare Callback function returning 0 when values match.
+ * @param free_data Callback function to free payload memory.
+ * @return 1 on success, -2 if list is empty, -1 if not found.
+ */
 int sll_deleteByValue(Node** head_ref, const void* value, int (*compare)(const void*, const void*),
                       void (*free_data)(void*));
 
-// Insert a value at the beginning of a singly linked list. Returns 1 on success, -1 on allocation
-// failure.
+/**
+ * @brief Inserts a value at the beginning of a singly linked list.
+ * @param head_ref Double pointer to the head node.
+ * @param value Pointer to the value payload to insert.
+ * @return 1 on success, -1 on allocation failure.
+ */
 int sll_insertAtBeginning(Node** head_ref, void* value);
 
-// Run the singly linked list demonstration module.
+/** @brief Runs the interactive Singly Linked List demonstration module. */
 void sll_demo(void);
 
-// Search for a key in a singly linked list. Returns The index of the key or -1 if not found.
+/**
+ * @brief Searches for a key in a singly linked list.
+ * @param head Pointer to the head node.
+ * @param key Pointer to target search key.
+ * @param compare Callback comparison function.
+ * @return 0-based index of key, or -1 if not found.
+ */
 int sll_search(const Node* head, const void* key, int (*compare)(const void*, const void*));
 
-// Reverse a singly linked list in place. Returns 1 on success, -2 if empty, -1 if only one node
-// exists.
+/**
+ * @brief Reverses a singly linked list in place.
+ * @param head_ref Double pointer to the head node.
+ * @return 1 on success, -2 if empty, -1 if single node.
+ */
 int sll_reverseList(Node** head_ref);
 
-// Free all nodes in a singly linked list.
+/**
+ * @brief Frees all nodes in a singly linked list.
+ * @param head Pointer to head node.
+ * @param free_data Callback function to free payload memory.
+ */
 void delete_sll(Node* head, void (*free_data)(void*));
 
-// Get the number of nodes in a singly linked list. Returns The number of nodes in the list.
+/**
+ * @brief Gets total number of nodes in a singly linked list.
+ * @param head Pointer to head node.
+ * @return Node count.
+ */
 int sll_getLength(const Node* head);
 
-// Insert a value at a specific position in a singly linked list. Returns 1 on success, -1 on
-// allocation failure, -2 on invalid position.
+/**
+ * @brief Inserts a value at a 1-based index position in a singly linked list.
+ * @param head_ref Double pointer to head node.
+ * @param value Pointer to value payload.
+ * @param position 1-based target insertion index.
+ * @return 1 on success, -1 on allocation failure, -2 on invalid position.
+ */
 int sll_insertAtPosition(Node** head_ref, void* value, int position);
 
-// Delete a node at a specific position in a singly linked list. Returns 1 on success, -1 if the
-// list is empty, -2 on invalid position.
+/**
+ * @brief Deletes a node at a 1-based index position in a singly linked list.
+ * @param head_ref Double pointer to head node.
+ * @param position 1-based target deletion index.
+ * @param free_data Callback function to free payload memory.
+ * @return 1 on success, -1 if list is empty, -2 on invalid position.
+ */
 int sll_deleteAtPosition(Node** head_ref, int position, void (*free_data)(void*));
 
 #endif

--- a/src/trees/avl.h
+++ b/src/trees/avl.h
@@ -4,23 +4,72 @@
 #include <stdbool.h>
 #include <stddef.h>
 
-// For AVL Tree (Self-Balancing Binary Search Tree)
+/**
+ * @brief Node structure for AVL Tree (Self-Balancing Binary Search Tree).
+ */
 typedef struct avlNode
 {
-    int data;
-    int height;
-    struct avlNode* left;
-    struct avlNode* right;
+    int data;              /**< Integer payload data. */
+    int height;            /**< Subtree height for balance factor calculations. */
+    struct avlNode* left;  /**< Pointer to left child subtree. */
+    struct avlNode* right; /**< Pointer to right child subtree. */
 } avlNode;
 
+/**
+ * @brief Inserts an integer value into the AVL Tree and maintains balance.
+ * @param root_ref Double pointer to root node.
+ * @param value Integer value to insert.
+ * @return 1 on success, 0 if duplicate, -1 on allocation failure.
+ */
 int avl_insert(avlNode** root_ref, int value);
+
+/**
+ * @brief Deletes an integer value from the AVL Tree and rebalances.
+ * @param root_ref Double pointer to root node.
+ * @param value Integer value to delete.
+ * @return 1 on success, 0 if not found.
+ */
 int avl_delete(avlNode** root_ref, int value);
+
+/**
+ * @brief Safely computes height of an AVL node (returns 0 for NULL).
+ * @param node Pointer to target AVL node.
+ * @return Node height value.
+ */
 int avl_height(const avlNode* node);
+
+/**
+ * @brief Calculates balance factor (left_height - right_height).
+ * @param node Pointer to target AVL node.
+ * @return Balance factor value.
+ */
 int avl_balance_factor(const avlNode* node);
+
+/**
+ * @brief Performs in-order traversal of the AVL Tree.
+ * @param root Pointer to root node.
+ */
 void avl_inorder(const avlNode* root);
+
+/**
+ * @brief Performs pre-order traversal of the AVL Tree.
+ * @param root Pointer to root node.
+ */
 void avl_preorder(const avlNode* root);
+
+/**
+ * @brief Performs post-order traversal of the AVL Tree.
+ * @param root Pointer to root node.
+ */
 void avl_postorder(const avlNode* root);
+
+/**
+ * @brief Recursively frees all nodes in the AVL Tree.
+ * @param root Pointer to root node.
+ */
 void destroy_avl(avlNode* root);
+
+/** @brief Runs the interactive AVL Tree demonstration module. */
 void avl_demo(void);
 
 #endif // AVL_H

--- a/src/trees/bst.h
+++ b/src/trees/bst.h
@@ -4,24 +4,83 @@
 #include <stdbool.h>
 #include <stddef.h>
 
-// For Binary Search Tree
+/**
+ * @brief Node structure for Binary Search Tree (BST).
+ */
 typedef struct bstNode
 {
-    int data;
-    struct bstNode* left;
-    struct bstNode* right;
+    int data;              /**< Integer payload data. */
+    struct bstNode* left;  /**< Pointer to left child subtree. */
+    struct bstNode* right; /**< Pointer to right child subtree. */
 } bstNode;
 
+/** @brief Runs the interactive Binary Search Tree demonstration module. */
 void binary_search_tree_demo(void);
+
+/**
+ * @brief Performs level-order (breadth-first) traversal printing to stdout.
+ * @param head Pointer to the root node.
+ */
 void bst_level_order(struct bstNode* head);
+
+/**
+ * @brief Renders 2D ASCII graphical representation of the tree to stdout.
+ * @param root Pointer to root node.
+ */
 void bst_print_ascii(const bstNode* root);
+
+/**
+ * @brief Inserts an integer value into the Binary Search Tree.
+ * @param head_ref Double pointer to root node pointer.
+ * @param value Integer value to insert.
+ * @return 1 on success, 0 if value already exists, -1 on allocation failure.
+ */
 int bst_insert(bstNode** head_ref, int value);
+
+/**
+ * @brief Performs in-order traversal (Left, Root, Right).
+ * @param head Pointer to root node.
+ */
 void bst_inorder(const bstNode* head);
+
+/**
+ * @brief Performs pre-order traversal (Root, Left, Right).
+ * @param head Pointer to root node.
+ */
 void bst_preorder(const bstNode* head);
+
+/**
+ * @brief Performs post-order traversal (Left, Right, Root).
+ * @param head Pointer to root node.
+ */
 void bst_postorder(const bstNode* head);
+
+/**
+ * @brief Counts the total number of nodes in the tree.
+ * @param head Pointer to root node.
+ * @return Total node count.
+ */
 int countnodes(const bstNode* head);
+
+/**
+ * @brief Calculates height (maximum depth) of the tree.
+ * @param root Pointer to root node.
+ * @return Height of tree (0 if empty).
+ */
 int tree_height(const bstNode* root);
+
+/**
+ * @brief Recursively frees all nodes in the Binary Search Tree.
+ * @param head Pointer to root node.
+ */
 void destroy_bst(bstNode* head);
+
+/**
+ * @brief Deletes a node with specified target value from the tree.
+ * @param root Pointer to root node.
+ * @param value Integer value to delete.
+ * @return Pointer to updated root node.
+ */
 bstNode* bst_delete(bstNode* root, int value);
 
 #endif // BST_H


### PR DESCRIPTION
Resolves #1146 (PR 1 of 3)

### Summary
Adds standardized Doxygen docstrings (`@brief`, `@param`, `@return`) to core exported headers:
- **Cache & Bitwise**: `src/cache_simulator/cache.h`, `src/bit_manipulation/bit_manipulation.h`.
- **Data Structures**: `src/data_structures/sll.h`.
- **Trees**: `src/trees/bst.h`, `src/trees/avl.h`.

### Testing
- Formatted with `cmake --build build --target fmt`.
- Compiled static library `dsa_lib` cleanly.