### PR TITLE
feat: add Tower of Hanoi backtracking algorithm

### DIFF
--- a/demos/backtracking/backtracking_demo.c
+++ b/demos/backtracking/backtracking_demo.c
@@ -17,8 +17,9 @@ void backtracking_demo(void)
                                    "\nenter 3 for Rat in a Maze"
                                    "\nenter 4 for Graph Coloring"
                                    "\nenter 5 for Knight's Tour"
+                                   "\nenter 6 for Tower of Hanoi"
                                    "\nenter choice (\'-1\' to exit, or \'help\') : ",
-                                   1, 5);
+                                   1, 6);
 
         if (bt_status == INPUT_EXIT_SIGNAL)
         {
@@ -50,6 +51,10 @@ void backtracking_demo(void)
             case 5:
                 display_header("Knight's Tour");
                 knights_tour_demo();
+                break;
+            case 6:
+                display_header("Tower of Hanoi");
+                tower_of_hanoi_demo();
                 break;
         }
     }

--- a/demos/backtracking/tower_of_hanoi_demo.c
+++ b/demos/backtracking/tower_of_hanoi_demo.c
@@ -1,0 +1,42 @@
+#include "backtracking.h"
+#include "config.h"
+#include "safe_input.h"
+#include <stdio.h>
+
+void tower_of_hanoi_demo(void)
+{
+    while (1)
+    {
+        int N;
+        // Cap at 8 for console formatting visibility
+        int status = safe_input_int(
+            &N, "\nEnter the number of disks (between 1 and 8), or -1 to exit: ", 1, 8);
+        if (status == INPUT_EXIT_SIGNAL)
+        {
+            printf("\nExiting Tower of Hanoi...\n");
+            return;
+        }
+        if (status == 0)
+        {
+            continue;
+        }
+
+        // Initialize state tracker for the 3 pegs
+        int pegs[3][10] = {0};
+        int counts[3] = {N, 0, 0};
+
+        // Peg 0 starts with N disks, from largest (N) at bottom to smallest (1) at top
+        for (int i = 0; i < N; i++)
+        {
+            pegs[0][i] = N - i;
+        }
+
+        printf("\nStarting Tower of Hanoi for %d disks...\n", N);
+        dynamic_sleep();
+
+        // Pass 0 (source), 1 (auxiliary), 2 (destination)
+        int total_moves = solve_tower_of_hanoi(N, 0, 1, 2, N, pegs, counts);
+
+        printf("\nSuccessfully completed Tower of Hanoi in %d moves!\n", total_moves);
+    }
+}

--- a/src/backtracking/backtracking.h
+++ b/src/backtracking/backtracking.h
@@ -19,8 +19,11 @@ void sudoku_demo(void);
 void rat_in_maze_demo(void);
 void graph_coloring_demo(void);
 void knights_tour_demo(void);
+void tower_of_hanoi_demo(void);
 
 // Exposed Solvers & Visualization Helper Functions
+int solve_tower_of_hanoi(int n, int source, int auxiliary, int destination, int disks,
+                         int pegs[3][10], int counts[3]);
 bool solve_n_queens_util(int N, char board[8][8], int col);
 
 bool solve_sudoku_util(int grid[6][6], int row, int col);

