### PR TITLE
fix: off-by-one in bit_manipulation basic ops (fixes #1218)

### DIFF
--- a/src/bit_manipulation/basic_ops.c
+++ b/src/bit_manipulation/basic_ops.c
@@ -6,7 +6,7 @@
  */
 int set_bit(int n, int k)
 {
-    if (k < 0 || k >= 31)
+    if (k < 0 || k >= 32)
     {
         return n;
     }
@@ -19,7 +19,7 @@ int set_bit(int n, int k)
  */
 int clear_bit(int n, int k)
 {
-    if (k < 0 || k >= 31)
+    if (k < 0 || k >= 32)
     {
         return n;
     }
@@ -32,7 +32,7 @@ int clear_bit(int n, int k)
  */
 int toggle_bit(int n, int k)
 {
-    if (k < 0 || k >= 31)
+    if (k < 0 || k >= 32)
     {
         return n;
     }
@@ -46,7 +46,7 @@ int toggle_bit(int n, int k)
  */
 int check_bit(int n, int k)
 {
-    if (k < 0 || k >= 31)
+    if (k < 0 || k >= 32)
     {
         return 0;
     }

--- a/tests/bit_manipulation/test_bits.c
+++ b/tests/bit_manipulation/test_bits.c
@@ -9,6 +9,8 @@ void test_set_bit(void)
     assert(set_bit(0, 3) == 8);
     assert(set_bit(5, 1) == 7);
     assert(set_bit(-1, 0) == -1); /* all bits already set */
+    assert(set_bit(0, 31) == (int)0x80000000);
+    assert(set_bit(0, 32) == 0);
 
     printf("set_bit tests passed\n");
 }
@@ -19,6 +21,8 @@ void test_clear_bit(void)
     assert(clear_bit(7, 0) == 6);
     assert(clear_bit(8, 3) == 0);
     assert(clear_bit(0, 5) == 0); /* no-op: bit already clear */
+    assert(clear_bit((int)0x80000000, 31) == 0);
+    assert(clear_bit((int)0x80000000, 32) == (int)0x80000000);
 
     printf("clear_bit tests passed\n");
 }
@@ -29,6 +33,8 @@ void test_toggle_bit(void)
     assert(toggle_bit(0, 2) == 4);
     assert(toggle_bit(7, 1) == 5);
     assert(toggle_bit(toggle_bit(10, 0), 0) == 10); /* double toggle = no change */
+    assert(toggle_bit(0, 31) == (int)0x80000000);
+    assert(toggle_bit(0, 32) == 0);
 
     printf("toggle_bit tests passed\n");
 }
@@ -40,6 +46,8 @@ void test_check_bit(void)
     assert(check_bit(5, 1) == 0); /* 5 = 101, bit 1 is clear */
     assert(check_bit(5, 2) == 1); /* 5 = 101, bit 2 is set */
     assert(check_bit(0, 7) == 0); /* no bits set */
+    assert(check_bit((int)0x80000000, 31) == 1);
+    assert(check_bit(0, 32) == 0);
 
     printf("check_bit tests passed\n");
 }


### PR DESCRIPTION
Fixes #1218.

This PR addresses an off-by-one bug in the basic bit manipulation operations where the bound check incorrectly excluded the 31st bit (the sign bit on 32-bit integers). 

### Changes made:
- **`src/bit_manipulation/basic_ops.c`**: Updated the boundary validation check from `k >= 31` to `k >= 32` in `set_bit`, `clear_bit`, `toggle_bit`, and `check_bit`. This allows these functions to operate correctly on bit `31`.
- **`tests/bit_manipulation/test_bits.c`**: Added tests across all four functions to assert that:
  - Operations on the 31st bit work as expected.
  - The 32nd bit remains correctly rejected (out-of-bounds).

### Testing:
- Re-compiled and executed the test suite (`tests/bit_manipulation/test_bits.c`).
- All tests (including the new boundary assertions) passed successfully.
