### PR TITLE
feat: Add Floyd's Cycle Detection (Tortoise and Hare) to Singly Linked List 

### DIFF
--- a/src/data_structures/sll.c
+++ b/src/data_structures/sll.c
@@ -330,3 +330,23 @@ int sll_deleteAtPosition(Node** head_ref, int position, void (*free_data)(void*)
     free(temp);
     return 1;
 }
+
+// Returns 1 if a cycle is detected, 0 if no cycle exists
+int sll_hasCycle(const Node* head)
+{
+    const Node* tortoise = head;
+    const Node* hare = head;
+
+    while (hare != NULL && hare->next != NULL)
+    {
+        tortoise = tortoise->next;
+        hare = hare->next->next;
+
+        if (tortoise == hare)
+        {
+            return 1;
+        }
+    }
+
+    return 0;
+}

--- a/src/data_structures/sll.h
+++ b/src/data_structures/sll.h
@@ -114,4 +114,12 @@ int sll_insertAtPosition(Node** head_ref, void* value, int position);
  */
 int sll_deleteAtPosition(Node** head_ref, int position, void (*free_data)(void*));
 
+/**
+ * @brief Detects whether a singly linked list contains a cycle using Floyd's
+ *        Cycle-Finding Algorithm (Tortoise and Hare).
+ * @param head Pointer to the head node.
+ * @return 1 if a cycle is detected, 0 if no cycle exists.
+ */
+int sll_hasCycle(const Node* head);
+
 #endif

--- a/tests/data_structures/test_sll.c
+++ b/tests/data_structures/test_sll.c
@@ -269,6 +269,62 @@ void test_edge_cases()
     printf("sll Edge case tests passed\n");
 }
 
+/* Test Floyd's cycle detection */
+void test_has_cycle()
+{
+    /* No cycle: NULL list */
+    assert(sll_hasCycle(NULL) == 0);
+
+    /* No cycle: single node */
+    int* v1 = malloc(sizeof(int));
+    *v1 = 1;
+    Node* head = NULL;
+    sll_insertAtEnd(&head, v1);
+    assert(sll_hasCycle(head) == 0);
+
+    /* No cycle: multiple nodes */
+    int* v2 = malloc(sizeof(int));
+    *v2 = 2;
+    int* v3 = malloc(sizeof(int));
+    *v3 = 3;
+    sll_insertAtEnd(&head, v2);
+    sll_insertAtEnd(&head, v3);
+    assert(sll_hasCycle(head) == 0);
+
+    /* Introduce a cycle: tail -> head */
+    Node* tail = head;
+    while (tail->next != NULL)
+        tail = tail->next;
+    tail->next = head; /* creates cycle */
+    assert(sll_hasCycle(head) == 1);
+
+    /* Break the cycle before freeing */
+    tail->next = NULL;
+    delete_sll(head, free);
+
+    /* Cycle in middle: tail -> second node */
+    int arr[] = {10, 20, 30, 40};
+    head = NULL;
+    for (int i = 0; i < 4; i++)
+    {
+        int* v = malloc(sizeof(int));
+        *v = arr[i];
+        sll_insertAtEnd(&head, v);
+    }
+    Node* second = head->next;
+    tail = head;
+    while (tail->next != NULL)
+        tail = tail->next;
+    tail->next = second; /* cycle: 40 -> 20 */
+    assert(sll_hasCycle(head) == 1);
+
+    /* Break cycle before freeing */
+    tail->next = NULL;
+    delete_sll(head, free);
+
+    printf("sll Cycle detection tests passed\n");
+}
+
 int main()
 {
     test_insert();
@@ -281,6 +337,7 @@ int main()
     test_delete_at_position();
     test_edge_cases();
     test_sll_advanced_edge_cases();
+    test_has_cycle();
 
     printf("All SLL tests passed\n");
     return 0;


### PR DESCRIPTION
Fixes #1314

### Changes Made:
- **Core Implementation** (`src/data_structures/sll.c`): Added `sll_hasCycle()` using Floyd's Cycle-Finding Algorithm. The function uses two `const Node*` pointers (tortoise and hare) — respecting the generic `void* data` design with zero type assumptions or casts. Runs in O(N) time and O(1) auxiliary space.
- **Header Update** (`src/data_structures/sll.h`): Added the declaration for `sll_hasCycle()` with a full Doxygen comment following the project style.
- **Test Coverage** (`tests/data_structures/test_sll.c`): Added `test_has_cycle()` covering all key scenarios:
  - NULL list
  - Single node (no cycle)
  - Linear list with no cycle
  - Full cycle (tail → head)
  - Mid-list cycle (tail → second node)
