### PR TITLE
fix: Add Boyer-Moore Search to TUI menu 

### DIFF
--- a/tui/tui.c
+++ b/tui/tui.c
@@ -304,6 +304,7 @@ static Entry ENTRIES[] = {
     {"Naive String Matching", naive_string_matching_demo, 0, 0, 1},
     {"KMP Search", kmp_demo, 0, 0, 1},
     {"Rabin-Karp Search", rabin_karp_demo, 0, 0, 1},
+    {"Boyer-Moore Search", boyer_moore_demo, 0, 0, 1},
     {"Suffix Array & Kasai's LCP", suffix_array_demo, 0, 0, 1},
     {"String Compression", compression_demo, 0, 0, 1},
 


### PR DESCRIPTION
closes #1303 

### Description:
- **TUI Integration**: Added the `boyer_moore_demo` to the `ENTRIES` array within `tui/tui.c` under the String Algorithms section.
- The Boyer-Moore String Search demo is now visible and runnable directly from the modern TUI menu.

