### PR TITLE
feat: complete separate chaining hash table with search and delete

### DIFF
--- a/demos/cache_simulator/cache_demo.c
+++ b/demos/cache_simulator/cache_demo.c
@@ -45,8 +45,9 @@ void cache_simulator_demo(void)
         cache_init(&cache, capacity);
 
         char ref_str[256];
-        int ref_status = safe_input_string(
-            ref_str, sizeof(ref_str), "Enter page reference string (e.g., 1,2,3,4,1,2), or 'X' to exit: ");
+        int ref_status =
+            safe_input_string(ref_str, sizeof(ref_str),
+                              "Enter page reference string (e.g., 1,2,3,4,1,2), or 'X' to exit: ");
         if (ref_status == INPUT_EXIT_SIGNAL)
         {
             return;

--- a/demos/compression/compression_demo.c
+++ b/demos/compression/compression_demo.c
@@ -160,7 +160,8 @@ static void run_lzw_demo(void)
 
     char input[256];
     int input_status = safe_input_string(
-        input, sizeof(input), "Enter a string to compress (e.g., TOBEORNOTTOBEORTOBEORNOT), or 'X' to exit: ");
+        input, sizeof(input),
+        "Enter a string to compress (e.g., TOBEORNOTTOBEORTOBEORNOT), or 'X' to exit: ");
     if (input_status == INPUT_EXIT_SIGNAL)
     {
         return;
@@ -220,8 +221,8 @@ static void run_bwt_mtf_demo(void)
     display_header("Burrows-Wheeler (BWT) & Move-To-Front (MTF)");
 
     char input[256];
-    int input_status =
-        safe_input_string(input, sizeof(input), "Enter a string to transform (e.g., banana), or 'X' to exit: ");
+    int input_status = safe_input_string(
+        input, sizeof(input), "Enter a string to transform (e.g., banana), or 'X' to exit: ");
     if (input_status == INPUT_EXIT_SIGNAL)
     {
         return;

--- a/demos/dynamic_programming/lcs_demo.c
+++ b/demos/dynamic_programming/lcs_demo.c
@@ -15,16 +15,16 @@ void lcs_demo(void)
 
         printf("\nLCS Demo\n");
 
-        int status_X =
-            safe_input_string(X, sizeof(X), "Enter first string (no spaces, max 99 chars), or 'X' to exit: ");
+        int status_X = safe_input_string(
+            X, sizeof(X), "Enter first string (no spaces, max 99 chars), or 'X' to exit: ");
         if (status_X == INPUT_EXIT_SIGNAL)
         {
             printf("\nExiting LCS demo...\n");
             return;
         }
 
-        int status_Y =
-            safe_input_string(Y, sizeof(Y), "Enter second string (no spaces, max 99 chars), or 'X' to exit: ");
+        int status_Y = safe_input_string(
+            Y, sizeof(Y), "Enter second string (no spaces, max 99 chars), or 'X' to exit: ");
         if (status_Y == INPUT_EXIT_SIGNAL)
         {
             printf("\nExiting LCS demo...\n");

--- a/demos/string_algorithms/kmp_demo.c
+++ b/demos/string_algorithms/kmp_demo.c
@@ -17,16 +17,16 @@ void kmp_demo(void)
 
         printf("\nKnuth-Morris-Pratt (KMP) Demo\n");
 
-        int status_T =
-            safe_input_string(text, sizeof(text), "Enter text (no spaces, max 99 chars), or 'X' to exit: ");
+        int status_T = safe_input_string(text, sizeof(text),
+                                         "Enter text (no spaces, max 99 chars), or 'X' to exit: ");
         if (status_T == INPUT_EXIT_SIGNAL)
         {
             printf("\nExiting demo...\n");
             return;
         }
 
-        int status_P =
-            safe_input_string(pattern, sizeof(pattern), "Enter pattern (no spaces, max 99 chars), or 'X' to exit: ");
+        int status_P = safe_input_string(
+            pattern, sizeof(pattern), "Enter pattern (no spaces, max 99 chars), or 'X' to exit: ");
         if (status_P == INPUT_EXIT_SIGNAL)
         {
             printf("\nExiting demo...\n");

--- a/demos/string_algorithms/naive_string_matching_demo.c
+++ b/demos/string_algorithms/naive_string_matching_demo.c
@@ -13,16 +13,16 @@ void naive_string_matching_demo(void)
 
         printf("\nNaive String Matching Demo\n");
 
-        int status_T =
-            safe_input_string(text, sizeof(text), "Enter text (no spaces, max 99 chars), or 'X' to exit: ");
+        int status_T = safe_input_string(text, sizeof(text),
+                                         "Enter text (no spaces, max 99 chars), or 'X' to exit: ");
         if (status_T == INPUT_EXIT_SIGNAL)
         {
             printf("\nExiting demo...\n");
             return;
         }
 
-        int status_P =
-            safe_input_string(pattern, sizeof(pattern), "Enter pattern (no spaces, max 99 chars), or 'X' to exit: ");
+        int status_P = safe_input_string(
+            pattern, sizeof(pattern), "Enter pattern (no spaces, max 99 chars), or 'X' to exit: ");
         if (status_P == INPUT_EXIT_SIGNAL)
         {
             printf("\nExiting demo...\n");

--- a/demos/string_algorithms/rabin_karp_demo.c
+++ b/demos/string_algorithms/rabin_karp_demo.c
@@ -19,16 +19,16 @@ void rabin_karp_demo(void)
 
         printf("\nRabin-Karp Algorithm Demo\n");
 
-        int status_T =
-            safe_input_string(text, sizeof(text), "Enter text (no spaces, max 99 chars), or 'X' to exit: ");
+        int status_T = safe_input_string(text, sizeof(text),
+                                         "Enter text (no spaces, max 99 chars), or 'X' to exit: ");
         if (status_T == INPUT_EXIT_SIGNAL)
         {
             printf("\nExiting demo...\n");
             return;
         }
 
-        int status_P =
-            safe_input_string(pattern, sizeof(pattern), "Enter pattern (no spaces, max 99 chars), or 'X' to exit: ");
+        int status_P = safe_input_string(
+            pattern, sizeof(pattern), "Enter pattern (no spaces, max 99 chars), or 'X' to exit: ");
         if (status_P == INPUT_EXIT_SIGNAL)
         {
             printf("\nExiting demo...\n");

--- a/demos/trees/avl_demo.c
+++ b/demos/trees/avl_demo.c
@@ -70,7 +70,8 @@ void avl_demo(void)
         if (option == 2)
         {
             char path[256];
-            int path_status = safe_input_string(path, sizeof(path), "\nenter filepath to load from:- ");
+            int path_status =
+                safe_input_string(path, sizeof(path), "\nenter filepath to load from:- ");
             if (path_status == INPUT_EXIT_SIGNAL)
             {
                 continue;
@@ -227,7 +228,8 @@ void avl_demo(void)
             else if (traversal_choice == 6)
             {
                 char path[256];
-                int path_status = safe_input_string(path, sizeof(path), "\nenter filepath to save to:- ");
+                int path_status =
+                    safe_input_string(path, sizeof(path), "\nenter filepath to save to:- ");
                 if (path_status != INPUT_EXIT_SIGNAL)
                 {
                     if (serialize_avl_to_file(root, path))

--- a/demos/trees/bst_demo.c
+++ b/demos/trees/bst_demo.c
@@ -35,7 +35,8 @@ void binary_search_tree_demo(void)
         if (option == 2)
         {
             char path[256];
-            int path_status = safe_input_string(path, sizeof(path), "\nenter filepath to load from:- ");
+            int path_status =
+                safe_input_string(path, sizeof(path), "\nenter filepath to load from:- ");
             if (path_status == INPUT_EXIT_SIGNAL)
             {
                 continue;
@@ -203,7 +204,8 @@ void binary_search_tree_demo(void)
             else if (bst_traversal_choice == 7)
             {
                 char path[256];
-                int path_status = safe_input_string(path, sizeof(path), "\nenter filepath to save to:- ");
+                int path_status =
+                    safe_input_string(path, sizeof(path), "\nenter filepath to save to:- ");
                 if (path_status != INPUT_EXIT_SIGNAL)
                 {
                     if (serialize_bst_to_file(head, path))

--- a/features/file_exporter/file_exporter_demo.c
+++ b/features/file_exporter/file_exporter_demo.c
@@ -35,7 +35,8 @@ void file_exporter_demo(void)
 
         char dest_dir[256] = {0};
         int input_res = safe_input_string(
-            dest_dir, sizeof(dest_dir), "\nEnter destination directory to export files (e.g. ./exported_files): ");
+            dest_dir, sizeof(dest_dir),
+            "\nEnter destination directory to export files (e.g. ./exported_files): ");
         if (input_res == INPUT_EXIT_SIGNAL)
         {
             printf("\nExiting File Exporter Dashboard...\n");

--- a/src/hashing/hash.h
+++ b/src/hashing/hash.h
@@ -13,7 +13,18 @@ int linear_probing_search(int arr[], int length_of_array, int search_val);
 void hashing_algorithms_demo(void);
 int hash_function(int value, int length_of_array);
 void separate_chaining_demo(void);
-bool separate_chaining_insert(Node* table[], int length_of_array, int value);
+
+// Insert a value into a separate chaining hash table.
+// Returns 1 on success, -1 on hash error, -2 on invalid arguments or malloc failure.
+int separate_chaining_insert(Node* table[], int length_of_array, int value);
+
+// Search for a value in a separate chaining hash table.
+// Returns 1 if found, -1 if not found, -2 on invalid arguments.
+int separate_chaining_search(Node* table[], int length_of_array, int value);
+
+// Delete a value from a separate chaining hash table.
+// Returns 1 on success, -1 if not found, -2 on invalid arguments.
+int separate_chaining_delete(Node* table[], int length_of_array, int value);
 void quadratic_probing_demo(void);
 bool quadratic_probing_insert(int arr[], int length_of_array, int value);
 int quadratic_probing_search(int arr[], int length_of_array, int search_val);

--- a/src/hashing/separate_chaining.c
+++ b/src/hashing/separate_chaining.c
@@ -1,22 +1,77 @@
 #include "hash.h"
 #include "safe_input.h"
 #include "sll.h"
+#include <stdint.h>
 #include <stdio.h>
 #include <string.h>
 
-bool separate_chaining_insert(Node* table[], int length_of_array, int value)
+// Returns 1 on success, -1 on hash error, -2 on invalid arguments or malloc failure
+int separate_chaining_insert(Node* table[], int length_of_array, int value)
 {
     if (length_of_array <= 0 || table == NULL)
     {
-        return false;
+        return -2;
     }
 
     int hash_location = hash_function(value, length_of_array);
     if (hash_location == -1)
     {
-        return false;
+        return -1;
     }
 
-    sll_insertAtEnd(&table[hash_location], (void*)(intptr_t)value);
-    return true;
+    int result = sll_insertAtEnd(&table[hash_location], (void*)(intptr_t)value);
+    if (result == -1)
+    {
+        return -2;
+    }
+    return 1;
+}
+
+// Returns 1 if found, -1 if not found, -2 on invalid arguments
+int separate_chaining_search(Node* table[], int length_of_array, int value)
+{
+    if (length_of_array <= 0 || table == NULL)
+    {
+        return -2;
+    }
+
+    int hash_location = hash_function(value, length_of_array);
+    if (hash_location == -1)
+    {
+        return -1;
+    }
+
+    Node* current = table[hash_location];
+    while (current != NULL)
+    {
+        if ((intptr_t)current->data == (intptr_t)value)
+        {
+            return 1;
+        }
+        current = current->next;
+    }
+    return -1;
+}
+
+// Returns 1 on success, -1 if not found, -2 on invalid arguments
+int separate_chaining_delete(Node* table[], int length_of_array, int value)
+{
+    if (length_of_array <= 0 || table == NULL)
+    {
+        return -2;
+    }
+
+    int hash_location = hash_function(value, length_of_array);
+    if (hash_location == -1)
+    {
+        return -1;
+    }
+
+    int result =
+        sll_deleteByValue(&table[hash_location], (void*)(intptr_t)value, NULL, NULL);
+    if (result == 1)
+    {
+        return 1;
+    }
+    return -1;
 }

--- a/src/hashing/separate_chaining.c
+++ b/src/hashing/separate_chaining.c
@@ -67,8 +67,7 @@ int separate_chaining_delete(Node* table[], int length_of_array, int value)
         return -1;
     }
 
-    int result =
-        sll_deleteByValue(&table[hash_location], (void*)(intptr_t)value, NULL, NULL);
+    int result = sll_deleteByValue(&table[hash_location], (void*)(intptr_t)value, NULL, NULL);
     if (result == 1)
     {
         return 1;

--- a/src/utils/algorithm_search.c
+++ b/src/utils/algorithm_search.c
@@ -324,8 +324,8 @@ void run_algorithm_search_menu(void)
     display_header("Interactive Algorithm Quick-Search Finder");
 
     char query[64] = {0};
-    int status =
-        safe_input_string(query, sizeof(query), "\nEnter search keyword (e.g. 'dijkstra', 'avl', 'sort'): ");
+    int status = safe_input_string(query, sizeof(query),
+                                   "\nEnter search keyword (e.g. 'dijkstra', 'avl', 'sort'): ");
     if (status == INPUT_EXIT_SIGNAL || strlen(query) == 0)
     {
         printf("\nExiting interactive algorithm finder...\n");

--- a/src/utils/safe_input_string.c
+++ b/src/utils/safe_input_string.c
@@ -17,7 +17,7 @@ int safe_input_string(char* buffer, size_t buffer_size, const char* prompt)
         fflush(stdout);
         if (fgets(buffer, buffer_size, stdin) == NULL)
         {
-            return 0; 
+            return 0;
         }
 
         size_t len = strlen(buffer);
@@ -32,7 +32,7 @@ int safe_input_string(char* buffer, size_t buffer_size, const char* prompt)
             while ((c = getchar()) != '\n' && c != EOF)
                 ;
         }
-        if (len == 0) 
+        if (len == 0)
         {
             continue;
         }

--- a/tests/hashing/test_separate_chaining.c
+++ b/tests/hashing/test_separate_chaining.c
@@ -1,0 +1,190 @@
+#include "hash.h"
+#include "sll.h"
+#include <assert.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <string.h>
+
+/* Forward declarations */
+int hash_function(int value, int length_of_array);
+int separate_chaining_insert(Node* table[], int length_of_array, int value);
+int separate_chaining_search(Node* table[], int length_of_array, int value);
+int separate_chaining_delete(Node* table[], int length_of_array, int value);
+void delete_sll(Node* head, void (*free_data)(void*));
+
+#define TABLE_SIZE 10
+
+static void init_table(Node* table[], int size)
+{
+    for (int i = 0; i < size; i++)
+    {
+        table[i] = NULL;
+    }
+}
+
+static void cleanup_table(Node* table[], int size)
+{
+    for (int i = 0; i < size; i++)
+    {
+        delete_sll(table[i], NULL);
+        table[i] = NULL;
+    }
+}
+
+void test_insert()
+{
+    Node* table[TABLE_SIZE];
+    init_table(table, TABLE_SIZE);
+
+    assert(separate_chaining_insert(table, TABLE_SIZE, 10) == 1);
+    assert(separate_chaining_insert(table, TABLE_SIZE, 20) == 1);
+    assert(separate_chaining_insert(table, TABLE_SIZE, 30) == 1);
+
+    cleanup_table(table, TABLE_SIZE);
+    printf("Separate chaining insert test passed\n");
+}
+
+void test_search_found()
+{
+    Node* table[TABLE_SIZE];
+    init_table(table, TABLE_SIZE);
+
+    separate_chaining_insert(table, TABLE_SIZE, 42);
+    separate_chaining_insert(table, TABLE_SIZE, 99);
+    separate_chaining_insert(table, TABLE_SIZE, 7);
+
+    assert(separate_chaining_search(table, TABLE_SIZE, 42) == 1);
+    assert(separate_chaining_search(table, TABLE_SIZE, 99) == 1);
+    assert(separate_chaining_search(table, TABLE_SIZE, 7) == 1);
+
+    cleanup_table(table, TABLE_SIZE);
+    printf("Separate chaining search found test passed\n");
+}
+
+void test_search_not_found()
+{
+    Node* table[TABLE_SIZE];
+    init_table(table, TABLE_SIZE);
+
+    separate_chaining_insert(table, TABLE_SIZE, 10);
+    separate_chaining_insert(table, TABLE_SIZE, 20);
+
+    assert(separate_chaining_search(table, TABLE_SIZE, 999) == -1);
+    assert(separate_chaining_search(table, TABLE_SIZE, 0) == -1);
+
+    cleanup_table(table, TABLE_SIZE);
+    printf("Separate chaining search not found test passed\n");
+}
+
+void test_delete_found()
+{
+    Node* table[TABLE_SIZE];
+    init_table(table, TABLE_SIZE);
+
+    separate_chaining_insert(table, TABLE_SIZE, 50);
+    separate_chaining_insert(table, TABLE_SIZE, 60);
+
+    assert(separate_chaining_search(table, TABLE_SIZE, 50) == 1);
+    assert(separate_chaining_delete(table, TABLE_SIZE, 50) == 1);
+    assert(separate_chaining_search(table, TABLE_SIZE, 50) == -1);
+
+    /* Other values should remain intact */
+    assert(separate_chaining_search(table, TABLE_SIZE, 60) == 1);
+
+    cleanup_table(table, TABLE_SIZE);
+    printf("Separate chaining delete found test passed\n");
+}
+
+void test_delete_not_found()
+{
+    Node* table[TABLE_SIZE];
+    init_table(table, TABLE_SIZE);
+
+    separate_chaining_insert(table, TABLE_SIZE, 10);
+
+    assert(separate_chaining_delete(table, TABLE_SIZE, 999) == -1);
+
+    /* Original value should still exist */
+    assert(separate_chaining_search(table, TABLE_SIZE, 10) == 1);
+
+    cleanup_table(table, TABLE_SIZE);
+    printf("Separate chaining delete not found test passed\n");
+}
+
+void test_invalid_args()
+{
+    Node* table[TABLE_SIZE];
+    init_table(table, TABLE_SIZE);
+
+    /* NULL table */
+    assert(separate_chaining_insert(NULL, TABLE_SIZE, 10) == -2);
+    assert(separate_chaining_search(NULL, TABLE_SIZE, 10) == -2);
+    assert(separate_chaining_delete(NULL, TABLE_SIZE, 10) == -2);
+
+    /* Zero length */
+    assert(separate_chaining_insert(table, 0, 10) == -2);
+    assert(separate_chaining_search(table, 0, 10) == -2);
+    assert(separate_chaining_delete(table, 0, 10) == -2);
+
+    /* Negative length */
+    assert(separate_chaining_insert(table, -1, 10) == -2);
+    assert(separate_chaining_search(table, -1, 10) == -2);
+    assert(separate_chaining_delete(table, -1, 10) == -2);
+
+    cleanup_table(table, TABLE_SIZE);
+    printf("Separate chaining invalid args test passed\n");
+}
+
+void test_collision_handling()
+{
+    Node* table[TABLE_SIZE];
+    init_table(table, TABLE_SIZE);
+
+    /* Insert many values that may collide into same buckets */
+    for (int i = 0; i < 50; i++)
+    {
+        assert(separate_chaining_insert(table, TABLE_SIZE, i) == 1);
+    }
+
+    /* All should be searchable */
+    for (int i = 0; i < 50; i++)
+    {
+        assert(separate_chaining_search(table, TABLE_SIZE, i) == 1);
+    }
+
+    /* Delete every other value */
+    for (int i = 0; i < 50; i += 2)
+    {
+        assert(separate_chaining_delete(table, TABLE_SIZE, i) == 1);
+    }
+
+    /* Deleted values should not be found, others should remain */
+    for (int i = 0; i < 50; i++)
+    {
+        if (i % 2 == 0)
+        {
+            assert(separate_chaining_search(table, TABLE_SIZE, i) == -1);
+        }
+        else
+        {
+            assert(separate_chaining_search(table, TABLE_SIZE, i) == 1);
+        }
+    }
+
+    cleanup_table(table, TABLE_SIZE);
+    printf("Separate chaining collision handling test passed\n");
+}
+
+int main()
+{
+    test_insert();
+    test_search_found();
+    test_search_not_found();
+    test_delete_found();
+    test_delete_not_found();
+    test_invalid_args();
+    test_collision_handling();
+
+    printf("All separate chaining tests passed\n");
+    return 0;
+}


### PR DESCRIPTION
Closes #1225

### Description
This PR completes the Separate Chaining hash table by adding `separate_chaining_search` and `separate_chaining_delete`, making it consistent with the other collision resolution algorithms.

Per project standards, all functions in this module (including the existing `separate_chaining_insert`) have been updated to return `int` instead of `bool`.

### Changes
- Changed return type of `separate_chaining_insert` from `bool` to `int` and added error handling for malloc failure.
- Implemented `separate_chaining_search`.
- Implemented `separate_chaining_delete` (reuses the existing `sll_deleteByValue` utility).
- Updated `hash.h` declarations and documented the specific integer return codes for all functions.
- Added comprehensive unit tests in a new file: `tests/hashing/test_separate_chaining.c`

### Return Codes
| Code | Meaning |
|------|---------|
| `1` | Success (inserted / found / deleted) |
| `-1` | Not found / hash error |
| `-2` | Invalid arguments / allocation failure |

### Verification
All 7 new tests and the existing hash tests pass perfectly with `gcc -Wall -Wextra -Werror`.
