### PR TITLE
docs: Sync README menu options with CLI paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ This suite includes over **100+ interactive, memory-audited data structures and 
 | **Postfix Expression Evaluator** | Expression Evaluation | $\mathcal{O}(N)$ | $\mathcal{O}(N)$ | Evaluates postfix token stream using operand stack. |
 | **Parentheses Match Checker** | Syntax Validation | $\mathcal{O}(N)$ | $\mathcal{O}(N)$ | Validates balanced parentheses, brackets, and braces `()`, `[]`, `{}`. |
 
-### 3. Elementary Sorting Algorithms $\mathcal{O}(N^2)$ (Menu Option 3)
+### 3. Elementary Sorting Algorithms $\mathcal{O}(N^2)$ (Menu Option 3 → 1)
 | Algorithm | Category | Time Complexity (Best / Avg / Worst) | Space Complexity | Description |
 | :--- | :--- | :--- | :--- | :--- |
 | **Bubble Sort (Optimized)** | Elementary Sorting | $\mathcal{O}(N) / \mathcal{O}(N^2) / \mathcal{O}(N^2)$ | $\mathcal{O}(1)$ | Swaps adjacent out-of-order elements with early-exit flag. |
@@ -282,7 +282,7 @@ This suite includes over **100+ interactive, memory-audited data structures and 
 | **Insertion Sort** | Elementary Sorting | $\mathcal{O}(N) / \mathcal{O}(N^2) / \mathcal{O}(N^2)$ | $\mathcal{O}(1)$ | Builds sorted array one item at a time by shifting elements. |
 | **Shell Sort** | Elementary Sorting | $\mathcal{O}(N \log N) / \mathcal{O}(N^{1.5}) / \mathcal{O}(N^2)$ | $\mathcal{O}(1)$ | In-place comparison sort using diminishing gap increments. |
 
-### 4. Advanced Sorting Algorithms $\mathcal{O}(N \log N)$ (Menu Option 3)
+### 4. Advanced Sorting Algorithms $\mathcal{O}(N \log N)$ (Menu Option 3 → 2)
 | Algorithm | Category | Time Complexity (Best / Avg / Worst) | Space Complexity | Description |
 | :--- | :--- | :--- | :--- | :--- |
 | **Quick Sort** | Divide & Conquer | $\mathcal{O}(N \log N) / \mathcal{O}(N \log N) / \mathcal{O}(N^2)$ | $\mathcal{O}(\log N)$ | Partitions array around a pivot element recursively. |
@@ -299,7 +299,7 @@ This suite includes over **100+ interactive, memory-audited data structures and 
 | **Jump Search** | Block Search | $\mathcal{O}(1) / \mathcal{O}(\sqrt{N}) / \mathcal{O}(\sqrt{N})$ | $\mathcal{O}(1)$ | Jumps ahead by fixed steps ($\sqrt{N}$) followed by linear search. |
 | **Interpolation Search** | Position Estimator | $\mathcal{O}(1) / \mathcal{O}(\log \log N) / \mathcal{O}(N)$ | $\mathcal{O}(1)$ | Position probe search for uniformly distributed sorted arrays. |
 
-### 6. Graph Traversals & Pathfinding (Menu Option 5)
+### 6. Graph Traversals & Pathfinding (Menu Option 5 → 1)
 | Algorithm | Category | Time Complexity | Space Complexity | Description |
 | :--- | :--- | :--- | :--- | :--- |
 | **Breadth-First Search (BFS)** | Graph Traversal | $\mathcal{O}(V + E)$ | $\mathcal{O}(V)$ | Level-order graph traversal using queue data structure. |
@@ -313,7 +313,7 @@ This suite includes over **100+ interactive, memory-audited data structures and 
 | **Prim's Algorithm** | Minimum Spanning Tree | $\mathcal{O}((V + E) \log V)$ | $\mathcal{O}(V)$ | Greedy MST growth from seed vertex using priority queue. |
 | **Floyd-Warshall Algorithm** | All-Pairs Shortest Path | $\mathcal{O}(V^3)$ | $\mathcal{O}(V^2)$ | All-pairs shortest path dynamic programming matrix solver. |
 
