### PR TITLE
feat(telemetry): integrate SLL, AVL, Dijkstra, and Bubble Sort with Telemetry Bridge

### DIFF
--- a/demos/data_structures/sll_demo.c
+++ b/demos/data_structures/sll_demo.c
@@ -1,7 +1,9 @@
 #include "safe_input.h"
 #include "sll.h"
+#include "step_debugger.h"
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 
 static void print_int(const void* data)
 {
@@ -16,9 +18,40 @@ static int compare_ints(const void* a, const void* b)
     return *(const int*)a - *(const int*)b;
 }
 
+static void update_sll_telemetry(Node* head, const char* status)
+{
+    AlgorithmStateBridge bridge;
+    telemetry_bridge_reset("Singly Linked List");
+    telemetry_bridge_get(&bridge);
+
+    strncpy(bridge.status_message, status, sizeof(bridge.status_message) - 1);
+    
+    bridge.var_count = 2;
+    strncpy(bridge.variables[0].name, "head", 31);
+    snprintf(bridge.variables[0].value, 63, "%p", (void*)head);
+    strncpy(bridge.variables[1].name, "length", 31);
+    snprintf(bridge.variables[1].value, 63, "%d", sll_getLength(head));
+
+    Node* curr = head;
+    int idx = 0;
+    while (curr && idx < MAX_TELEMETRY_ALLOCATIONS)
+    {
+        bridge.allocations[idx].address = (void*)curr;
+        bridge.allocations[idx].size = sizeof(Node);
+        snprintf(bridge.allocations[idx].label, 31, "Node(%d)", *(int*)curr->data);
+        bridge.allocations[idx].active = 1;
+        idx++;
+        curr = curr->next;
+    }
+    bridge.alloc_count = idx;
+    
+    telemetry_bridge_update(&bridge);
+}
+
 void sll_demo(void)
 {
     Node* head = NULL;
+    update_sll_telemetry(head, "SLL Initialized Empty");
     int sll_element_count;
     int sll_length_status;
 
@@ -103,6 +136,8 @@ start_sll:
             }
             printf("\n");
             sll_printlist(head, print_int);
+            update_sll_telemetry(head, "Inserted node at end");
+            algorithm_step_hook("SLL: Insert At End");
         }
         else if (sll_position_choice == 0)
         {
@@ -142,6 +177,8 @@ start_sll:
             }
             printf("\n");
             sll_printlist(head, print_int);
+            update_sll_telemetry(head, "Inserted node at beginning");
+            algorithm_step_hook("SLL: Insert At Beginning");
         }
         else if (sll_position_choice == 2)
         {

--- a/demos/data_structures/sll_demo.c
+++ b/demos/data_structures/sll_demo.c
@@ -25,7 +25,7 @@ static void update_sll_telemetry(Node* head, const char* status)
     telemetry_bridge_get(&bridge);
 
     strncpy(bridge.status_message, status, sizeof(bridge.status_message) - 1);
-    
+
     bridge.var_count = 2;
     strncpy(bridge.variables[0].name, "head", 31);
     snprintf(bridge.variables[0].value, 63, "%p", (void*)head);
@@ -44,7 +44,7 @@ static void update_sll_telemetry(Node* head, const char* status)
         curr = curr->next;
     }
     bridge.alloc_count = idx;
-    
+
     telemetry_bridge_update(&bridge);
 }
 

--- a/demos/trees/avl_demo.c
+++ b/demos/trees/avl_demo.c
@@ -1,9 +1,46 @@
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 
 #include "avl.h"
 #include "safe_input.h"
 #include "serialization.h"