--- a/src/backtracking/tower_of_hanoi.c
+++ b/src/backtracking/tower_of_hanoi.c
@@ -1,0 +1,124 @@
+#include "backtracking.h"
+#include "config.h"
+#include <stdio.h>
+#include <stdlib.h>
+
+#define MAX_HANOI_DISKS 10
+
+static const char* disk_colors[] = {
+    "\x1b[0m",  // Reset
+    "\x1b[31m", // 1 Red
+    "\x1b[32m", // 2 Green
+    "\x1b[33m", // 3 Yellow
+    "\x1b[34m", // 4 Blue
+    "\x1b[35m", // 5 Magenta
+    "\x1b[36m", // 6 Cyan
+    "\x1b[91m", // 7 Bright Red
+    "\x1b[92m", // 8 Bright Green
+    "\x1b[93m", // 9 Bright Yellow
+    "\x1b[94m"  // 10 Bright Blue
+};
+
+// Internal function to print the current state of the pegs
+static void print_towers_state(int total_disks, int pegs[3][MAX_HANOI_DISKS], int counts[3])
+{
+    printf("\n");
+    // Print row by row, from top (total_disks - 1) to bottom (0)
+    for (int row = total_disks - 1; row >= 0; row--)
+    {
+        for (int p = 0; p < 3; p++)
+        {
+            if (row < counts[p])
+            {
+                int disk_size = pegs[p][row];
+                int spaces = total_disks - disk_size;
+
+                // Print leading spaces
+                for (int i = 0; i < spaces; i++)
+                    printf(" ");
+
+                // Print left half of disk with color
+                printf("%s", disk_colors[disk_size % 11]);
+                for (int i = 0; i < disk_size; i++)
+                    printf("=");
+
+                // Print peg
+                printf("\x1b[0m|");
+
+                // Print right half of disk with color
+                printf("%s", disk_colors[disk_size % 11]);
+                for (int i = 0; i < disk_size; i++)
+                    printf("=");
+                printf("\x1b[0m");
+
+                // Print trailing spaces
+                for (int i = 0; i < spaces; i++)
+                    printf(" ");
+            }
+            else
+            {
+                // Print empty peg line
+                for (int i = 0; i < total_disks; i++)
+                    printf(" ");
+                printf("|");
+                for (int i = 0; i < total_disks; i++)
+                    printf(" ");
+            }
+            printf("   "); // Space between pegs
+        }
+        printf("\n");
+    }
+
+    // Base
+    for (int p = 0; p < 3; p++)
+    {
+        for (int i = 0; i < total_disks * 2 + 1; i++)
+            printf("-");
+        printf("   ");
+    }
+    printf("\n");
+
+    // Labels
+    int center = total_disks;
+    for (int p = 0; p < 3; p++)
+    {
+        for (int i = 0; i < center; i++)
+            printf(" ");
+        printf("%c", 'A' + p);
+        for (int i = 0; i < center; i++)
+            printf(" ");
+        printf("   ");
+    }
+    printf("\n\n");
+
+    dynamic_sleep();
+}
+
+int solve_tower_of_hanoi(int n, int source, int auxiliary, int destination, int disks,
+                         int pegs[3][MAX_HANOI_DISKS], int counts[3])
+{
+    if (n == 1)
+    {
+        // Move one disk from source to destination
+        int disk = pegs[source][counts[source] - 1];
+        counts[source]--;
+
+        pegs[destination][counts[destination]] = disk;
+        counts[destination]++;
+
+        // Visualize if disks > 0 (during tests we can pass disks=0 to skip prints)
+        if (disks > 0)
+        {
+            printf("\nMove disk %d from %c to %c:\n", disk, 'A' + source, 'A' + destination);
+            print_towers_state(disks, pegs, counts);
+        }
+        return 1;
+    }
+
+    int moves = 0;
+    moves += solve_tower_of_hanoi(n - 1, source, destination, auxiliary, disks, pegs, counts);
+    moves += solve_tower_of_hanoi(1, source, auxiliary, destination, disks, pegs, counts);
+    moves += solve_tower_of_hanoi(n - 1, auxiliary, source, destination, disks, pegs, counts);
+
+    return moves;
+}

