### PR TITLE
fix: add missing NULL and length validation in naive_string_matching

### DIFF
--- a/src/string_algorithms/naive_string_matching.c
+++ b/src/string_algorithms/naive_string_matching.c
@@ -6,8 +6,27 @@
 
 void naive_string_matching(const char* text, const char* pattern)
 {
+    if (text == NULL || pattern == NULL)
+    {
+        printf("Text or pattern is NULL.\n");
+        return;
+    }
+
     int n = strlen(text);
     int m = strlen(pattern);
+
+    if (m == 0 || n == 0)
+    {
+        printf("Text or pattern is empty.\n");
+        return;
+    }
+
+    if (m > n)
+    {
+        printf("Pattern is longer than text.\n");
+        return;
+    }
+
     int found = 0;
 
     for (int i = 0; i <= n - m; i++)


### PR DESCRIPTION
closes #1280

## Description
Added the missing safety guardrails in the `naive_string_matching` function (`src/string_algorithms/naive_string_matching.c`). 

### Changes Made
- Added `NULL` pointer checks for both `text` and `pattern` prior to calling `strlen()`.
- Added validation to check if either string is empty (`m == 0 || n == 0`).
- Added boundary condition to return early if the `pattern` is longer than the `text` (`m > n`).

These standard safety checks prevent segmentation faults and ensure the algorithm behaves consistently with others in the suite (e.g., `boyer_moore.c`).

