### PR TITLE
ci: explicitly enable and enforce UndefinedBehaviorSanitizer (UBSan) in CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,11 +35,11 @@ jobs:
       - name: Memory check with valgrind
         run: cmake --build build --target valgrind
 
-      - name: Configure ASan build
+      - name: Configure ASan/UBSan build
         run: cmake -S . -B build-asan -DSANITIZE=ON
       
-      - name: Build ASan
+      - name: Build ASan/UBSan
         run: cmake --build build-asan --parallel
       
-      - name: Run ASan tests
-        run: ctest --test-dir build-asan --output-on-failure --verbose
+      - name: Run ASan/UBSan tests
+        run: UBSAN_OPTIONS=print_stacktrace=1:halt_on_error=1 ctest --test-dir build-asan --output-on-failure --verbose


### PR DESCRIPTION
## Description
Resolves #1302

## Changes Made
- Updated `.github/workflows/ci.yml` step labels to explicitly reflect that both **AddressSanitizer (ASan)** and **UndefinedBehaviorSanitizer (UBSan)** run concurrently during the `-DSANITIZE=ON` build step.
- Configured `UBSAN_OPTIONS=print_stacktrace=1:halt_on_error=1` during the `ctest` step so any undefined behavior (misaligned pointers, integer overflows, out-of-bounds bit shifts) immediately halts execution and prints a clear stack trace in PR checks.
- Confirmed `CMakeLists.txt` already compiles with `-fsanitize=address,undefined` and `-fno-sanitize-recover=all` under `SANITIZE=ON`.
- Preserved `LF` line endings.

## Checklist
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own changes.
- [x] I have verified that the CI/CD pipeline passes.