### PR TITLE
fix: prevent out-of-bounds access in max_array and min_array on empty strings

### DIFF
--- a/src/data_structures/array.c
+++ b/src/data_structures/array.c
@@ -1,4 +1,5 @@
 #include "array.h"
+#include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>
 
@@ -37,6 +38,10 @@ void print_array(const int arr[], int length_of_array)
 
 int max_array(const int arr[], int length_of_array)
 {
+    if (length_of_array <= 0)
+    {
+        return INT_MIN;
+    }
     int max_element = arr[0];
     for (int i = 1; i < length_of_array; i++)
     {
@@ -50,6 +55,10 @@ int max_array(const int arr[], int length_of_array)
 
 int min_array(const int arr[], int length_of_array)
 {
+    if (length_of_array <= 0)
+    {
+        return INT_MAX;
+    }
     int min_element = arr[0];
     for (int i = 1; i < length_of_array; i++)
     {

--- a/tests/data_structures/test_array.c
+++ b/tests/data_structures/test_array.c
@@ -1,5 +1,6 @@
 #include "array.h"
 #include <assert.h>
+#include <limits.h>
 #include <stdio.h>
 
 /* swap tests */
@@ -89,6 +90,17 @@ void test_negative_values()
     printf("Array negative value test passed\n");
 }
 
+/* empty array edge case */
+void test_empty_array()
+{
+    int arr[] = {1, 2, 3};
+
+    assert(max_array(arr, 0) == INT_MIN);
+    assert(min_array(arr, 0) == INT_MAX);
+
+    printf("Array empty array test passed\n");
+}
+
 int main()
 {
 
@@ -99,6 +111,7 @@ int main()
     test_max_array();
     test_min_array();
     test_negative_values();
+    test_empty_array();
 
     printf("All array tests passed\n");
 


### PR DESCRIPTION
(Fixes #1223)

### Problem
`max_array` and `min_array` in `src/data_structures/array.c` access `arr[0]` without checking if the array is empty, causing undefined behavior when `length_of_array <= 0`.

### Fix
- Added an early-return guard in `max_array` to return `INT_MIN` for empty arrays.
- Added an early-return guard in `min_array` to return `INT_MAX` for empty arrays.
- Added `#include <limits.h>` in both source and test files.
- Added `test_empty_array()` in `tests/data_structures/test_array.c` to verify the fix.

### Verification
Compiled with `gcc -Wall -Wextra -Werror` — 0 warnings, 0 errors. All 8 tests pass.
