### PR TITLE
Fix: Data corruption in RLE and LZW compression edge-cases

### DIFF
--- a/src/compression/lzw.c
+++ b/src/compression/lzw.c
@@ -98,7 +98,8 @@ int lzw_encode(const char* input, int* output, int out_max)
 
             if (dict_size < LZW_MAX_CODES)
             {
-                strcpy(dict[dict_size].str, pc);
+                strncpy(dict[dict_size].str, pc, sizeof(dict[dict_size].str) - 1);
+                dict[dict_size].str[sizeof(dict[dict_size].str) - 1] = '\0';
                 dict_size++;
             }
             else

--- a/src/compression/lzw.c
+++ b/src/compression/lzw.c
@@ -98,16 +98,10 @@ int lzw_encode(const char* input, int* output, int out_max)
 
             if (dict_size < LZW_MAX_CODES)
             {
-                strncpy(dict[dict_size].str, pc, sizeof(dict[dict_size].str) - 1);
-                dict[dict_size].str[sizeof(dict[dict_size].str) - 1] = '\0';
+                strcpy(dict[dict_size].str, pc);
                 dict_size++;
             }
             else
-            {
-                reset_dict(dict, &dict_size);
-            }
-
-            if (dict_size >= LZW_MAX_CODES)
             {
                 reset_dict(dict, &dict_size);
             }

--- a/src/compression/rle.c
+++ b/src/compression/rle.c
@@ -33,7 +33,7 @@ int rle_encode(const char* input, char* output, int len, int out_max)
         i++;
 
         char temp[32];
-        int written = snprintf(temp, sizeof(temp), "%c%d", ch, count);
+        int written = snprintf(temp, sizeof(temp), "%c%d;", ch, count);
         if (written < 0 || written >= (int)sizeof(temp))
         {
             return -1;
@@ -87,6 +87,15 @@ int rle_decode(const char* input, int len, char* output, int out_max)
                 return -1;
             }
             i++;
+        }
+
+        if (i < len && input[i] == ';')
+        {
+            i++;
+        }
+        else
+        {
+            return -1;
         }
 
         for (int j = 0; j < count; j++)


### PR DESCRIPTION

Closes #1335

## Description
This PR resolves Issue #1335 by addressing data corruption edge-cases exposed by property-based fuzzing in the `rle` and `lzw` compression algorithms.

### Changes Made:
- **RLE (`src/compression/rle.c`)**: Modified the run-length encoding format to safely separate characters from their run counts using a semicolon (`;`) delimiter. `rle_encode` now generates strings like `a1;11;21;` instead of `a11121`, preventing `rle_decode` from erroneously treating data digits as part of run counts.
- **LZW (`src/compression/lzw.c`)**: Fixed the off-by-one synchronization boundary error. Removed a redundant dictionary boundary reset check (`if (dict_size >= LZW_MAX_CODES)`) located immediately after inserting a new code into the dictionary. The encoder now perfectly waits until the subsequent iteration to reset the dictionary without adding the entry, flawlessly synchronizing with the `lzw_decode` logic (`just_reset = true` -> `continue;`).

### Verification:
- Built project via `cmake`.
- Tested using the `test_compression_fuzz` property-based fuzzer, which correctly passed completely without any dictionary desynchronizations or string corruption.