-### 7. Advanced Graph Algorithms (Menu Option 6)
+### 7. Advanced Graph Algorithms (Menu Option 5 → 2)
 | Algorithm | Category | Time Complexity | Space Complexity | Description |
 | :--- | :--- | :--- | :--- | :--- |
 | **Tarjan's SCC Algorithm** | Graph Connectivity | $\mathcal{O}(V + E)$ | $\mathcal{O}(V)$ | Strongly Connected Components using DFS lowlink values. |
@@ -341,7 +341,7 @@ This suite includes over **100+ interactive, memory-audited data structures and 
 | **Splay Tree** | Self-Adjusting Tree | $\mathcal{O}(\log N) / \mathcal{O}(\log N) / \mathcal{O}(\log N)$ | $\mathcal{O}(N)$ | Amortized self-adjusting search tree moving recent nodes to root. |
 | **Red-Black Tree** | Self-Balancing Tree | $\mathcal{O}(\log N) / \mathcal{O}(\log N) / \mathcal{O}(\log N)$ | $\mathcal{O}(N)$ | Color-balanced binary search tree using black-height invariant. |
 
-### 9. Dynamic Programming (Menu Option 8)
+### 9. Dynamic Programming (Menu Option 11)
 | Algorithm / Problem | Category | Time Complexity | Space Complexity | Description |
 | :--- | :--- | :--- | :--- | :--- |
 | **0/1 Knapsack Problem** | Optimization DP | $\mathcal{O}(N \cdot W)$ | $\mathcal{O}(N \cdot W)$ | Maximizes item values under capacity constraint $W$. |
@@ -351,7 +351,7 @@ This suite includes over **100+ interactive, memory-audited data structures and 
 | **Edit Distance (Levenshtein)** | String DP | $\mathcal{O}(M \cdot N)$ | $\mathcal{O}(M \cdot N)$ | Minimum insertion, deletion, and replacement operations. |
 | **Coin Change Problem** | Optimization DP | $\mathcal{O}(N \cdot A)$ | $\mathcal{O}(A)$ | Minimum coins needed to make target amount $A$. |
 
-### 10. Advanced Heaps & Priority Queues (Menu Option 9)
+### 10. Advanced Heaps & Priority Queues (Menu Option 13)
 | Heap Structure | Category | Time Complexity (Push / Pop / Meld) | Space Complexity | Description |
 | :--- | :--- | :--- | :--- | :--- |
 | **Binomial Heap** | Priority Queue | $\mathcal{O}(1) / \mathcal{O}(\log N) / \mathcal{O}(\log N)$ | $\mathcal{O}(N)$ | Collection of binomial trees supporting fast heap merges. |
@@ -372,21 +372,21 @@ This suite includes over **100+ interactive, memory-audited data structures and 
 | **Knuth-Morris-Pratt (KMP)** | Pattern Matching | $\mathcal{O}(N + M)$ | $\mathcal{O}(M)$ | String search using partial match failure function table. |
 | **Rabin-Karp Algorithm** | Pattern Matching | $\mathcal{O}(N + M)$ | $\mathcal{O}(1)$ | Rolling hash string search supporting multi-pattern lookup. |
 
-### 12. Probabilistic Data Structures (Menu Option 16)
+### 12. Probabilistic Data Structures (Menu Option 15)
 | Data Structure | Category | Time Complexity | Space Complexity | Description |
 | :--- | :--- | :--- | :--- | :--- |
 | **Bloom Filter** | Membership Estimator | $\mathcal{O}(k)$ | $\mathcal{O}(m)$ | Space-efficient set membership test with configurable false positive rate. |
 | **Count-Min Sketch** | Frequency Estimator | $\mathcal{O}(k)$ | $\mathcal{O}(w \cdot d)$ | Sub-linear memory stream frequency estimation matrix. |
 | **HyperLogLog (HLL)** | Cardinality Estimator | $\mathcal{O}(1)$ | $\mathcal{O}(\log \log N)$ | Estimates unique element counts using harmonic mean of zero-runs. |
 
