### PR TITLE
fix: Add missing NULL validation and TUI registration for Cocktail Shaker Sort

### DIFF
--- a/src/sorting_algorithms_n2/cocktail_shaker_sort.c
+++ b/src/sorting_algorithms_n2/cocktail_shaker_sort.c
@@ -2,6 +2,10 @@
 
 void cocktail_shaker_sort(int arr[], int n)
 {
+    if (arr == NULL || n <= 0)
+    {
+        return;
+    }
     int swapped = 1;
     int start = 0;
     int end = n - 1;

--- a/tui/tui.c
+++ b/tui/tui.c
@@ -207,6 +207,7 @@ static Entry ENTRIES[] = {
     {"Sorting Algorithms", NULL, 1, 0, 0},
     {"O(N^2) Family", NULL, 1, 0, 1},
     {"Bubble Sort", bubble_sort_optimized_demo, 0, 0, 2}, /* add fn when known */
+    {"Cocktail Shaker Sort", cocktail_shaker_sort_demo, 0, 0, 2},
     {"Selection Sort", selection_sort_demo, 0, 0, 2},
     {"Insertion Sort", insertion_sort_demo, 0, 0, 2},
     {"Shell Sort", shell_sort_demo, 0, 0, 2},


### PR DESCRIPTION

closes #1306

### Changes done:
- **Safety Guardrails**: Added strict `NULL` pointer and length bounds validations to the core algorithm in `src/sorting_algorithms_n2/cocktail_shaker_sort.c`. This completely prevents segmentation faults if the user passes invalid array parameters.
- **TUI Integration**: Re-wired the `cocktail_shaker_sort_demo` into the `ENTRIES` array inside `tui/tui.c` under the `O(N^2)`category. Users can now natively launch and interact with the algorithm from the modern TUI.
