### PR TITLE
Fix: Handle KEY_RESIZE in the ncurses TUI to prevent layout mangling

### DIFF
--- a/tui/tui.c
+++ b/tui/tui.c
@@ -834,6 +834,10 @@ void tui_run(void)
 
         switch (ch)
         {
+            case KEY_RESIZE:
+                clear();
+                break;
+
             case '/':
             case 's':
             case 'S':


### PR DESCRIPTION
Fixes #1322
## Description
This PR fixes Issue #1322 where the `ncurses` TUI would mangle its text layout or crash due to out-of-bounds drawing if the user resized their terminal window while the menu was active.

### Changes Made:
- Added `case KEY_RESIZE:` to the `wgetch()` event loop switch statement inside `tui/tui.c`.
- Called `clear()` to safely wipe any artifacting off the screen and `break` so the next loop iteration naturally recreates and dynamically redraws the navigation, visualization, and status panes based on the updated dimensions.

### Verification:
- Built successfully using `cmake --build build`.
- Ran and passed `test_tui` via `ctest`.
