### PR TITLE
removed all the redundant display_header calls from the legacy CLI menu

### DIFF
--- a/demos/bit_manipulation/advanced_bit_ops_demo.c
+++ b/demos/bit_manipulation/advanced_bit_ops_demo.c
@@ -55,10 +55,12 @@ void count_set_bits_demo(void)
 
             if (un > 0)
             {
+                printf("Press Enter to continue...\n");
                 press_enter_to_continue();
             }
         }
         printf("Final Count: %d\n", count);
+        printf("Press Enter to continue...\n");
         press_enter_to_continue();
     }
 }
@@ -137,6 +139,7 @@ void xor_swap_demo(void)
         printf("  B = ");
         print_binary_32(ub);
         printf("  (%d)\n\n", b);
+        printf("Press Enter to continue...\n");
         press_enter_to_continue();
 
         printf("Step 1: A = A ^ B\n");
@@ -150,6 +153,7 @@ void xor_swap_demo(void)
         print_binary_32_highlight(new_a, ua ^ new_a, "\033[1;32m");
         printf("  (New A)\n\n");
         ua = new_a;
+        printf("Press Enter to continue...\n");
         press_enter_to_continue();
 
         printf("Step 2: B = A ^ B\n");
@@ -163,6 +167,7 @@ void xor_swap_demo(void)
         print_binary_32_highlight(new_b, ub ^ new_b, "\033[1;32m");
         printf("  (New B)\n\n");
         ub = new_b;
+        printf("Press Enter to continue...\n");
         press_enter_to_continue();
 
         printf("Step 3: A = A ^ B\n");
@@ -183,6 +188,7 @@ void xor_swap_demo(void)
 
         /* Actually swap the real variables so it's formally correct */
         xor_swap(&a, &b);
+        printf("Press Enter to continue...\n");
         press_enter_to_continue();
     }
 }

--- a/demos/bit_manipulation/applications_demo.c
+++ b/demos/bit_manipulation/applications_demo.c
@@ -70,6 +70,7 @@ void find_unique_demo(void)
             printf("  (%d)\n\n", next_xor);
 
             running_xor = next_xor;
+            printf("Press Enter to continue...\n");
             press_enter_to_continue();
         }
 
@@ -141,6 +142,7 @@ void generate_subsets_demo(void)
 
             if ((mask + 1) % 8 == 0 && (mask + 1) != total_subsets)
             {
+                printf("Press Enter to continue...\n");
                 press_enter_to_continue();
             }
         }

--- a/features/bigo_verifier/bigo_verifier_demo.c
+++ b/features/bigo_verifier/bigo_verifier_demo.c
@@ -1,4 +1,5 @@
 #include "bigo_verifier.h"
+#include "display_header.h"
 #include "safe_input.h"
 #include <stdio.h>
 #include <stdlib.h>
