### PR TITLE
ci: Add Code Coverage reporting (gcov) and Codecov integration

### DIFF
--- a/.github/workflows/codecoverage.yml
+++ b/.github/workflows/codecoverage.yml
@@ -1,0 +1,51 @@
+name: Code Coverage
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install build tools and lcov
+        run: sudo apt update && sudo apt install -y build-essential cmake libncurses-dev lcov
+
+      - name: Configure project with coverage
+        run: cmake -S . -B build -DENABLE_COVERAGE=ON
+
+      - name: Build project
+        run: cmake --build build --parallel
+
+      - name: Run tests
+        run: ctest --test-dir build --output-on-failure --verbose
+
+      - name: Generate coverage report
+        run: |
+          lcov --version
+          lcov --capture \
+            --directory build \
+            --output-file coverage.info \
+            --ignore-errors mismatch,unused
+          lcov --remove coverage.info \
+            '/usr/*' \
+            '*/tests/*' \
+            '*/demos/*' \
+            '*/features/*' \
+            '*/tui/*' \
+            --output-file coverage.info \
+            --ignore-errors unused
+          lcov --list coverage.info
+
+      - name: Upload to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          files: ./coverage.info
+          fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,14 @@ if(SANITIZE)
     set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fsanitize=address,undefined")
 endif()
 
+option(ENABLE_COVERAGE "Enable code coverage reporting" OFF)
+
+if(ENABLE_COVERAGE)
+    message(STATUS "Code coverage enabled")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} --coverage")
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} --coverage")
+endif()
+
 # Source directories
 set(SRC_DIRS
     help
@@ -170,5 +178,3 @@ if(DOXYGEN_FOUND)
         VERBATIM
     )
 endif()
-
-

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # C_DSA_interactive_suite
+[![codecov](https://codecov.io/gh/darshan2456/C_DSA_interactive_suite/graph/badge.svg)](https://codecov.io/gh/darshan2456/C_DSA_interactive_suite)
 
 A modular, console-based **Data Structures & Algorithms library** written entirely in **C**, built from scratch with pointer-level control, manual memory management (`malloc` / `free`), and defensive input validation.
 


### PR DESCRIPTION
closes #1300 

### Changes Made:
- **CMake Support**: Added the `ENABLE_COVERAGE` option to `CMakeLists.txt`. When set to `ON`, it automatically appends `--coverage` to both compiler and linker flags to track line execution.
- **Dedicated CI Workflow**: Created `.github/workflows/codecoverage.yml` to specifically handle building with coverage enabled, running `ctest`, and extracting the coverage using `lcov`. The `tests`, `demos`, and `features` folders are excluded to ensure accurate percentage metrics for the `src` folder. 
- **Codecov Integration**: Integrated the official `codecov/codecov-action@v4` action into the new workflow to automatically upload the generated `coverage.info` files tokenlessly.
- **README Update**: Appended the Markdown Codecov Badge to the very top of `README.md` to display the repository's coverage metrics.
