### PR TITLE
refactor(menu): reorder Developer Utilities to the bottom of main menu in CLI and TUI

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -68,10 +68,10 @@ void run_legacy_menu(void)
             "click 12 for string processing & compression algorithms demo\n"
             "click 13 for advanced heaps & priority queues suite demo\n"
             "click 14 for Bit Manipulation demo\n"
-            "click 15 for Developer Console & System Utilities\n"
-            "click 16 for Probabilistic Data Structures Module\n"
-            "click 17 for Spatial Indexing Module\n"
-            "click 18 for Interactive Algorithm Quick-Search Finder\n"
+            "click 15 for Probabilistic Data Structures Module\n"
+            "click 16 for Spatial Indexing Module\n"
+            "click 17 for Interactive Algorithm Quick-Search Finder\n"
+            "click 18 for Developer Console & System Utilities\n"
             "\nenter choice (\'-1\' to exit, or \'help\') : ",
             1, 18 /* limits */
         );
@@ -272,6 +272,17 @@ void run_legacy_menu(void)
                 bit_manipulation_demo();
                 break;
             case 15:
+                display_header("Probabilistic Data Structures Module");
+                probabilistic_ds_demo();
+                break;
+            case 16:
+                display_header("Spatial Indexing Module");
+                spatial_indexing_demo();
+                break;
+            case 17:
+                run_algorithm_search_menu();
+                break;
+            case 18:
                 while (1)
                 {
                     int dev_choice;
@@ -336,17 +347,6 @@ void run_legacy_menu(void)
                         serialization_demo();
                     }
                 }
-                break;
-            case 16:
-                display_header("Probabilistic Data Structures Module");
-                probabilistic_ds_demo();
-                break;
-            case 17:
-                display_header("Spatial Indexing Module");
-                spatial_indexing_demo();
-                break;
-            case 18:
-                run_algorithm_search_menu();
                 break;
         }
     }

--- a/tui/tui.c
+++ b/tui/tui.c
@@ -294,6 +294,18 @@ static Entry ENTRIES[] = {
     {"Bit Manipulation", NULL, 1, 0, 0},
     {"Bit Manipulation Demo", bit_manipulation_demo, 0, 0, 1},
 
+    {"Probabilistic Data Structures", NULL, 1, 0, 0},
+    {"Bloom Filter", bloom_filter_demo, 0, 0, 1},
+    {"Count-Min Sketch", count_min_sketch_demo, 0, 0, 1},
+    {"HyperLogLog", hyperloglog_demo, 0, 0, 1},
+
+    {"Spatial Indexing", NULL, 1, 0, 0},
+    {"k-d Tree", kd_tree_demo, 0, 0, 1},
+    {"QuadTree", quadtree_demo, 0, 0, 1},
+    {"R-Tree", rtree_demo, 0, 0, 1},
+
+    {"Interactive Algorithm Quick-Search", run_algorithm_search_menu, 0, 0, 0},
+
     {"Developer Utilities", NULL, 1, 0, 0},
     {"algorithm_benchmarks", NULL, 1, 0, 1},
     {"Sorting Benchmarks", run_sorting_benchmark_wrapper, 0, 0, 2},
@@ -317,18 +329,6 @@ static Entry ENTRIES[] = {
     {"Standalone File Exporter", file_exporter_demo, 0, 0, 1},
     {"State Serialization Engine", serialization_demo, 0, 0, 1},
     {"System Settings (Animation Speed)", settings_menu_demo, 0, 0, 1},
-
-    {"Probabilistic Data Structures", NULL, 1, 0, 0},
-    {"Bloom Filter", bloom_filter_demo, 0, 0, 1},
-    {"Count-Min Sketch", count_min_sketch_demo, 0, 0, 1},
-    {"HyperLogLog", hyperloglog_demo, 0, 0, 1},
-
-    {"Spatial Indexing", NULL, 1, 0, 0},
-    {"k-d Tree", kd_tree_demo, 0, 0, 1},
-    {"QuadTree", quadtree_demo, 0, 0, 1},
-    {"R-Tree", rtree_demo, 0, 0, 1},
-
-    {"Interactive Algorithm Quick-Search", run_algorithm_search_menu, 0, 0, 0},
 };
 
 static const int ENTRY_COUNT = sizeof(ENTRIES) / sizeof(ENTRIES[0]);


### PR DESCRIPTION
Resolves #1181

### Summary
Reorders the developer/system utility menu items to place them at the very bottom of the main menu list, ensuring that all actual data structures and algorithm categories are grouped contiguously first.

### Key Changes
- **TUI (`tui/tui.c`)**:
  - Relocated the `"Developer Utilities"` registry block from its middle position to the very bottom of the `ENTRIES[]` array.
- **CLI (`src/main.c`)**:
  - Shifted the print statement positions in the legacy menu prompt block.
  - Updated case handlers in the main switch statement (case 15, 16, 17, 18) to match the new order.