### PR TITLE
fix: add missing NULL pointer validation in rabin_karp_search

### DIFF
--- a/src/string_algorithms/rabin_karp.c
+++ b/src/string_algorithms/rabin_karp.c
@@ -11,6 +11,12 @@
 
 void rabin_karp_search(char* text, char* pattern, int q)
 {
+    if (text == NULL || pattern == NULL)
+    {
+        printf("Error: Text or pattern cannot be NULL.\n");
+        return;
+    }
+
     int m = strlen(pattern);
     int n = strlen(text);
     int i, j;


### PR DESCRIPTION
closed #1291 

## Description
Fixed a segmentation fault vulnerability in the `rabin_karp_search` function within `src/string_algorithms/rabin_karp.c`.

### Changes Made
- Added a `NULL` pointer guardrail for both `text` and `pattern` at the very beginning of the `rabin_karp_search` function. 
- Ensured these checks happen *before* calling `strlen()` to prevent the program from crashing on invalid inputs.

These updates bring `rabin_karp_search` in line with the safety standards used across the suite's other string algorithms. The entire test suite has been executed and verified locally.