### PR TITLE
feat(telemetry): implement telemetry state bridge and side-by-side TUI visualization

### DIFF
--- a/features/debugger/step_debugger.c
+++ b/features/debugger/step_debugger.c
@@ -300,6 +300,7 @@ void telemetry_bridge_reset(const char* algorithm_name)
     memset(&current_bridge_state, 0, sizeof(current_bridge_state));
     if (algorithm_name != NULL)
     {
-        strncpy(current_bridge_state.algorithm_name, algorithm_name, sizeof(current_bridge_state.algorithm_name) - 1);
+        strncpy(current_bridge_state.algorithm_name, algorithm_name,
+                sizeof(current_bridge_state.algorithm_name) - 1);
     }
 }

--- a/features/debugger/step_debugger.c
+++ b/features/debugger/step_debugger.c
@@ -276,3 +276,30 @@ void print_recent_events_card(void)
     }
     printf("└──────────────────────────────────────────────────┘\n");
 }
+
+static AlgorithmStateBridge current_bridge_state = {0};
+
+void telemetry_bridge_update(const AlgorithmStateBridge* bridge)
+{
+    if (bridge != NULL)
+    {
+        current_bridge_state = *bridge;
+    }
+}
+
+void telemetry_bridge_get(AlgorithmStateBridge* bridge_out)
+{
+    if (bridge_out != NULL)
+    {
+        *bridge_out = current_bridge_state;
+    }
+}
+
+void telemetry_bridge_reset(const char* algorithm_name)
+{
+    memset(&current_bridge_state, 0, sizeof(current_bridge_state));
+    if (algorithm_name != NULL)
+    {
+        strncpy(current_bridge_state.algorithm_name, algorithm_name, sizeof(current_bridge_state.algorithm_name) - 1);
+    }
+}

--- a/features/debugger/step_debugger.h
+++ b/features/debugger/step_debugger.h
@@ -3,6 +3,35 @@
 
 #include <stddef.h>
 
+#define MAX_TELEMETRY_VARIABLES 8
+#define MAX_TELEMETRY_ALLOCATIONS 16
+
+typedef struct VariableSnapshot
+{
+    char name[32];
+    char value[64];
+} VariableSnapshot;
+
+typedef struct AllocationSnapshot
+{
+    void* address;
+    size_t size;
+    char label[32];
+    int active; // 1 = active, 0 = freed
+} AllocationSnapshot;
+
+typedef struct AlgorithmStateBridge
+{
+    char algorithm_name[64];
+    int step_index;
+    int recursion_depth;
+    int var_count;
+    VariableSnapshot variables[MAX_TELEMETRY_VARIABLES];
+    int alloc_count;
+    AllocationSnapshot allocations[MAX_TELEMETRY_ALLOCATIONS];
+    char status_message[128];
+} AlgorithmStateBridge;
+
 void set_step_mode(int active);
 int get_step_mode(void);
 
@@ -24,6 +53,11 @@ void debugger_step_reset(void);
 void debugger_toggle_inspector(void);
 int debugger_is_inspector_visible(void);
 void print_state_inspector_card(void);
+
+/* ── Unified Interactive Telemetry Bridge API ──────────────────── */
+void telemetry_bridge_update(const AlgorithmStateBridge* bridge);
+void telemetry_bridge_get(AlgorithmStateBridge* bridge_out);
+void telemetry_bridge_reset(const char* algorithm_name);
 
 void debugger_demo(void);
 

--- a/tui/tui.c
+++ b/tui/tui.c
@@ -1,6 +1,18 @@
 #include <ctype.h>
-#include <ncurses.h>
 #include <string.h>
+
+#ifndef WITHOUT_NCURSES
+#include <ncurses.h>
+#else
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+typedef void WINDOW;
+#define stdscr NULL
+#define A_BOLD 0
+#define FALSE 0
+#define TRUE 1
+#endif
 
 #include "advanced_graph_algorithms.h"
 #include "advanced_heaps.h"