-### 13. Spatial & Multi-Dimensional Indexing (Menu Option 17)
+### 13. Spatial & Multi-Dimensional Indexing (Menu Option 16)
 | Index Structure | Category | Time Complexity (Search / Insert) | Space Complexity | Description |
 | :--- | :--- | :--- | :--- | :--- |
 | **k-d Tree** | Spatial Indexing | $\mathcal{O}(\log N) / \mathcal{O}(\log N)$ | $\mathcal{O}(N)$ | $k$-dimensional point search tree for nearest-neighbor queries. |
 | **QuadTree** | Spatial Partitioning | $\mathcal{O}(\log N) / \mathcal{O}(\log N)$ | $\mathcal{O}(N)$ | 2D space recursive quadrant partitioning tree. |
 | **R-Tree** | Bounding Box Index | $\mathcal{O}(\log_M N) / \mathcal{O}(\log_M N)$ | $\mathcal{O}(N)$ | Minimum Bounding Rectangle (MBR) spatial indexing. |
 
-### 14. Error Correction & Integrity Algorithms (Menu Option 13)
+### 14. Error Correction & Integrity Algorithms (Menu Option 8)
 | Algorithm | Category | Time Complexity | Space Complexity | Description |
 | :--- | :--- | :--- | :--- | :--- |
 | **Checksum Validation** | Data Integrity | $\mathcal{O}(N)$ | $\mathcal{O}(1)$ | Simple additive sum verification across byte streams. |
@@ -395,7 +395,7 @@ This suite includes over **100+ interactive, memory-audited data structures and 
 | **Vertical Redundancy Check (VRC)** | Error Detection | $\mathcal{O}(N)$ | $\mathcal{O}(1)$ | Single parity bit verification per character. |
 | **Longitudinal Redundancy Check (LRC)** | Error Detection | $\mathcal{O}(N)$ | $\mathcal{O}(1)$ | Block parity bit calculation across character streams. |
 
-### 15. Process Synchronization Simulators (Menu Option 14)
+### 15. Process Synchronization Simulators (Menu Option 9 → 2)
 | Simulator / Problem | Category | Complexity | Description |
 | :--- | :--- | :--- | :--- |
 | **Peterson's Algorithm** | Concurrency | $\mathcal{O}(1)$ per step | 2-process mutual exclusion with flags and turn variables. |
@@ -403,7 +403,7 @@ This suite includes over **100+ interactive, memory-audited data structures and 
 | **Readers-Writers Problem** | Semaphore Sync | $\mathcal{O}(1)$ per access | Priority reader/writer access control via semaphores. |
 | **Producer-Consumer Problem** | Bounded Buffer | $\mathcal{O}(1)$ per item | Bounded buffer synchronization with mutexes and condition variables. |
 
-### 16. Cache Simulator & Eviction Policies (Menu Option 15)
+### 16. Cache Simulator & Eviction Policies (Menu Option 18)
 | Eviction Policy | Category | Time Complexity | Description |
 | :--- | :--- | :--- | :--- |
 | **Least Recently Used (LRU)** | Cache Replacement | $\mathcal{O}(1)$ | Evicts page with oldest access timestamp. |
