### PR TITLE
 cache simulator in CLI and TUI

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -71,9 +71,10 @@ void run_legacy_menu(void)
             "click 15 for Probabilistic Data Structures Module\n"
             "click 16 for Spatial Indexing Module\n"
             "click 17 for Interactive Algorithm Quick-Search Finder\n"
-            "click 18 for Developer Console & System Utilities\n"
+            "click 18 for Cache Simulator\n"
+            "click 19 for Developer Console & System Utilities\n"
             "\nenter choice (\'-1\' to exit, or \'help\') : ",
-            1, 18 /* limits */
+            1, 19 /* limits */
         );
 
         if (status == INPUT_EXIT_SIGNAL)
@@ -281,6 +282,9 @@ void run_legacy_menu(void)
                 run_algorithm_search_menu();
                 break;
             case 18:
+                cache_simulator_demo();
+                break;
+            case 19:
                 while (1)
                 {
                     int dev_choice;
@@ -291,11 +295,10 @@ void run_legacy_menu(void)
                                        "2. Interactive Step-Debugger\n"
                                        "3. Raw Memory Layout Inspector / Hexdump Visualizer\n"
                                        "4. System Settings (Animation Speed, Debugger toggles)\n"
-                                       "5. Cache Replacement Simulator\n"
-                                       "6. Stochastic Fuzz Testing Engine\n"
-                                       "7. Empirical Big-O Verifier\n"
-                                       "8. Standalone File Exporter Engine\n"
-                                       "9. State Serialization & Deserialization Engine\n"
+                                       "5. Stochastic Fuzz Testing Engine\n"
+                                       "6. Empirical Big-O Verifier\n"
+                                       "7. Standalone File Exporter Engine\n"
+                                       "8. State Serialization & Deserialization Engine\n"
                                        "\nenter choice (\'-1\' to exit) : ",
                                        1, 9);
                     if (dev_status == INPUT_EXIT_SIGNAL)

--- a/tui/tui.c
+++ b/tui/tui.c
@@ -258,6 +258,9 @@ static Entry ENTRIES[] = {
     {"d-Ary Heap", run_dary_demo, 0, 0, 1},
     {"Treap", run_treap_demo, 0, 0, 1},
 
+    {"Cache Replacement Simulator", NULL, 1, 0, 0},
+    {"Cache Replacement Simulator", cache_simulator_demo, 0, 0, 1},
+
     {"hashing", NULL, 1, 0, 0},
     {"Linear Probing", linear_probing_demo, 0, 0, 1},
     {"Separate Chaining", separate_chaining_demo, 0, 0, 1},
@@ -335,7 +338,6 @@ static Entry ENTRIES[] = {
 
     {"Algorithm Step Debugger", debugger_demo, 0, 0, 1},
     {"Memory Layout Inspector", memory_inspector_demo, 0, 0, 1},
-    {"Cache Replacement Simulator", cache_simulator_demo, 0, 0, 1},
     {"Stochastic Fuzz Testing", fuzzer_demo, 0, 0, 1},
     {"Empirical Big-O Verifier", bigo_verifier_demo, 0, 0, 1},
     {"Standalone File Exporter", file_exporter_demo, 0, 0, 1},


### PR DESCRIPTION
## Summary

This PR promotes the **Cache Replacement Simulator** from the **Developer Console & System Utilities** section to a standalone educational module, making it more discoverable and consistent with other algorithm demonstrations in the application.

## Changes Made

* Added **Cache Replacement Simulator** as a top-level entry in the CLI main menu.
* Updated the CLI menu numbering and input validation range.
* Added a dedicated switch case to launch the Cache Replacement Simulator directly from the main menu.
* Removed the Cache Replacement Simulator entry from the Developer Console menu and renumbered the remaining options.
* Updated the TUI navigation to expose the Cache Replacement Simulator as a standalone module.
* Removed the Cache Replacement Simulator from the **Developer Utilities** section in the TUI to maintain consistency.

Closes #1207 