+#include "step_debugger.h"
+
+static void scan_avl_nodes(avlNode* root, AlgorithmStateBridge* bridge)
+{
+    if (root == NULL || bridge->alloc_count >= MAX_TELEMETRY_ALLOCATIONS)
+        return;
+
+    int idx = bridge->alloc_count;
+    bridge->allocations[idx].address = (void*)root;
+    bridge->allocations[idx].size = sizeof(avlNode);
+    snprintf(bridge->allocations[idx].label, 31, "Node(%d, H:%d)", root->data, root->height);
+    bridge->allocations[idx].active = 1;
+    bridge->alloc_count++;
+
+    scan_avl_nodes(root->left, bridge);
+    scan_avl_nodes(root->right, bridge);
+}
+
+static void update_avl_telemetry(avlNode* root, const char* status)
+{
+    AlgorithmStateBridge bridge;
+    telemetry_bridge_reset("AVL Tree");
+    telemetry_bridge_get(&bridge);
+
+    strncpy(bridge.status_message, status, sizeof(bridge.status_message) - 1);
+    
+    bridge.var_count = 2;
+    strncpy(bridge.variables[0].name, "root", 31);
+    snprintf(bridge.variables[0].value, 63, "%p", (void*)root);
+    strncpy(bridge.variables[1].name, "height", 31);
+    snprintf(bridge.variables[1].value, 63, "%d", root ? root->height : 0);
+
+    scan_avl_nodes(root, &bridge);
+    
+    telemetry_bridge_update(&bridge);
+}
 
 void avl_demo(void)
 {
@@ -28,6 +65,7 @@ void avl_demo(void)
         }
 
         avlNode* root = NULL;
+        update_avl_telemetry(root, "AVL Tree Initialized Empty");
 
         if (option == 2)
         {
@@ -44,6 +82,8 @@ void avl_demo(void)
                 continue;
             }
             printf("\nAVL tree loaded successfully from '%s'.\n", path);
+            update_avl_telemetry(root, "AVL Tree loaded from file");
+            algorithm_step_hook("AVL: Load from File");
         }
         else
         {
@@ -95,6 +135,11 @@ void avl_demo(void)
                 }
                 i++;
                 total_nodes--;
+
+                char status_msg[128];
+                snprintf(status_msg, sizeof(status_msg), "Inserted unique value %d", node_value);
+                update_avl_telemetry(root, status_msg);
+                algorithm_step_hook("AVL: Node Inserted");
             }
         }
 
@@ -168,6 +213,11 @@ void avl_demo(void)
                     printf("\nnode deleted. updated inorder traversal: ");
                     avl_inorder(root);
                     printf("\n");
+
+                    char status_msg[128];
+                    snprintf(status_msg, sizeof(status_msg), "Deleted value %d", delete_value);
+                    update_avl_telemetry(root, status_msg);
+                    algorithm_step_hook("AVL: Node Deleted");
                 }
             }
             else if (traversal_choice == 5)

--- a/demos/trees/avl_demo.c
+++ b/demos/trees/avl_demo.c
@@ -30,7 +30,7 @@ static void update_avl_telemetry(avlNode* root, const char* status)
     telemetry_bridge_get(&bridge);
 
     strncpy(bridge.status_message, status, sizeof(bridge.status_message) - 1);
-    
+
     bridge.var_count = 2;
     strncpy(bridge.variables[0].name, "root", 31);
     snprintf(bridge.variables[0].value, 63, "%p", (void*)root);
@@ -38,7 +38,7 @@ static void update_avl_telemetry(avlNode* root, const char* status)
     snprintf(bridge.variables[1].value, 63, "%d", root ? root->height : 0);
 
     scan_avl_nodes(root, &bridge);
-    
+
     telemetry_bridge_update(&bridge);
 }
 

--- a/features/debugger/step_debugger.c
+++ b/features/debugger/step_debugger.c
@@ -300,6 +300,7 @@ void telemetry_bridge_reset(const char* algorithm_name)
     memset(&current_bridge_state, 0, sizeof(current_bridge_state));
     if (algorithm_name != NULL)
     {
-        strncpy(current_bridge_state.algorithm_name, algorithm_name, sizeof(current_bridge_state.algorithm_name) - 1);
+        strncpy(current_bridge_state.algorithm_name, algorithm_name,
+                sizeof(current_bridge_state.algorithm_name) - 1);
     }
 }

--- a/features/debugger/step_debugger.c
+++ b/features/debugger/step_debugger.c
@@ -276,3 +276,30 @@ void print_recent_events_card(void)
     }
     printf("└──────────────────────────────────────────────────┘\n");
 }