@@ -412,7 +412,7 @@ This suite includes over **100+ interactive, memory-audited data structures and 
 | **CLOCK (Second-Chance)** | Cache Replacement | $\mathcal{O}(1)$ avg | Circular buffer pointer approximation of LRU using reference bits. |
 | **Optimal (Belady's OPT)** | Theoretical Limit | $\mathcal{O}(N)$ | Evicts page that will not be used for longest time in future. |
 
-### 17. Backtracking Algorithms
+### 17. Backtracking Algorithms (Menu Option 10)
 | Algorithm / Problem | Category | Time Complexity | Space Complexity | Description |
 | :--- | :--- | :--- | :--- | :--- |
 | **Knight's Tour Problem** | Backtracking | $\mathcal{O}(8^{N^2})$ | $\mathcal{O}(N^2)$ | Warnsdorff's heuristic knight's tour board traversal. |
@@ -421,7 +421,7 @@ This suite includes over **100+ interactive, memory-audited data structures and 
 | **Subset Sum Problem** | Backtracking | $\mathcal{O}(2^N)$ | $\mathcal{O}(N)$ | Finds subsets matching target sum using pruning. |
 | **Rat in a Maze** | Backtracking | $\mathcal{O}(2^{N^2})$ | $\mathcal{O}(N^2)$ | Grid maze pathfinding from source to destination. |
 
-### 18. Hashing & Collision Resolution
+### 18. Hashing & Collision Resolution (Menu Option 6)
 | Hash Technique | Category | Time Complexity (Avg / Worst) | Space Complexity | Description |
 | :--- | :--- | :--- | :--- | :--- |
 | **Separate Chaining** | Open Hashing | $\mathcal{O}(1) / \mathcal{O}(N)$ | $\mathcal{O}(N + M)$ | Collision resolution via linked lists per table bucket. |
@@ -429,7 +429,7 @@ This suite includes over **100+ interactive, memory-audited data structures and 
 | **Quadratic Probing** | Closed Hashing | $\mathcal{O}(1) / \mathcal{O}(N)$ | $\mathcal{O}(M)$ | Open addressing with quadratic step $i^2$ probing. |
 | **Double Hashing** | Closed Hashing | $\mathcal{O}(1) / \mathcal{O}(N)$ | $\mathcal{O}(M)$ | Open addressing using independent secondary hash function. |
 
-### 19. CPU & Job Scheduling Algorithms
+### 19. CPU & Job Scheduling Algorithms (Menu Option 9 → 1)
 | Scheduling Policy | Category | Preemptive | Complexity | Description |
 | :--- | :--- | :--- | :--- | :--- |
 | **First-Come First-Served (FCFS)** | CPU Scheduling | No | $\mathcal{O}(N \log N)$ | Non-preemptive arrival order job execution. |
@@ -439,7 +439,7 @@ This suite includes over **100+ interactive, memory-audited data structures and 
 | **Preemptive Priority Scheduling** | CPU Scheduling | Yes | $\mathcal{O}(N \log N)$ | Preemptive higher-priority job execution. |
 | **Round Robin (RR)** | CPU Scheduling | Yes | $\mathcal{O}(N)$ | Preemptive time-slice quantum round-robin scheduler. |
 
-### 20. Bit Manipulation & Bitwise Operations
+### 20. Bit Manipulation & Bitwise Operations (Menu Option 14)
 | Bitwise Feature | Category | Time Complexity | Description |
 | :--- | :--- | :--- | :--- |
 | **Basic Bitwise Operations** | Bit Operations | $\mathcal{O}(1)$ | Set, clear, toggle, and test individual bit positions. |
@@ -447,7 +447,7 @@ This suite includes over **100+ interactive, memory-audited data structures and 
 | **Bitwise Applications** | Bit Operations | $\mathcal{O}(1)$ | Single number finder, subset generation, and XOR tricks. |
 | **Interactive Bit Visualizer** | Bit Visualization | $\mathcal{O}(1)$ | Step-by-step 32-bit register bitwise visualizer. |
 
-### 21. System Utilities: Telemetry, Memory Inspector & Serialization (Menu Options 10, 11, 18)
+### 21. System Utilities: Telemetry, Memory Inspector & Serialization (Menu Options 17, 19)
 | Utility Feature | Category | Description |
 | :--- | :--- | :--- |
 | **Sorting Telemetry Dashboard** | Performance Audit | Real-time comparative execution metrics, comparison counters, and swap timers. |


### PR DESCRIPTION
### Description
This PR resolves an inconsistency between the "Menu Option N" references in the `README.md` and the actual `case` statements mapping in `src/main.c`. As new features were added to the CLI, the README drifted out of sync.

Specifically:
- Updated 16 outdated or missing menu option numbers in the README.
- Added explicit submenu paths (e.g. `Menu Option 5 → 2`) to eliminate ambiguity when a top-level menu choice branches into a submenu, addressing the stretch goal mentioned in the issue.

### Related Issue
Closes #1217

### Type of Change
- Documentation update

### Checklist
- I have read the `CONTRIBUTING.md` guidelines.
- My changes generate no new compiler warnings.
- I have updated the documentation accordingly.
