### PR TITLE
fix(doxygen): update output directory to doxygen_out and remove non-existent include dir

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Upload Doxygen Artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: docs/doxygen/html
+          path: doxygen_out/html
 
       - name: Deploy to GitHub Pages
         id: deployment

--- a/Doxyfile
+++ b/Doxyfile
@@ -3,7 +3,7 @@
 PROJECT_NAME           = "C DSA Interactive Suite"
 PROJECT_NUMBER         = "2.0.0"
 PROJECT_BRIEF          = "A modular, interactive Data Structures & Algorithms library written in pure C"
-OUTPUT_DIRECTORY       = docs/doxygen
+OUTPUT_DIRECTORY       = doxygen_out
 CREATE_SUBDIRS         = NO
 OUTPUT_LANGUAGE        = English
 
@@ -12,7 +12,7 @@ EXTRACT_ALL            = YES
 EXTRACT_PRIVATE        = YES
 EXTRACT_STATIC         = YES
 CASE_SENSE_NAMES       = YES
-INPUT                  = src/ help/ tui/ demos/ features/ include/
+INPUT                  = src/ help/ tui/ demos/ features/
 RECURSIVE              = YES
 FILE_PATTERNS          = *.c *.h
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ The codebase is structured as a reusable **DSA library**, with an interactive, c
 - [Build Instructions](#build-instructions)
 - [Continuous Integration](#continuous-integration)
 - [Architectural Breakdown: Docker & The Build System](#architectural-breakdown-docker--the-build-system)
+  - [System Architecture Overview](#system-architecture-overview)
+  - [Why Docker?](#why-docker)
+  - [Container Build Chain](#container-build-chain)
 - [List of All Implemented Data Structures & Algorithms](#list-of-all-implemented-data-structures--algorithms)
 - [License](#license)
 


### PR DESCRIPTION
Resolves #1166

### Summary
Fixes Doxygen deployment CI (`docs.yml`) exit code 2 failure:
- `Doxyfile`: Updated `OUTPUT_DIRECTORY` to `doxygen_out` (since `docs/` parent folder does not exist).
- `Doxyfile`: Removed non-existent `include/` directory from `INPUT`.
- `.github/workflows/docs.yml`: Updated `upload-pages-artifact` path to `doxygen_out/html`.

### Testing
- Verified `cmake --build build --target doc` runs cleanly locally without directory errors.