--- a/tests/backtracking/test_backtracking.c
+++ b/tests/backtracking/test_backtracking.c
@@ -64,15 +64,31 @@ void test_knights_tour()
 void test_tower_of_hanoi()
 {
     printf("[TEST] Running Tower of Hanoi...\n");
-    int pegs[3][10];
-    int counts[3];
-    // For testing, we pass disks=0 so it skips the visual printout
-    assert(solve_tower_of_hanoi(3, 0, 1, 2, 0, pegs, counts) == 7 &&
+
+    // Test 3 disks
+    int pegs3[3][10] = {0};
+    int counts3[3] = {3, 0, 0};
+    for (int i = 0; i < 3; i++)
+        pegs3[0][i] = 3 - i;
+    assert(solve_tower_of_hanoi(3, 0, 1, 2, 0, pegs3, counts3) == 7 &&
            "3 disks should take exactly 7 moves");
-    assert(solve_tower_of_hanoi(4, 0, 1, 2, 0, pegs, counts) == 15 &&
+
+    // Test 4 disks
+    int pegs4[3][10] = {0};
+    int counts4[3] = {4, 0, 0};
+    for (int i = 0; i < 4; i++)
+        pegs4[0][i] = 4 - i;
+    assert(solve_tower_of_hanoi(4, 0, 1, 2, 0, pegs4, counts4) == 15 &&
            "4 disks should take exactly 15 moves");
-    assert(solve_tower_of_hanoi(5, 0, 1, 2, 0, pegs, counts) == 31 &&
+
+    // Test 5 disks
+    int pegs5[3][10] = {0};
+    int counts5[3] = {5, 0, 0};
+    for (int i = 0; i < 5; i++)
+        pegs5[0][i] = 5 - i;
+    assert(solve_tower_of_hanoi(5, 0, 1, 2, 0, pegs5, counts5) == 31 &&
            "5 disks should take exactly 31 moves");
+
     printf("  --> PASSED\n");
 }
 

--- a/tests/backtracking/test_backtracking.c
+++ b/tests/backtracking/test_backtracking.c
@@ -60,6 +60,22 @@ void test_knights_tour()
     printf("  --> PASSED\n");
 }
 
+// --- 6. Tower of Hanoi Tests ---
+void test_tower_of_hanoi()
+{
+    printf("[TEST] Running Tower of Hanoi...\n");
+    int pegs[3][10];
+    int counts[3];
+    // For testing, we pass disks=0 so it skips the visual printout
+    assert(solve_tower_of_hanoi(3, 0, 1, 2, 0, pegs, counts) == 7 &&
+           "3 disks should take exactly 7 moves");
+    assert(solve_tower_of_hanoi(4, 0, 1, 2, 0, pegs, counts) == 15 &&
+           "4 disks should take exactly 15 moves");
+    assert(solve_tower_of_hanoi(5, 0, 1, 2, 0, pegs, counts) == 31 &&
+           "5 disks should take exactly 31 moves");
+    printf("  --> PASSED\n");
+}
+
 int main()
 {
     printf("\n===================================\n");
@@ -71,6 +87,7 @@ int main()
     test_rat_in_maze();
     test_graph_coloring();
     test_knights_tour();
+    test_tower_of_hanoi();
 
     printf("\n===================================\n");
     printf(" ✅ ALL BACKTRACKING TESTS PASSED!\n");


### PR DESCRIPTION
Closes #1238

### Description
This PR implements the missing Tower of Hanoi algorithm to the `src/backtracking/` module! It includes a custom frame-by-frame visualizer in the terminal using ANSI colors.

### Changes Made
- **`tower_of_hanoi.c`**: Added the core recursive function. I also built a state array tracker and an ASCII renderer to draw the 3 pegs side-by-side. The pipes (`|`) are rendered straight through the disks, which are colored distinctively using ANSI escapes to make the animation easy to follow.
- **`tower_of_hanoi_demo.c`**: Added the CLI menu wrapper so users can specify `N` (up to 8).
- **`backtracking_demo.c`**: Appended Tower of Hanoi to the main backtracking menu.
- **`test_backtracking.c`**: Wrote tests asserting the exact mathematical move counts ($2^n - 1$) for disks of size 3, 4, and 5.

### Verification
- Ran mathematical test assertions successfully.
- Verified smooth CLI animation with `dynamic_sleep()`.