### PR TITLE
fix: add missing Stack data structure to Legacy and TUI menus

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -93,13 +93,13 @@ void run_legacy_menu(void)
                 while (1)
                 {
                     int ds_type;
-                    int ds_status =
-                        safe_input_int(&ds_type,
-                                       "\n--- Core Data Structures ---\n"
-                                       "1. Linear Data Structures (SLL, DLL, Array, Queue, PQ)\n"
-                                       "2. Circular Data Structures (CQ, SCLL, DCLL, Deque)\n"
-                                       "\nenter choice (\'-1\' to exit) : ",
-                                       1, 2);
+                    int ds_status = safe_input_int(
+                        &ds_type,
+                        "\n--- Core Data Structures ---\n"
+                        "1. Linear Data Structures (SLL, DLL, Array, Queue, PQ, Stack)\n"
+                        "2. Circular Data Structures (CQ, SCLL, DCLL, Deque)\n"
+                        "\nenter choice (\'-1\' to exit) : ",
+                        1, 2);
                     if (ds_status == INPUT_EXIT_SIGNAL)
                         break;
                     if (ds_status == 0)
@@ -117,8 +117,9 @@ void run_legacy_menu(void)
                                                             "3. Array\n"
                                                             "4. Priority Queue\n"
                                                             "5. Linear Queue\n"
+                                                            "6. Stack\n"
                                                             "\nenter choice (\'-1\' to exit) : ",
-                                                            1, 5);
+                                                            1, 6);
                             if (lin_status == INPUT_EXIT_SIGNAL)
                                 break;
                             if (lin_status == 0)
@@ -133,6 +134,8 @@ void run_legacy_menu(void)
                                 priority_queue_demo();
                             else if (lin_choice == 5)
                                 simple_queue_demo();
+                            else if (lin_choice == 6)
+                                stack_demo();
                         }
                     }
                     else if (ds_type == 2)

--- a/tui/tui.c
+++ b/tui/tui.c
@@ -169,6 +169,7 @@ static Entry ENTRIES[] = {
     {"Array", array_demo, 0, 0, 2},
     {"Priority Queue", priority_queue_demo, 0, 0, 2},
     {"Linear Queue", simple_queue_demo, 0, 0, 2},
+    {"Stack", stack_demo, 0, 0, 2},
     {"Circular Data Structures", NULL, 1, 0, 1},
     {"Circular Queue", circular_queue_demo, 0, 0, 2},
     {"Singly Circular Linked List", scll_demo, 0, 0, 2},


### PR DESCRIPTION
Closes #1252

### Description
This PR resolves the issue where the Stack data structure demo was completely inaccessible to users because it was omitted from the application menus.

### Changes Made
- **`src/main.c`**: Added `Stack` to the "Linear Data Structures" string prompt, updated the `safe_input_int` bounds, and added the conditional routing to properly launch `stack_demo()`.
- **`tui/tui.c`**: Inserted a new item block for the Stack directly into the `ENTRIES` array, ensuring it renders dynamically in the modern Terminal UI.

### Verification
- Ran strict syntax check via `gcc -fsyntax-only` to ensure no compiler warnings/errors were introduced.