@@ -431,6 +443,7 @@ static int build_visible(int* visible, int max, const char* query)
 #define COL_GREEN 8
 #define COL_RED 9
 
+#ifndef WITHOUT_NCURSES
 static void init_colors(void)
 {
     if (!has_colors())
@@ -928,3 +941,38 @@ void tui_run(void)
         delwin(status_win);
     }
 }
+#else
+void tui_run(void)
+{
+    printf("\n\033[1;33m⚠️  Warning: NCURSES is missing or disabled.\033[0m\n");
+    printf("\033[1;36m=== ANSI Fallback Console Dashboard ===\033[0m\n");
+
+    int visible[256];
+    int vis_count = build_visible(visible, 256, NULL);
+    int demo_count = 0;
+    int demo_mapping[256];
+
+    for (int i = 0; i < vis_count; i++)
+    {
+        int idx = visible[i];
+        if (ENTRIES[idx].is_folder)
+        {
+            printf("\n\033[1;34m[%s]\033[0m\n", ENTRIES[idx].name);
+        }
+        else if (ENTRIES[idx].fn != NULL)
+        {
+            demo_mapping[demo_count] = idx;
+            printf("  %d. %s\n", ++demo_count, ENTRIES[idx].name);
+        }
+    }
+
+    printf("\nSelect a demo to run (1-%d, or -1 to exit): ", demo_count);
+    int choice;
+    if (scanf("%d", &choice) == 1 && choice >= 1 && choice <= demo_count)
+    {
+        int target_idx = demo_mapping[choice - 1];
+        printf("\n\033[1;32mRunning %s...\033[0m\n", ENTRIES[target_idx].name);
+        ENTRIES[target_idx].fn();
+    }
+}
+#endif

