### PR TITLE
fix: add Adler-32 Checksum to TUI menu

### DIFF
--- a/tui/tui.c
+++ b/tui/tui.c
@@ -275,6 +275,7 @@ static Entry ENTRIES[] = {
     {"Infix to Prefix", infix_to_prefix_demo, 0, 0, 1},
 
     {"error_correction_algorithms", NULL, 1, 0, 0},
+    {"Adler-32 Checksum", adler32_demo, 0, 0, 1},
     {"Checksum (Sender)", checksum_demo, 0, 0, 1},
     {"Checksum (Receiver)", checksum_receiver_demo, 0, 0, 1},
     {"CRC (Sender)", crc_demo, 0, 0, 1},


### PR DESCRIPTION
Resolves #1274 

The Adler-32 algorithm was fully implemented and tested but was missing from the main Text User Interface (TUI) navigation menu.

This PR wires up the adler32_demo function into the ENTRIES registry in tui/tui.c so users can now easily select and run it from the "error_correction_algorithms" menu.
