### PR TITLE
fix: add missing defensive NULL pointer guards to tree algorithms

### DIFF
--- a/src/trees/bst.c
+++ b/src/trees/bst.c
@@ -137,6 +137,9 @@ void bst_print_ascii(const bstNode* root)
 
 int bst_insert(bstNode** head_ref, int value)
 {
+    if (head_ref == NULL)
+        return -1;
+
     if ((*head_ref) == NULL)
     {
         bstNode* node = malloc(sizeof(bstNode));


### PR DESCRIPTION
Resolves #1282 

While reviewing the Tree data structures, I noticed that bst_insert takes a double pointer (bstNode** head_ref) but immediately dereferences it without verifying if the pointer itself is valid. If NULL is passed, this causes an immediate segmentation fault.

This PR adds standard defensive NULL pointer validations to prevent hard crashes and ensure the API fails gracefully (returning -1) when passed invalid memory addresses.