--- a/tui/tui.c
+++ b/tui/tui.c
@@ -569,8 +569,8 @@ static void draw_viz(WINDOW* viz, State* s, int* visible, int cursor, int active
     {
         /* Live Side-by-Side Step Debugger and Memory Inspector Telemetry Display */
         wattron(viz, COLOR_PAIR(COL_VIZPANE) | A_BOLD);
-        mvwprintw(viz, 2, 2, "Telemetry: %s (Step %d, Recurse Depth %d)", 
-                  bridge.algorithm_name, bridge.step_index, bridge.recursion_depth);
+        mvwprintw(viz, 2, 2, "Telemetry: %s (Step %d, Recurse Depth %d)", bridge.algorithm_name,
+                  bridge.step_index, bridge.recursion_depth);
         wattroff(viz, COLOR_PAIR(COL_VIZPANE) | A_BOLD);
 
         /* Variables Panel (Left) */
@@ -580,15 +580,16 @@ static void draw_viz(WINDOW* viz, State* s, int* visible, int cursor, int active
         {
             if (i < bridge.var_count)
             {
-                mvwprintw(viz, 5 + i, 2, "│  %-12.12s : %-24.24s │", 
-                          bridge.variables[i].name, bridge.variables[i].value);
+                mvwprintw(viz, 5 + i, 2, "│  %-12.12s : %-24.24s │", bridge.variables[i].name,
+                          bridge.variables[i].value);
             }
             else
             {
                 mvwprintw(viz, 5 + i, 2, "│  %-12s : %-24s │", "-", "-");
             }
         }
-        mvwprintw(viz, 5 + MAX_TELEMETRY_VARIABLES, 2, "└──────────────────────────────────────────┘");
+        mvwprintw(viz, 5 + MAX_TELEMETRY_VARIABLES, 2,
+                  "└──────────────────────────────────────────┘");
         wattroff(viz, COLOR_PAIR(COL_ITEM));
 
         /* Memory Inspector Panel (Right) */
@@ -603,7 +604,7 @@ static void draw_viz(WINDOW* viz, State* s, int* visible, int cursor, int active
                 {
                     int color = bridge.allocations[i].active ? COL_GREEN : COL_RED;
                     wattron(viz, COLOR_PAIR(color));
-                    mvwprintw(viz, 5 + i, start_col + 3, "%s [%s] %zuB", 
+                    mvwprintw(viz, 5 + i, start_col + 3, "%s [%s] %zuB",
                               bridge.allocations[i].active ? "🟩" : "🟥",
                               bridge.allocations[i].label, bridge.allocations[i].size);
                     wattroff(viz, COLOR_PAIR(color));
@@ -615,7 +616,8 @@ static void draw_viz(WINDOW* viz, State* s, int* visible, int cursor, int active
                 /* Print padding for borders */
                 mvwprintw(viz, 5 + i, start_col + 43, "│");
             }
-            mvwprintw(viz, 5 + MAX_TELEMETRY_ALLOCATIONS, start_col, "└──────────────────────────────────────────┘");
+            mvwprintw(viz, 5 + MAX_TELEMETRY_ALLOCATIONS, start_col,
+                      "└──────────────────────────────────────────┘");
             wattroff(viz, COLOR_PAIR(COL_ITEM));
         }
 

--- a/tui/tui.c
+++ b/tui/tui.c
@@ -428,6 +428,8 @@ static int build_visible(int* visible, int max, const char* query)
 #define COL_BORDER 5
 #define COL_VIZPANE 6
 #define COL_STATUS 7
+#define COL_GREEN 8
+#define COL_RED 9
 
 static void init_colors(void)
 {
@@ -443,6 +445,8 @@ static void init_colors(void)
     init_pair(COL_BORDER, COLOR_BLUE, -1);
     init_pair(COL_VIZPANE, COLOR_GREEN, -1);
     init_pair(COL_STATUS, COLOR_BLACK, COLOR_BLUE);
+    init_pair(COL_GREEN, COLOR_GREEN, -1);
+    init_pair(COL_RED, COLOR_RED, -1);
 }
 
 /* ── draw helpers ───────────────────────────────────────────────────────────── */
@@ -531,6 +535,9 @@ static void draw_viz(WINDOW* viz, State* s, int* visible, int cursor, int active
     int mid_row = rows / 2;
     int mid_col = cols / 2;
 
+    AlgorithmStateBridge bridge = {0};
+    telemetry_bridge_get(&bridge);
+
     if (!s->demo_ran)
     {
         /* idle state */
@@ -545,9 +552,68 @@ static void draw_viz(WINDOW* viz, State* s, int* visible, int cursor, int active
         mvwprintw(viz, mid_row + 3, mid_col - 12, "q to quit");
         wattroff(viz, COLOR_PAIR(COL_ITEM));
     }
+    else if (strlen(bridge.algorithm_name) > 0)
+    {
+        /* Live Side-by-Side Step Debugger and Memory Inspector Telemetry Display */
+        wattron(viz, COLOR_PAIR(COL_VIZPANE) | A_BOLD);
+        mvwprintw(viz, 2, 2, "Telemetry: %s (Step %d, Recurse Depth %d)", 
+                  bridge.algorithm_name, bridge.step_index, bridge.recursion_depth);
+        wattroff(viz, COLOR_PAIR(COL_VIZPANE) | A_BOLD);
+
+        /* Variables Panel (Left) */
+        wattron(viz, COLOR_PAIR(COL_ITEM));
+        mvwprintw(viz, 4, 2, "┌── Variables Inspector ───────────────────┐");
+        for (int i = 0; i < MAX_TELEMETRY_VARIABLES; i++)
+        {
+            if (i < bridge.var_count)
+            {
+                mvwprintw(viz, 5 + i, 2, "│  %-12.12s : %-24.24s │", 
+                          bridge.variables[i].name, bridge.variables[i].value);
+            }
+            else
+            {
+                mvwprintw(viz, 5 + i, 2, "│  %-12s : %-24s │", "-", "-");
+            }
+        }
+        mvwprintw(viz, 5 + MAX_TELEMETRY_VARIABLES, 2, "└──────────────────────────────────────────┘");
+        wattroff(viz, COLOR_PAIR(COL_ITEM));
+
+        /* Memory Inspector Panel (Right) */
+        if (cols > 75)
+        {
+            int start_col = cols - 44;
+            wattron(viz, COLOR_PAIR(COL_ITEM));
+            mvwprintw(viz, 4, start_col, "┌── Heap Memory Map ───────────────────────┐");
+            for (int i = 0; i < MAX_TELEMETRY_ALLOCATIONS; i++)
+            {
+                if (i < bridge.alloc_count)
+                {
+                    int color = bridge.allocations[i].active ? COL_GREEN : COL_RED;
+                    wattron(viz, COLOR_PAIR(color));
+                    mvwprintw(viz, 5 + i, start_col + 3, "%s [%s] %zuB", 
+                              bridge.allocations[i].active ? "🟩" : "🟥",
+                              bridge.allocations[i].label, bridge.allocations[i].size);
+                    wattroff(viz, COLOR_PAIR(color));
+                }
+                else
+                {
+                    mvwprintw(viz, 5 + i, start_col + 3, "⬛ [Empty]");
+                }
+                /* Print padding for borders */
+                mvwprintw(viz, 5 + i, start_col + 43, "│");
+            }
+            mvwprintw(viz, 5 + MAX_TELEMETRY_ALLOCATIONS, start_col, "└──────────────────────────────────────────┘");
+            wattroff(viz, COLOR_PAIR(COL_ITEM));
+        }
+
+        /* Status Bar (Bottom) */
+        wattron(viz, COLOR_PAIR(COL_TITLE));
+        mvwprintw(viz, rows - 4, 2, "Status: %s", bridge.status_message);
+        wattroff(viz, COLOR_PAIR(COL_TITLE));
+    }
     else
     {
-        /* show last ran info */
+        /* fallback show last ran info */
         wattron(viz, COLOR_PAIR(COL_VIZPANE) | A_BOLD);
         mvwprintw(viz, 2, 3, "Last run: %s", s->last_ran);
         wattroff(viz, COLOR_PAIR(COL_VIZPANE) | A_BOLD);
@@ -555,11 +621,7 @@ static void draw_viz(WINDOW* viz, State* s, int* visible, int cursor, int active
         wattron(viz, COLOR_PAIR(COL_ITEM));
         mvwprintw(viz, 4, 3, "Demo ran in full terminal mode.");
         mvwprintw(viz, 5, 3, "Press Enter again to re-run.");
-        mvwprintw(viz, 7, 3, "Note: interactive demos require");
-        mvwprintw(viz, 8, 3, "full terminal I/O. The visualizer");
-        mvwprintw(viz, 9, 3, "pane will show step-by-step output");
-        mvwprintw(viz, 10, 3, "once demos are refactored to return");
-        mvwprintw(viz, 11, 3, "structured data.");
+        mvwprintw(viz, 7, 3, "No active telemetry data was captured.");
         wattroff(viz, COLOR_PAIR(COL_ITEM));
     }
 


### PR DESCRIPTION
Resolves #1190 (PR 1)

### Summary
Implements the shared `AlgorithmStateBridge` telemetry structure to capture live variables and heap node addresses, and refactors the TUI Visualizer pane to show a side-by-side variable status table and heap memory map.

### Key Changes
- **Telemetry Bridge (`features/debugger/step_debugger.h/.c`)**:
  - Defined `AlgorithmStateBridge` representing current variable states and active allocations.
  - Added global getters/setters (`telemetry_bridge_update()`, `telemetry_bridge_get()`).
- **TUI Dashboard (`tui/tui.c`)**:
  - Redesigned `draw_viz()` to render live telemetry side-by-side (variables on the left, heap memory map on the right).
  - Initialized active/freed color codes `COL_GREEN` and `COL_RED`.
  - Added `#ifndef WITHOUT_NCURSES` guards and implemented a standard terminal fallback menu in `tui_run()` to handle missing ncurses compiler setups cleanly.