### PR TITLE
docs: Document Counting Sort in README and Interactive Help Manual

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,7 @@ This suite includes over **100+ interactive, memory-audited data structures and 
 | **Heap Sort** | Tree-based Sorting | $\mathcal{O}(N \log N) / \mathcal{O}(N \log N) / \mathcal{O}(N \log N)$ | $\mathcal{O}(1)$ | In-place comparison sort using binary max-heap heapify. |
 | **Radix Sort** | Non-comparison Sort | $\mathcal{O}(N \cdot k) / \mathcal{O}(N \cdot k) / \mathcal{O}(N \cdot k)$ | $\mathcal{O}(N + k)$ | Digit-by-digit distribution sort using counting sort buckets. |
 | **Bucket Sort** | Distribution Sort | $\mathcal{O}(N + k) / \mathcal{O}(N + k) / \mathcal{O}(N^2)$ | $\mathcal{O}(N)$ | Distributes elements into uniform floating-point buckets. |
+| **Counting Sort** | Non-comparison Sort | $\mathcal{O}(N + k) / \mathcal{O}(N + k) / \mathcal{O}(N + k)$ | $\mathcal{O}(N + k)$ | Integer sorting by counting element occurrences. |
 
 ### 4. Searching Algorithms (Menu Option 4)
 | Algorithm | Category | Time Complexity (Best / Avg / Worst) | Space Complexity | Description |

--- a/help/help_advanced_sorting_algorithms.c
+++ b/help/help_advanced_sorting_algorithms.c
@@ -20,6 +20,9 @@ void help_advanced_sorting_algorithms_menu(void)
     printf("RADIX SORT:\n");
     printf("    Non-comparison sort that processes digits from least to most significant.\n");
     printf("    O(D * (N + K)) where D is the number of digits.\n\n");
+    printf("COUNTING SORT:\n");
+    printf("    Integer sorting algorithm that counts the number of objects having distinct\n");
+    printf("    key values. O(N + K) time and space complexity, where K is the key range.\n\n");
 
     printf("\nPress [ENTER] to return...\n");
     press_enter_to_continue();


### PR DESCRIPTION
Closes #1285
### **Description**
Added Counting Sort to the project documentation, as it was previously fully implemented but missing from the public documentation pages.

### Changes Made:
- **`README.md`**: Added Counting Sort to the "Advanced Sorting Algorithms" table, clearly displaying its Time Complexity `O(N + K)` and Space Complexity `O(N + K)` along with a brief description.
- **Interactive Help Manual**: Updated `help/help_advanced_sorting_algorithms.c` to include an entry for Counting Sort. The menu now correctly describes how the algorithm works and provides its `O(N + K)` time and space complexity to users directly in the CLI.

