### PR TITLE
docs(architecture): add System Architecture to README.md and expand CONTRIBUTING.md PR 3-3

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -160,3 +160,18 @@ When opening an issue, please include:
 - Your OS and GCC version
 
 Use the appropriate label: `bug`, `enhancement`, `documentation`, `good first issue`, `refactor` etc.
+
+---
+
+## Adding a New Algorithm or Data Structure
+
+When adding a new module:
+1. **Core Implementation**: Create `src/<category>/<algo>.c` and `src/<category>/<algo>.h`.
+2. **Doxygen Annotations**: Add Doxygen comments (`@brief`, `@param`, `@return`) to all exported header prototypes.
+3. **Menu Integration**:
+   - Register the subroutine in `src/main.c` for CLI menu access.
+   - Register the entry in `src/utils/algorithm_search.c` (`GLOBAL_ALGORITHM_TABLE`) for the Algorithm Finder.
+   - Register the entry in `tui/tui.c` (`TUI_ENTRIES`) for TUI parity.
+4. **Unit Tests**: Create `tests/<category>/test_<algo>.c` and register it in `CMakeLists.txt`.
+5. **Format & Verify**: Run `cmake --build build --target fmt` and verify `ctest --test-dir build`.
+

--- a/README.md
+++ b/README.md
@@ -324,6 +324,32 @@ Removes executables and generated object/test binaries.
 
 ## Architectural Breakdown: Docker & The Build System
 
+### System Architecture Overview
+
+The **C DSA Interactive Suite** is organized into a modular three-tier architecture:
+- **Core Engine (`dsa_lib`)**: Reusable C static library containing implementations of data structures, graph traversals, dynamic programming, probabilistic models, memory profiler, and telemetry engines.
+- **Interactive CLI (`src/main.c`)**: Main menu driver supporting CLI arguments (`--profile`, `--load-bst`, `--export-trace`) and prompt-driven algorithm demos.
+- **Terminal UI (`tui/tui.c`)**: Ncurses/ANSI grid visualizer indexed directly with the `AlgorithmRegistry` (`src/utils/algorithm_search.c`).
+
+```mermaid
+flowchart TD
+    CLI[src/main.c - CLI Driver] -->|Menu Dispatch| Demos[src/ Module Demos]
+    CLI -->|Command Flags| Features[features/ Options]
+    TUI[tui/tui.c - TUI Visualizer] -->|Search Index| Registry[src/utils/algorithm_search.c]
+
+    Demos --> DSALib[libdsa_lib.a Core Library]
+    Features --> DSALib
+    TUI --> DSALib
+
+    subgraph DSALib [Core Engine - dsa_lib]
+        direction LR
+        DS[Data Structures & Trees]
+        Graph[Graphs & DP]
+        Sys[Cache & Utilities]
+        Prof[Memory Profiler & Telemetry]
+    end
+```
+
 ### Why Docker?
 
 Docker acts as a cross-platform wrapper around the build system. Contributors on Windows, macOS, and Linux can use the same isolated Ubuntu environment without manually configuring compiler toolchains, build dependencies, or platform-specific settings.


### PR DESCRIPTION
Resolves #1146 (PR 3 of 3 )

### Summary
- **System Architecture (`README.md`)**: Added System Architecture Overview section with Mermaid component interaction diagrams directly into `README.md` under `## Architectural Breakdown` (detailing interactions between `dsa_lib`, main CLI application, and TUI renderer).
- **Developer Onboarding (`CONTRIBUTING.md`)**: Restored missing `Reporting Issues` section guidelines and added step-by-step developer guidelines on how to implement a new algorithm, update CLI/TUI registries, and add CTest unit fixtures.

### Testing
- Formatted with `cmake --build build --target fmt`.
- Verified markdown rendering and clean build.