### PR TITLE
fix: render initial state in Tower of Hanoi before first move

### DIFF
--- a/demos/backtracking/tower_of_hanoi_demo.c
+++ b/demos/backtracking/tower_of_hanoi_demo.c
@@ -34,6 +34,9 @@ void tower_of_hanoi_demo(void)
         printf("\nStarting Tower of Hanoi for %d disks...\n", N);
         dynamic_sleep();
 
+        printf("\nInitial State:\n");
+        print_towers_state(N, pegs, counts);
+
         // Pass 0 (source), 1 (auxiliary), 2 (destination)
         int total_moves = solve_tower_of_hanoi(N, 0, 1, 2, N, pegs, counts);
 

--- a/src/backtracking/backtracking.h
+++ b/src/backtracking/backtracking.h
@@ -22,6 +22,7 @@ void knights_tour_demo(void);
 void tower_of_hanoi_demo(void);
 
 // Exposed Solvers & Visualization Helper Functions
+void print_towers_state(int total_disks, int pegs[3][10], int counts[3]);
 int solve_tower_of_hanoi(int n, int source, int auxiliary, int destination, int disks,
                          int pegs[3][10], int counts[3]);
 bool solve_n_queens_util(int N, char board[8][8], int col);

--- a/src/backtracking/tower_of_hanoi.c
+++ b/src/backtracking/tower_of_hanoi.c
@@ -20,7 +20,7 @@ static const char* disk_colors[] = {
 };
 
 // Internal function to print the current state of the pegs
-static void print_towers_state(int total_disks, int pegs[3][MAX_HANOI_DISKS], int counts[3])
+void print_towers_state(int total_disks, int pegs[3][MAX_HANOI_DISKS], int counts[3])
 {
     printf("\n");
     // Print row by row, from top (total_disks - 1) to bottom (0)


### PR DESCRIPTION
Closes #1258

### Description
This PR resolves a confusing visual bug in the Tower of Hanoi demo where the animation skipped straight to the state *after* the first move, denying the user the chance to see the fully constructed initial tower.

### Changes Made
- **`src/backtracking/tower_of_hanoi.c`**: Removed the `static` keyword from `print_towers_state()`.
- **`src/backtracking/backtracking.h`**: Exposed the `print_towers_state()` function declaration so it can be called externally.
- **`demos/backtracking/tower_of_hanoi_demo.c`**: Inserted a call to `print_towers_state()` with an "Initial State:" label right before kicking off the `solve_tower_of_hanoi()` recursion.

### Verification
- Verified that compiling via `gcc -fsyntax-only` passes cleanly.