+
+static AlgorithmStateBridge current_bridge_state = {0};
+
+void telemetry_bridge_update(const AlgorithmStateBridge* bridge)
+{
+    if (bridge != NULL)
+    {
+        current_bridge_state = *bridge;
+    }
+}
+
+void telemetry_bridge_get(AlgorithmStateBridge* bridge_out)
+{
+    if (bridge_out != NULL)
+    {
+        *bridge_out = current_bridge_state;
+    }
+}
+
+void telemetry_bridge_reset(const char* algorithm_name)
+{
+    memset(&current_bridge_state, 0, sizeof(current_bridge_state));
+    if (algorithm_name != NULL)
+    {
+        strncpy(current_bridge_state.algorithm_name, algorithm_name, sizeof(current_bridge_state.algorithm_name) - 1);
+    }
+}

--- a/features/debugger/step_debugger.h
+++ b/features/debugger/step_debugger.h
@@ -3,6 +3,35 @@
 
 #include <stddef.h>
 
+#define MAX_TELEMETRY_VARIABLES 8
+#define MAX_TELEMETRY_ALLOCATIONS 16
+
+typedef struct VariableSnapshot
+{
+    char name[32];
+    char value[64];
+} VariableSnapshot;
+
+typedef struct AllocationSnapshot
+{
+    void* address;
+    size_t size;
+    char label[32];
+    int active; // 1 = active, 0 = freed
+} AllocationSnapshot;
+
+typedef struct AlgorithmStateBridge
+{
+    char algorithm_name[64];
+    int step_index;
+    int recursion_depth;
+    int var_count;
+    VariableSnapshot variables[MAX_TELEMETRY_VARIABLES];
+    int alloc_count;
+    AllocationSnapshot allocations[MAX_TELEMETRY_ALLOCATIONS];
+    char status_message[128];
+} AlgorithmStateBridge;
+
 void set_step_mode(int active);
 int get_step_mode(void);
 
@@ -24,6 +53,11 @@ void debugger_step_reset(void);
 void debugger_toggle_inspector(void);
 int debugger_is_inspector_visible(void);
 void print_state_inspector_card(void);
+
+/* ── Unified Interactive Telemetry Bridge API ──────────────────── */
+void telemetry_bridge_update(const AlgorithmStateBridge* bridge);
+void telemetry_bridge_get(AlgorithmStateBridge* bridge_out);
+void telemetry_bridge_reset(const char* algorithm_name);
 
 void debugger_demo(void);
 

