### PR TITLE
chore: add GitHub Issue and Pull Request templates to streamline contributions

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,25 @@
+---
+name: Bug Report
+about: Create a report to help us improve the project
+title: "bug: "
+labels: bug
+assignees: ''
+---
+
+## Describe the bug
+A clear and concise description of what the bug is.
+
+## To Reproduce
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Run command '....'
+3. Input '....'
+4. See error
+
+## Expected behavior
+A clear and concise description of what you expected to happen.
+
+## Environment
+- OS: [e.g. Windows (WSL), Linux, macOS]
+- Compiler: [e.g. GCC, Clang]
+- Version: [e.g. Ubuntu 24.04]

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,16 @@
+---
+name: Feature Request
+about: Suggest an idea or new algorithm for this project
+title: "feat: "
+labels: enhancement
+assignees: ''
+---
+
+## Is your feature request related to a problem?
+A clear and concise description of what the problem is. Ex. "The current tree traversal lacks..."
+
+## Describe the solution you'd like
+A clear and concise description of what you want to happen.
+
+## Describe alternatives you've considered
+A clear and concise description of any alternative solutions or features you've considered.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -9,8 +9,8 @@ assignees: ''
 ## Is your feature request related to a problem?
 A clear and concise description of what the problem is. Ex. "The current tree traversal lacks..."
 
-## Describe the solution you'd like
+## Describe the feature you want to implement
 A clear and concise description of what you want to happen.
 
-## Describe alternatives you've considered
+## Describe the effect it will have on the application as a whole
 A clear and concise description of any alternative solutions or features you've considered.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,13 @@
+## Description
+Resolves #[Insert Issue Number Here]
+
+## Changes Made
+- [Describe the specific changes made in this PR]
+- 
+
+## Checklist
+- [ ] My code follows the style guidelines of this project (e.g., clang-format).
+- [ ] I have performed a self-review of my own code.
+- [ ] I have added/updated necessary Doxygen documentation (if applicable).
+- [ ] My changes generate no new warnings or memory leaks.
+- [ ] I have verified that the CI/CD pipeline passes.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,6 +8,5 @@ Resolves #[Insert Issue Number Here]
 ## Checklist
 - [ ] My code follows the style guidelines of this project (e.g., clang-format).
 - [ ] I have performed a self-review of my own code.
-- [ ] I have added/updated necessary Doxygen documentation (if applicable).
-- [ ] My changes generate no new warnings or memory leaks.
+- [ ] After making the changes I have compiled and ran the application and found no issues whatsoever.
 - [ ] I have verified that the CI/CD pipeline passes.


### PR DESCRIPTION
Resolves #1286 

As the repository grows, standardizing incoming contributions will save significant triage time. This PR adds standard GitHub templates to the .github/ directory:

PULL_REQUEST_TEMPLATE.md: Includes a checklist reminding contributors to run clang-format, self-review, and check for memory leaks before submitting.

bug_report.md: Prompts users for exact reproduction steps and environment details (OS/Compiler).

feature_request.md: Provides a clean structure for proposing new algorithms or data structures.

These will automatically populate in the text box whenever a contributor clicks "New Issue" or "New Pull Request" moving forward.