### PR TITLE
ci(docs): automated Doxygen API documentation deployment via GitHub Actions & GitHub Pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,47 @@
+name: Doxygen Documentation Deployment
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  deploy-docs:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Doxygen and Graphviz
+        run: sudo apt update && sudo apt install -y doxygen graphviz cmake
+
+      - name: Configure project with CMake
+        run: cmake -S . -B build
+
+      - name: Generate Doxygen Documentation
+        run: cmake --build build --target doc
+
+      - name: Setup GitHub Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload Doxygen Artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/doxygen/html
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
Resolves #1161

### Summary
Adds an automated GitHub Actions workflow (`.github/workflows/docs.yml`) that builds Doxygen HTML documentation on pushes to `main` and deploys it to GitHub Pages.

### Workflow Steps
1. Trigger on push to `main` or manual `workflow_dispatch`.
2. Install `doxygen`, `graphviz`, and `cmake`.
3. Execute `cmake --build build --target doc` to generate HTML documentation into `docs/doxygen/html`.
4. Upload and deploy site via `actions/deploy-pages@v4`.

### Verification
- Validated workflow configuration.
- Verified local Doxygen build target `doc` works cleanly.