### PR TITLE
fix: flush stdin on oversized input in safe_input_int

### DIFF
--- a/src/utils/safe_input_int.c
+++ b/src/utils/safe_input_int.c
@@ -35,6 +35,13 @@ int safe_input_int(int* input, const char* prompt, int min_val, int max_val)
             return INPUT_EXIT_SIGNAL;
         }
 
+        if (strchr(buffer, '\n') == NULL)
+        {
+            int c;
+            while ((c = getchar()) != '\n' && c != EOF)
+                ;
+        }
+
         // Remove trailing newline, if present
         trim_newline(buffer);
 


### PR DESCRIPTION
### Description
This PR fixes a stream pollution issue in `safe_input_int` when a user inputs a string longer than the designated `INPUT_BUFFER_SIZE`. 

Previously, if `fgets` truncated the input, the remaining characters were left in the `stdin` stream, causing subsequent input prompts to consume the leftover characters and potentially spiral into error loops.

**Changes made:**
- Added a check using `strchr(buffer, '\n')` immediately after `fgets`.
- If a newline is not found, the remainder of the input stream is safely flushed using `getchar()` until `\n` or `EOF` is reached.
- Code has been formatted using `clang-format`.

Closes #1213