### PR TITLE
feat: add circ_queue_is_empty and circ_queue_is_full utility functions to Circular Queue

### DIFF
--- a/demos/data_structures/circular_queue_demo.c
+++ b/demos/data_structures/circular_queue_demo.c
@@ -38,7 +38,7 @@ void circular_queue_demo(void)
             int circ_queue_choice;
             int circ_queue_status =
                 safe_input_int(&circ_queue_choice,
-                               "\n\nenter 1 for enqueue, 2 for dequeue and '-1' for exit:- ", 1, 2);
+                               "\n\nenter 1 for enqueue, 2 for dequeue, 3 to check if empty, 4 to check if full and '-1' for exit:- ", 1, 4);
 
             if (circ_queue_status == INPUT_EXIT_SIGNAL)
             {
@@ -102,6 +102,20 @@ void circular_queue_demo(void)
                 }
 
                 display_circ_queue(&rollnos);
+            }
+            else if (circ_queue_choice == 3)
+            {
+                if (circ_queue_is_empty(&rollnos))
+                    printf("\nQueue is empty.\n");
+                else
+                    printf("\nQueue is not empty.\n");
+            }
+            else if (circ_queue_choice == 4)
+            {
+                if (circ_queue_is_full(&rollnos))
+                    printf("\nQueue is full.\n");
+                else
+                    printf("\nQueue is not full.\n");
             }
         }
     }

--- a/src/data_structures/circular_queue.c
+++ b/src/data_structures/circular_queue.c
@@ -74,3 +74,17 @@ void display_circ_queue(Queue* queue_ptr)
         i = (i + 1) % queue_ptr->N;
     }
 }
+
+bool circ_queue_is_empty(const Queue* q)
+{
+    if (q == NULL || q->arr == NULL)
+        return true;
+    return q->rear == q->front;
+}
+
+bool circ_queue_is_full(const Queue* q)
+{
+    if (q == NULL || q->arr == NULL)
+        return false;
+    return ((q->rear + 1) % q->N) == q->front;
+}

--- a/src/data_structures/queue.h
+++ b/src/data_structures/queue.h
@@ -27,6 +27,12 @@ void* dequeue(Queue* queue_ptr);
 // Display the contents of a circular queue.
 void display_circ_queue(Queue* queue_ptr);
 
+// Check whether a circular queue is empty. Returns true if empty, false otherwise.
+bool circ_queue_is_empty(const Queue* q);
+
+// Check whether a circular queue is full. Returns true if full, false otherwise.
+bool circ_queue_is_full(const Queue* q);
+
 // Run the circular queue demonstration module.
 void circular_queue_demo(void);
 

--- a/tests/data_structures/test_circ_queue.c
+++ b/tests/data_structures/test_circ_queue.c
@@ -118,6 +118,44 @@ void test_wraparound()
     printf("Circular queue wraparound test passed\n");
 }
 
+void test_is_empty_is_full()
+{
+    assert(circ_queue_is_empty(NULL) == true);
+    assert(circ_queue_is_full(NULL) == false);
+
+    Queue q;
+    init_circ_queue(4, &q);
+
+    assert(circ_queue_is_empty(&q) == true);
+    assert(circ_queue_is_full(&q) == false);
+
+    enqueue(&q, returnMallocInt(10));
+    assert(circ_queue_is_empty(&q) == false);
+    assert(circ_queue_is_full(&q) == false);
+
+    enqueue(&q, returnMallocInt(20));
+    enqueue(&q, returnMallocInt(30));
+    assert(circ_queue_is_empty(&q) == false);
+    assert(circ_queue_is_full(&q) == true);
+
+    int* val = dequeue(&q);
+    assert(val != NULL);
+    free(val);
+    assert(circ_queue_is_full(&q) == false);
+
+    val = dequeue(&q);
+    assert(val != NULL);
+    free(val);
+    val = dequeue(&q);
+    assert(val != NULL);
+    free(val);
+    assert(circ_queue_is_empty(&q) == true);
+
+    destroy_circ_queue(&q);
+
+    printf("Circular queue is_empty/is_full test passed\n");
+}
+
 int main()
 {
     test_init();
@@ -125,6 +163,7 @@ int main()
     test_underflow();
     test_overflow();
     test_wraparound();
+    test_is_empty_is_full();
 
     printf("All circular queue tests passed\n");
     return 0;


### PR DESCRIPTION
Closes #1248

### Problem
The Circular Queue had no way to check if it's empty or full, unlike the Deque which already has `deque_is_empty` and `deque_is_full`.


### Changes
- `queue.h` — added declarations for `circ_queue_is_empty` and `circ_queue_is_full`
- `circular_queue.c` — implemented both functions using the same logic already present in `enqueue`/`dequeue` guards
- `circular_queue_demo.c` — added menu options 3 (Is Empty?) and 4 (Is Full?)
- `test_circ_queue.c` — added `test_is_empty_is_full()` covering NULL, empty, partial, full, and drain cases
