### PR TITLE
fix: Enable inserting 0 in Linear, Quadratic, and Double Hashing

### DIFF
--- a/demos/hashing/double_hashing_demo.c
+++ b/demos/hashing/double_hashing_demo.c
@@ -1,5 +1,6 @@
 #include "array.h"
 #include "hash.h"
+#include <limits.h>
 #include <safe_input.h>
 #include <stdbool.h>
 #include <stdio.h>
@@ -27,13 +28,16 @@ void double_hashing_demo(void)
 
         int arr[length_of_array];
 
-        memset(arr, 0, sizeof(arr)); // empty slot is represented by 0
+        for (int i = 0; i < length_of_array; i++)
+        {
+            arr[i] = INT_MIN; // empty slot is represented by INT_MIN
+        }
 
         // ---------- insertion phase ----------
         while (1)
         {
             int value_status = safe_input_int(
-                &value, "\nenter a value between 1 and 1000 (enter '-1' to search elements):- ", 1,
+                &value, "\nenter a value between 0 and 1000 (enter '-1' to search elements):- ", 0,
                 1000);
 
             if (value_status == INPUT_EXIT_SIGNAL)
@@ -62,7 +66,7 @@ void double_hashing_demo(void)
             int search_val;
             int search_status = safe_input_int(
                 &search_val, "\nenter a value to search in the hash table (enter '-1' to exit):- ",
-                1, 1000);
+                0, 1000);
 
             if (search_status == INPUT_EXIT_SIGNAL)
             {

--- a/demos/hashing/linear_probing_demo.c
+++ b/demos/hashing/linear_probing_demo.c
@@ -1,5 +1,6 @@
 #include "array.h"
 #include "hash.h"
+#include <limits.h>
 #include <safe_input.h>
 #include <stdbool.h>
 #include <stdio.h>
@@ -27,12 +28,15 @@ void linear_probing_demo(void)
 
         int arr[length_of_array]; // allocate memory for the array
 
-        memset(arr, 0, sizeof(arr)); // setting all values to zero
+        for (int i = 0; i < length_of_array; i++)
+        {
+            arr[i] = INT_MIN; // empty slot is represented by INT_MIN
+        }
 
         while (1)
         {
             int value_status = safe_input_int(
-                &value, "\nenter a value between 1 and 1000 (enter '-1' to search elements):- ", 1,
+                &value, "\nenter a value between 0 and 1000 (enter '-1' to search elements):- ", 0,
                 1000);
 
             if (value_status == INPUT_EXIT_SIGNAL)
@@ -61,7 +65,7 @@ void linear_probing_demo(void)
             int search_val;
             int search_status = safe_input_int(
                 &search_val, "\nenter a value to search in the hash table (enter '-1' to exit):- ",
-                1, 1000);
+                0, 1000);
 
             if (search_status == INPUT_EXIT_SIGNAL)
             {

--- a/demos/hashing/quadratic_probing_demo.c
+++ b/demos/hashing/quadratic_probing_demo.c
@@ -1,5 +1,6 @@
 #include "array.h"
 #include "hash.h"
+#include <limits.h>
 #include <safe_input.h>
 #include <stdbool.h>
 #include <stdio.h>
@@ -27,12 +28,15 @@ void quadratic_probing_demo(void)
 
         int arr[length_of_array];
 
-        memset(arr, 0, sizeof(arr));
+        for (int i = 0; i < length_of_array; i++)
+        {
+            arr[i] = INT_MIN; // empty slot is represented by INT_MIN
+        }
 
         while (1)
         {
             int value_status = safe_input_int(
-                &value, "\nenter a value between 1 and 1000 (enter '-1' to search elements):- ", 1,
+                &value, "\nenter a value between 0 and 1000 (enter '-1' to search elements):- ", 0,
                 1000);
 
             if (value_status == INPUT_EXIT_SIGNAL)
@@ -62,7 +66,7 @@ void quadratic_probing_demo(void)
 
             int search_status = safe_input_int(
                 &search_value,
-                "\nenter a value to search in the hash table (enter '-1' to exit):- ", 1, 1000);
+                "\nenter a value to search in the hash table (enter '-1' to exit):- ", 0, 1000);
 
             if (search_status == INPUT_EXIT_SIGNAL)
             {

--- a/features/benchmark/benchmark_hashing.c
+++ b/features/benchmark/benchmark_hashing.c
@@ -1,6 +1,7 @@
 #define _GNU_SOURCE
 #include "../hashing/hash.h"
 #include "benchmark.h"
+#include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -14,22 +15,24 @@ typedef struct HashNode
 
 static void run_linear_probing(const int* keys, int m, int n)
 {
-    int* table = calloc(n, sizeof(int));
+    int* table = malloc(n * sizeof(int));
     if (!table)
         return;
+    for (int i = 0; i < n; i++)
+        table[i] = INT_MIN;
 
     for (int i = 0; i < m; i++)
     {
         int val = keys[i];
         int hash_loc = hash_function(val, n);
         int start = hash_loc;
-        while (table[hash_loc] != 0)
+        while (table[hash_loc] != INT_MIN)
         {
             hash_loc = (hash_loc + 1) % n;
             if (hash_loc == start)
                 break; // Table full
         }
-        if (table[hash_loc] == 0)
+        if (table[hash_loc] == INT_MIN)
         {
             table[hash_loc] = val;
         }
@@ -41,7 +44,7 @@ static void run_linear_probing(const int* keys, int m, int n)
         int val = keys[i];
         int hash_loc = hash_function(val, n);
         int start = hash_loc;
-        while (table[hash_loc] != 0)
+        while (table[hash_loc] != INT_MIN)
         {
             if (table[hash_loc] == val)
                 break;
@@ -56,9 +59,11 @@ static void run_linear_probing(const int* keys, int m, int n)
 
 static void run_quadratic_probing(const int* keys, int m, int n)
 {
-    int* table = calloc(n, sizeof(int));
+    int* table = malloc(n * sizeof(int));
     if (!table)
         return;
+    for (int i = 0; i < n; i++)
+        table[i] = INT_MIN;
 
     for (int i = 0; i < m; i++)
     {
@@ -67,7 +72,7 @@ static void run_quadratic_probing(const int* keys, int m, int n)
         for (int j = 0; j < n; j++)
         {
             int hash_loc = (base + j * j) % n;
-            if (table[hash_loc] == 0)
+            if (table[hash_loc] == INT_MIN)
             {
                 table[hash_loc] = val;
                 break;
@@ -85,7 +90,7 @@ static void run_quadratic_probing(const int* keys, int m, int n)
             int hash_loc = (base + j * j) % n;
             if (table[hash_loc] == val)
                 break;
-            if (table[hash_loc] == 0)
+            if (table[hash_loc] == INT_MIN)
                 break;
         }
     }
@@ -95,9 +100,11 @@ static void run_quadratic_probing(const int* keys, int m, int n)
 
 static void run_double_hashing(const int* keys, int m, int n)
 {
-    int* table = calloc(n, sizeof(int));
+    int* table = malloc(n * sizeof(int));
     if (!table)
         return;
+    for (int i = 0; i < n; i++)
+        table[i] = INT_MIN;
 
     for (int i = 0; i < m; i++)
     {
@@ -112,7 +119,7 @@ static void run_double_hashing(const int* keys, int m, int n)
         for (int j = 0; j < n; j++)
         {
             int hash_loc = (h1 + j * h2) % n;
-            if (table[hash_loc] == 0)
+            if (table[hash_loc] == INT_MIN)
             {
                 table[hash_loc] = val;
                 break;
@@ -136,7 +143,7 @@ static void run_double_hashing(const int* keys, int m, int n)
             int hash_loc = (h1 + j * h2) % n;
             if (table[hash_loc] == val)
                 break;
-            if (table[hash_loc] == 0)
+            if (table[hash_loc] == INT_MIN)
                 break;
         }
     }

--- a/src/hashing/double_hashing.c
+++ b/src/hashing/double_hashing.c
@@ -1,5 +1,6 @@
 #include "array.h"
 #include "hash.h"
+#include <limits.h>
 #include <safe_input.h>
 #include <stdbool.h>
 #include <stdio.h>
@@ -65,7 +66,7 @@ bool double_hashing_insert(int arr[], int length_of_array, int value)
             probe_location += length_of_array;
         }
 
-        if (arr[probe_location] == 0)
+        if (arr[probe_location] == INT_MIN)
         {
             arr[probe_location] = value;
             return true;
@@ -103,7 +104,7 @@ int double_hashing_search(int arr[], int length_of_array, int search_val)
             return probe_location;
         }
 
-        if (arr[probe_location] == 0)
+        if (arr[probe_location] == INT_MIN)
         {
             break;
         }

--- a/src/hashing/linear_probing.c
+++ b/src/hashing/linear_probing.c
@@ -1,5 +1,6 @@
 #include "array.h"
 #include "hash.h"
+#include <limits.h>
 #include <safe_input.h>
 #include <stdbool.h>
 #include <stdio.h>
@@ -57,7 +58,7 @@ bool linear_probing_insert(int arr[], int length_of_array, int value)
         return false;
     }
 
-    if (!arr[hash_location])
+    if (arr[hash_location] == INT_MIN)
     {
         arr[hash_location] = value; // inserting value at its hash location
         return true;
@@ -75,7 +76,7 @@ bool linear_probing_insert(int arr[], int length_of_array, int value)
             array_full = true;
             break;
         }
-    } while (arr[hash_location]);
+    } while (arr[hash_location] != INT_MIN);
 
     if (array_full)
         return false;
@@ -101,7 +102,7 @@ int linear_probing_search(int arr[], int length_of_array, int search_val)
             return hash_location;
         }
         hash_location = (hash_location + 1) % length_of_array;
-    } while (hash_location != start && arr[hash_location]);
+    } while (hash_location != start && arr[hash_location] != INT_MIN);
 
     return -1; // value not found
 }

--- a/src/hashing/quadratic_probing.c
+++ b/src/hashing/quadratic_probing.c
@@ -1,5 +1,6 @@
 #include "array.h"
 #include "hash.h"
+#include <limits.h>
 #include <safe_input.h>
 #include <stdbool.h>
 #include <stdio.h>
@@ -23,7 +24,7 @@ bool quadratic_probing_insert(int arr[], int length_of_array, int value)
         int probe_location =
             (int)(((long long)base_hash_location + (long long)i * i) % length_of_array);
 
-        if (!arr[probe_location])
+        if (arr[probe_location] == INT_MIN)
         {
             arr[probe_location] = value;
             return true;
@@ -55,7 +56,7 @@ int quadratic_probing_search(int arr[], int length_of_array, int search_val)
             return probe_location;
         }
 
-        if (!arr[probe_location])
+        if (arr[probe_location] == INT_MIN)
         {
             break; // stop searching if we hit an empty slot
         }


### PR DESCRIPTION
closes #1268
## Description

This PR fixes a critical bug in the array-based hash map implementations (`linear_probing`, `quadratic_probing`, and `double_hashing`) where the number `0` could not be inserted or correctly searched for. 

Previously, the arrays were initialized with `0`, and the probing logic relied on checking `!arr[location]` to determine if a slot was empty. This made it impossible to store `0` as an actual value.

## Changes Made
- Changed the empty slot sentinel value from `0` to `INT_MIN` in all three hash map implementations.
- Updated `demos/hashing/linear_probing_demo.c`, `demos/hashing/quadratic_probing_demo.c`, and `demos/hashing/double_hashing_demo.c` to explicitly loop and initialize arrays to `INT_MIN` instead of using `memset` to zero them out.
- Updated the CLI prompts in the demos to accept `0` as a valid input.
- Updated `features/benchmark/benchmark_hashing.c` to initialize tables with `INT_MIN` instead of relying on `calloc`.

## Verification
- The project compiles successfully with `gcc` without errors or warnings.
- Demos have been manually tested to ensure `0` can now be correctly inserted and looked up without issue.