@@ -7,9 +8,7 @@ void bigo_verifier_demo(void)
 {
     while (1)
     {
-        printf("\n========================================================================\n");
-        printf("         EMPIRICAL ASYMPTOTIC COMPLEXITY VERIFIER (BIG-O ENGINE)        \n");
-        printf("========================================================================\n");
+        display_header("Empirical Big-O Verifier");
         printf("1. Profile Bubble Sort [Theoretical O(N^2)]\n");
         printf("2. Profile Quick Sort [Theoretical O(N log N)]\n");
         printf("3. Profile Merge Sort [Theoretical O(N log N)]\n");

--- a/features/file_exporter/file_exporter_demo.c
+++ b/features/file_exporter/file_exporter_demo.c
@@ -1,3 +1,4 @@
+#include "display_header.h"
 #include "file_exporter.h"
 #include "safe_input.h"
 #include <stdio.h>
@@ -8,9 +9,7 @@ void file_exporter_demo(void)
 {
     while (1)
     {
-        printf("\n========================================================================\n");
-        printf("           STANDALONE RECURSIVE FILE EXPORTER ENGINE DASHBOARD          \n");
-        printf("========================================================================\n");
+        display_header("Standalone File Exporter Engine");
         printf("click 1 for sll export\n");
         printf("click 2 for dll export\n");
         printf("click 3 for binary search tree export\n");

--- a/features/memory_inspector/memory_inspector_demo.c
+++ b/features/memory_inspector/memory_inspector_demo.c
@@ -1,3 +1,4 @@
+#include "display_header.h"
 #include "dll.h"
 #include "memory_inspector.h"
 #include "safe_input.h"
@@ -11,9 +12,7 @@ void memory_inspector_demo(void)
 {
     while (1)
     {
-        printf("\n========================================================================\n");
-        printf("         RAW MEMORY LAYOUT INSPECTOR & HEXDUMP VISUALIZER SUITE          \n");
-        printf("========================================================================\n");
+        display_header("Raw Memory Layout Inspector");
         printf("1. Inspect Singly-Linked List Node (Node) Memory Layout\n");
         printf("2. Inspect Doubly-Linked List Node (doubly_ll_Node) Memory Layout\n");
         printf("3. Inspect Binary Search Tree Node (bstNode) Memory Layout\n");

--- a/src/main.c
+++ b/src/main.c
@@ -272,11 +272,9 @@ void run_legacy_menu(void)
                 bit_manipulation_demo();
                 break;
             case 15:
-                display_header("Probabilistic Data Structures Module");
                 probabilistic_ds_demo();
                 break;
             case 16:
-                display_header("Spatial Indexing Module");
                 spatial_indexing_demo();
                 break;
             case 17:
@@ -305,47 +303,23 @@ void run_legacy_menu(void)
                     if (dev_status == 0)
                         continue;
                     if (dev_choice == 1)
-                    {
-                        display_header("Algorithm Benchmarking & Profiling");
                         benchmark_menu_demo();
-                    }
                     else if (dev_choice == 2)
                         debugger_demo();
                     else if (dev_choice == 3)
-                    {
-                        display_header("Raw Memory Layout Inspector");
                         memory_inspector_demo();
-                    }
                     else if (dev_choice == 4)
-                    {
-                        display_header("Settings");
                         settings_menu_demo();
-                    }
                     else if (dev_choice == 5)
-                    {
-                        display_header("Cache Replacement Simulator");
                         cache_simulator_demo();
-                    }
                     else if (dev_choice == 6)
-                    {
-                        display_header("Stochastic Fuzz Testing Engine");
                         fuzzer_demo();
-                    }
                     else if (dev_choice == 7)
-                    {
-                        display_header("Empirical Big-O Verifier");
                         bigo_verifier_demo();
-                    }
                     else if (dev_choice == 8)
-                    {
-                        display_header("Standalone File Exporter Engine");
                         file_exporter_demo();
-                    }
                     else if (dev_choice == 9)
-                    {
-                        display_header("State Serialization Engine");
                         serialization_demo();
-                    }
                 }
                 break;
         }

--- a/src/utils/config.c
+++ b/src/utils/config.c
@@ -1,5 +1,6 @@
 #include "config.h"
 #include "cross_platform_timer.h"
+#include "display_header.h"
 #include "safe_input.h"
 #include "step_debugger.h"
 #include "telemetry.h"
@@ -98,9 +99,7 @@ void settings_menu_demo(void)
 {
     while (1)
     {
-        printf("\n===================================\n");
-        printf("        Settings & Debugger        \n");
-        printf("===================================\n");
+        display_header("Settings");
         print_current_speed();
         printf("Debugger Step Mode: %s\n", get_step_mode() ? "ON" : "OFF");
         printf("\nOptions:\n");

--- a/src/utils/fuzzer_demo.c
+++ b/src/utils/fuzzer_demo.c
@@ -1,3 +1,4 @@
+#include "display_header.h"
 #include "fuzzer.h"
 #include "safe_input.h"
 #include <stdio.h>
@@ -32,7 +33,7 @@ void fuzzer_demo(void)
 {
     while (1)
     {
-        printf("\n=== STOCHASTIC FUZZ TESTING ENGINE ===\n");
+        display_header("Stochastic Fuzz Testing Engine");
         printf("1. Fuzz Tree Data Structures\n");
         printf("2. Fuzz Heap Data Structures\n");
         printf("3. Fuzz Graph Algorithms\n");


### PR DESCRIPTION
closes #1183

removed all the redundant display_header calls from the legacy CLI menu inside src/main.c (from option 15 onwards). Then, I went into each of the corresponding modules and injected #include "display_header.h" and the display_header(...) function at the very top of their while(1) interactive loops. This completely standardizes the UI logic exactly as it is done everywhere else in the project.

Here are the files that were updated:

src/main.c (Removed the calls)
features/memory_inspector/memory_inspector_demo.c (Added header)
src/utils/config.c (Added header for settings menu)
src/utils/fuzzer_demo.c (Added header)
features/bigo_verifier/bigo_verifier_demo.c (Added header)
features/file_exporter/file_exporter_demo.c (Added header)
(Note: probabilistic_ds_demo, spatial_indexing_demo, benchmark_menu_demo, serialization_demo, and cache_simulator_demo already correctly called display_header internally, so they simply had the double-calls removed from main.c).