--- a/src/graph_traversals/dijkstra.c
+++ b/src/graph_traversals/dijkstra.c
@@ -172,6 +172,7 @@ void dijkstra(weightedGraph* graph, int start)
     {
         PQ_graph pq = {0};
         init_pq_graph(&pq, 10);
+        telemetry_bridge_reset("Dijkstra (Binary)");
 
         if (!insert_pq_graph(&pq, start, 0))
         {
@@ -181,6 +182,7 @@ void dijkstra(weightedGraph* graph, int start)
         }
 
         PQ_graph_node currentNode;
+        int step_counter = 1;
 
         while (extractTop_pq_graph(&pq, &currentNode))
         {
@@ -192,6 +194,20 @@ void dijkstra(weightedGraph* graph, int start)
             char msg[128];
             snprintf(msg, sizeof(msg), "Dijkstra (Binary): Extracted node %d (distance %d)", u,
                      dist[u]);
+
+            // Update Telemetry Bridge on extraction
+            AlgorithmStateBridge bridge = {0};
+            telemetry_bridge_get(&bridge);
+            strncpy(bridge.algorithm_name, "Dijkstra (Binary)", sizeof(bridge.algorithm_name) - 1);
+            bridge.step_index = step_counter++;
+            bridge.var_count = 2;
+            strncpy(bridge.variables[0].name, "curr_vertex", 31);
+            snprintf(bridge.variables[0].value, 63, "%d", u);
+            strncpy(bridge.variables[1].name, "curr_dist", 31);
+            snprintf(bridge.variables[1].value, 63, "%d", dist[u]);
+            strncpy(bridge.status_message, msg, sizeof(bridge.status_message) - 1);
+            telemetry_bridge_update(&bridge);
+
             algorithm_step_hook(msg);
 
             Edge* current = graph->array[u];
@@ -206,6 +222,12 @@ void dijkstra(weightedGraph* graph, int start)
                     snprintf(msg, sizeof(msg),
                              "Dijkstra (Binary): Relaxed edge %d -> %d (new dist %d)", u, v,
                              dist[v]);
+
+                    // Update Telemetry Bridge on relaxation
+                    bridge.step_index = step_counter++;
+                    strncpy(bridge.status_message, msg, sizeof(bridge.status_message) - 1);
+                    telemetry_bridge_update(&bridge);
+
                     algorithm_step_hook(msg);
                     if (!insert_pq_graph(&pq, v, dist[v]))
                     {

--- a/src/sorting_algorithms_n2/bubble_sort.c
+++ b/src/sorting_algorithms_n2/bubble_sort.c
@@ -40,13 +40,13 @@ void bubble_sort_optimized_with_telemetry(int arr[], int length_of_array,
             bridge.step_index = step_counter++;
             bridge.recursion_depth = 0;
             bridge.var_count = 3;
-            
+
             strncpy(bridge.variables[0].name, "i", 31);
             snprintf(bridge.variables[0].value, 63, "%d", i);
-            
+
             strncpy(bridge.variables[1].name, "j", 31);
             snprintf(bridge.variables[1].value, 63, "%d", j);
-            
+
             strncpy(bridge.variables[2].name, "swapped", 31);
             snprintf(bridge.variables[2].value, 63, "%d", swapped);
 

--- a/src/sorting_algorithms_n2/bubble_sort.c
+++ b/src/sorting_algorithms_n2/bubble_sort.c
@@ -6,6 +6,7 @@
 #include "step_debugger.h"
 #include "telemetry.h"
 #include <stdio.h>
+#include <string.h>
 #include <time.h>
 
 void bubble_sort_optimized_with_telemetry(int arr[], int length_of_array,
@@ -17,6 +18,9 @@ void bubble_sort_optimized_with_telemetry(int arr[], int length_of_array,
         sorting_telemetry_start(telemetry);
     }
     telemetry_init("bubble_sort");
+    telemetry_bridge_reset("Bubble Sort");
+
+    int step_counter = 1;
 
     for (int i = 0; i < length_of_array - 1; i++)
     {
@@ -28,6 +32,27 @@ void bubble_sort_optimized_with_telemetry(int arr[], int length_of_array,
             char msg[128];
             snprintf(msg, sizeof(msg), "Bubble Sort: Comparing index %d (%d) and %d (%d)", j,
                      arr[j], j + 1, arr[j + 1]);
+
+            // Update Telemetry Bridge
+            AlgorithmStateBridge bridge = {0};
+            telemetry_bridge_get(&bridge);
+            strncpy(bridge.algorithm_name, "Bubble Sort", sizeof(bridge.algorithm_name) - 1);
+            bridge.step_index = step_counter++;
+            bridge.recursion_depth = 0;
+            bridge.var_count = 3;
+            
+            strncpy(bridge.variables[0].name, "i", 31);
+            snprintf(bridge.variables[0].value, 63, "%d", i);
+            
+            strncpy(bridge.variables[1].name, "j", 31);
+            snprintf(bridge.variables[1].value, 63, "%d", j);
+            
+            strncpy(bridge.variables[2].name, "swapped", 31);
+            snprintf(bridge.variables[2].value, 63, "%d", swapped);
+
+            strncpy(bridge.status_message, msg, sizeof(bridge.status_message) - 1);
+            telemetry_bridge_update(&bridge);
+
             algorithm_step_hook(msg);
             visualize_sort(arr, length_of_array, j, j + 1, -1, "Bubble Sort: Comparing elements");
             sorting_telemetry_add_comparison(telemetry, 1);
@@ -41,6 +66,13 @@ void bubble_sort_optimized_with_telemetry(int arr[], int length_of_array,
                 sorting_telemetry_add_swap(telemetry, 1);
 
                 snprintf(msg, sizeof(msg), "Bubble Sort: Swapped index %d and %d", j, j + 1);
+
+                // Update Telemetry Bridge on Swap
+                bridge.step_index = step_counter++;
+                snprintf(bridge.variables[2].value, 63, "%d (Swapped!)", swapped);
+                strncpy(bridge.status_message, msg, sizeof(bridge.status_message) - 1);
+                telemetry_bridge_update(&bridge);
+
                 algorithm_step_hook(msg);
                 visualize_sort(arr, length_of_array, j, j + 1, -1,
                                "Bubble Sort: Swapping elements");

--- a/tui/tui.c
+++ b/tui/tui.c
@@ -1,6 +1,18 @@
 #include <ctype.h>
-#include <ncurses.h>
 #include <string.h>
+
+#ifndef WITHOUT_NCURSES
+#include <ncurses.h>
+#else
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+typedef void WINDOW;
+#define stdscr NULL
+#define A_BOLD 0
+#define FALSE 0
+#define TRUE 1
+#endif
 
 #include "advanced_graph_algorithms.h"
 #include "advanced_heaps.h"
@@ -431,6 +443,7 @@ static int build_visible(int* visible, int max, const char* query)
 #define COL_GREEN 8
 #define COL_RED 9
 
+#ifndef WITHOUT_NCURSES
 static void init_colors(void)
 {
     if (!has_colors())
@@ -928,3 +941,38 @@ void tui_run(void)
         delwin(status_win);
     }
 }
+#else
+void tui_run(void)
+{
+    printf("\n\033[1;33m⚠️  Warning: NCURSES is missing or disabled.\033[0m\n");
+    printf("\033[1;36m=== ANSI Fallback Console Dashboard ===\033[0m\n");
+
+    int visible[256];
+    int vis_count = build_visible(visible, 256, NULL);
+    int demo_count = 0;
+    int demo_mapping[256];
+
+    for (int i = 0; i < vis_count; i++)
+    {
+        int idx = visible[i];
+        if (ENTRIES[idx].is_folder)
+        {
+            printf("\n\033[1;34m[%s]\033[0m\n", ENTRIES[idx].name);
+        }
+        else if (ENTRIES[idx].fn != NULL)
+        {
+            demo_mapping[demo_count] = idx;
+            printf("  %d. %s\n", ++demo_count, ENTRIES[idx].name);
+        }
+    }
+
+    printf("\nSelect a demo to run (1-%d, or -1 to exit): ", demo_count);
+    int choice;
+    if (scanf("%d", &choice) == 1 && choice >= 1 && choice <= demo_count)
+    {
+        int target_idx = demo_mapping[choice - 1];
+        printf("\n\033[1;32mRunning %s...\033[0m\n", ENTRIES[target_idx].name);
+        ENTRIES[target_idx].fn();
+    }
+}
+#endif

--- a/tui/tui.c
+++ b/tui/tui.c
@@ -569,8 +569,8 @@ static void draw_viz(WINDOW* viz, State* s, int* visible, int cursor, int active
     {
         /* Live Side-by-Side Step Debugger and Memory Inspector Telemetry Display */
         wattron(viz, COLOR_PAIR(COL_VIZPANE) | A_BOLD);
-        mvwprintw(viz, 2, 2, "Telemetry: %s (Step %d, Recurse Depth %d)", 
-                  bridge.algorithm_name, bridge.step_index, bridge.recursion_depth);
+        mvwprintw(viz, 2, 2, "Telemetry: %s (Step %d, Recurse Depth %d)", bridge.algorithm_name,
+                  bridge.step_index, bridge.recursion_depth);
         wattroff(viz, COLOR_PAIR(COL_VIZPANE) | A_BOLD);
 
         /* Variables Panel (Left) */
@@ -580,15 +580,16 @@ static void draw_viz(WINDOW* viz, State* s, int* visible, int cursor, int active
         {
             if (i < bridge.var_count)
             {
-                mvwprintw(viz, 5 + i, 2, "│  %-12.12s : %-24.24s │", 
-                          bridge.variables[i].name, bridge.variables[i].value);
+                mvwprintw(viz, 5 + i, 2, "│  %-12.12s : %-24.24s │", bridge.variables[i].name,
+                          bridge.variables[i].value);
             }
             else
             {
                 mvwprintw(viz, 5 + i, 2, "│  %-12s : %-24s │", "-", "-");
             }
         }
-        mvwprintw(viz, 5 + MAX_TELEMETRY_VARIABLES, 2, "└──────────────────────────────────────────┘");
+        mvwprintw(viz, 5 + MAX_TELEMETRY_VARIABLES, 2,
+                  "└──────────────────────────────────────────┘");
         wattroff(viz, COLOR_PAIR(COL_ITEM));
 
         /* Memory Inspector Panel (Right) */
@@ -603,7 +604,7 @@ static void draw_viz(WINDOW* viz, State* s, int* visible, int cursor, int active
                 {
                     int color = bridge.allocations[i].active ? COL_GREEN : COL_RED;
                     wattron(viz, COLOR_PAIR(color));
-                    mvwprintw(viz, 5 + i, start_col + 3, "%s [%s] %zuB", 
+                    mvwprintw(viz, 5 + i, start_col + 3, "%s [%s] %zuB",
                               bridge.allocations[i].active ? "🟩" : "🟥",
                               bridge.allocations[i].label, bridge.allocations[i].size);
                     wattroff(viz, COLOR_PAIR(color));
@@ -615,7 +616,8 @@ static void draw_viz(WINDOW* viz, State* s, int* visible, int cursor, int active
                 /* Print padding for borders */
                 mvwprintw(viz, 5 + i, start_col + 43, "│");
             }
-            mvwprintw(viz, 5 + MAX_TELEMETRY_ALLOCATIONS, start_col, "└──────────────────────────────────────────┘");
+            mvwprintw(viz, 5 + MAX_TELEMETRY_ALLOCATIONS, start_col,
+                      "└──────────────────────────────────────────┘");
             wattroff(viz, COLOR_PAIR(COL_ITEM));
         }
 

--- a/tui/tui.c
+++ b/tui/tui.c
@@ -428,6 +428,8 @@ static int build_visible(int* visible, int max, const char* query)
 #define COL_BORDER 5
 #define COL_VIZPANE 6
 #define COL_STATUS 7
+#define COL_GREEN 8
+#define COL_RED 9
 
 static void init_colors(void)
 {
@@ -443,6 +445,8 @@ static void init_colors(void)
     init_pair(COL_BORDER, COLOR_BLUE, -1);
     init_pair(COL_VIZPANE, COLOR_GREEN, -1);
     init_pair(COL_STATUS, COLOR_BLACK, COLOR_BLUE);
+    init_pair(COL_GREEN, COLOR_GREEN, -1);
+    init_pair(COL_RED, COLOR_RED, -1);
 }
 
 /* ── draw helpers ───────────────────────────────────────────────────────────── */
@@ -531,6 +535,9 @@ static void draw_viz(WINDOW* viz, State* s, int* visible, int cursor, int active
     int mid_row = rows / 2;
     int mid_col = cols / 2;
 
+    AlgorithmStateBridge bridge = {0};
+    telemetry_bridge_get(&bridge);
+
     if (!s->demo_ran)
     {
         /* idle state */
@@ -545,9 +552,68 @@ static void draw_viz(WINDOW* viz, State* s, int* visible, int cursor, int active
         mvwprintw(viz, mid_row + 3, mid_col - 12, "q to quit");
         wattroff(viz, COLOR_PAIR(COL_ITEM));
     }
+    else if (strlen(bridge.algorithm_name) > 0)
+    {
+        /* Live Side-by-Side Step Debugger and Memory Inspector Telemetry Display */
+        wattron(viz, COLOR_PAIR(COL_VIZPANE) | A_BOLD);
+        mvwprintw(viz, 2, 2, "Telemetry: %s (Step %d, Recurse Depth %d)", 
+                  bridge.algorithm_name, bridge.step_index, bridge.recursion_depth);
+        wattroff(viz, COLOR_PAIR(COL_VIZPANE) | A_BOLD);
+
+        /* Variables Panel (Left) */
+        wattron(viz, COLOR_PAIR(COL_ITEM));
+        mvwprintw(viz, 4, 2, "┌── Variables Inspector ───────────────────┐");
+        for (int i = 0; i < MAX_TELEMETRY_VARIABLES; i++)
+        {
+            if (i < bridge.var_count)
+            {
+                mvwprintw(viz, 5 + i, 2, "│  %-12.12s : %-24.24s │", 
+                          bridge.variables[i].name, bridge.variables[i].value);
+            }
+            else
+            {
+                mvwprintw(viz, 5 + i, 2, "│  %-12s : %-24s │", "-", "-");
+            }
+        }
+        mvwprintw(viz, 5 + MAX_TELEMETRY_VARIABLES, 2, "└──────────────────────────────────────────┘");
+        wattroff(viz, COLOR_PAIR(COL_ITEM));
+
+        /* Memory Inspector Panel (Right) */
+        if (cols > 75)
+        {
+            int start_col = cols - 44;
+            wattron(viz, COLOR_PAIR(COL_ITEM));
+            mvwprintw(viz, 4, start_col, "┌── Heap Memory Map ───────────────────────┐");
+            for (int i = 0; i < MAX_TELEMETRY_ALLOCATIONS; i++)
+            {
+                if (i < bridge.alloc_count)
+                {
+                    int color = bridge.allocations[i].active ? COL_GREEN : COL_RED;
+                    wattron(viz, COLOR_PAIR(color));
+                    mvwprintw(viz, 5 + i, start_col + 3, "%s [%s] %zuB", 
+                              bridge.allocations[i].active ? "🟩" : "🟥",
+                              bridge.allocations[i].label, bridge.allocations[i].size);
+                    wattroff(viz, COLOR_PAIR(color));
+                }
+                else
+                {
+                    mvwprintw(viz, 5 + i, start_col + 3, "⬛ [Empty]");
+                }
+                /* Print padding for borders */
+                mvwprintw(viz, 5 + i, start_col + 43, "│");
+            }
+            mvwprintw(viz, 5 + MAX_TELEMETRY_ALLOCATIONS, start_col, "└──────────────────────────────────────────┘");
+            wattroff(viz, COLOR_PAIR(COL_ITEM));
+        }
+
+        /* Status Bar (Bottom) */
+        wattron(viz, COLOR_PAIR(COL_TITLE));
+        mvwprintw(viz, rows - 4, 2, "Status: %s", bridge.status_message);
+        wattroff(viz, COLOR_PAIR(COL_TITLE));
+    }
     else
     {
-        /* show last ran info */
+        /* fallback show last ran info */
         wattron(viz, COLOR_PAIR(COL_VIZPANE) | A_BOLD);
         mvwprintw(viz, 2, 3, "Last run: %s", s->last_ran);
         wattroff(viz, COLOR_PAIR(COL_VIZPANE) | A_BOLD);
@@ -555,11 +621,7 @@ static void draw_viz(WINDOW* viz, State* s, int* visible, int cursor, int active
         wattron(viz, COLOR_PAIR(COL_ITEM));
         mvwprintw(viz, 4, 3, "Demo ran in full terminal mode.");
         mvwprintw(viz, 5, 3, "Press Enter again to re-run.");
-        mvwprintw(viz, 7, 3, "Note: interactive demos require");
-        mvwprintw(viz, 8, 3, "full terminal I/O. The visualizer");
-        mvwprintw(viz, 9, 3, "pane will show step-by-step output");
-        mvwprintw(viz, 10, 3, "once demos are refactored to return");
-        mvwprintw(viz, 11, 3, "structured data.");
+        mvwprintw(viz, 7, 3, "No active telemetry data was captured.");
         wattroff(viz, COLOR_PAIR(COL_ITEM));
     }
 


### PR DESCRIPTION
Resolves #1190 (PR 2)

### Summary
Hooks Singly Linked List, AVL Tree, Dijkstra's Shortest Path, and Bubble Sort into the Telemetry Bridge to stream real-time variables and active heap allocations to the side-by-side TUI visualizer panel.

### Key Changes
- **Linked List & Tree Demos (`sll_demo.c`, `avl_demo.c`)**:
  - Added telemetry scanning functions to feed active nodes to the Heap Memory Map side-by-side panel in real-time.
- **Algorithms (`dijkstra.c`, `bubble_sort.c`)**:
  - Added telemetry bridge updates for tracking loop parameters, relaxed edges, and current indices.