### PR TITLE
Perf: Dynamic iteration scaling under Valgrind

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
         run: ctest --test-dir build --output-on-failure --verbose
 
       - name: Memory check with valgrind
-        run: cmake --build build --target valgrind
+        run: VALGRIND_MODE=1 cmake --build build --target valgrind
 
       - name: Configure ASan/UBSan build
         run: cmake -S . -B build-asan -DSANITIZE=ON

--- a/features/fuzzy_tester/fuzzer.c
+++ b/features/fuzzy_tester/fuzzer.c
@@ -97,3 +97,13 @@ int fuzzer_rand_int(FuzzerState* fuzzer, int min, int max)
     unsigned int val = (fuzzer->seed / 65536) % 32768;
     return min + (int)(val % (unsigned int)(max - min + 1));
 }
+
+int fuzzer_get_iterations(int default_iterations)
+{
+    const char* valgrind_mode = getenv("VALGRIND_MODE");
+    if (valgrind_mode != NULL && strcmp(valgrind_mode, "1") == 0)
+    {
+        return 20;
+    }
+    return default_iterations;
+}

--- a/features/fuzzy_tester/fuzzer.h
+++ b/features/fuzzy_tester/fuzzer.h
@@ -15,6 +15,7 @@ void fuzzer_free(FuzzerState* fuzzer);
 void fuzzer_log_op(FuzzerState* fuzzer, const char* format, ...);
 void fuzzer_dump_log(const FuzzerState* fuzzer);
 int fuzzer_rand_int(FuzzerState* fuzzer, int min, int max);
+int fuzzer_get_iterations(int default_iterations);
 
 // Shared Fuzz Runners
 void run_bst_fuzz(FuzzerState* fuzzer, int ops);
@@ -39,50 +40,6 @@ void run_cache_fuzz(FuzzerState* fuzzer, int ops);
 void run_hashing_fuzz(FuzzerState* fuzzer, int ops);
 void run_string_fuzz(FuzzerState* fuzzer, int ops);
 void run_dp_fuzz(FuzzerState* fuzzer, int ops);
-
-void fuzzer_demo(void);
-
-#endif // FUZZER_H
-#ifndef FUZZER_H
-#define FUZZER_H
-
-typedef struct
-{
-    unsigned int seed;
-    int current_op;
-    int max_ops;
-    char** op_log;
-    int log_capacity;
-} FuzzerState;
-
-void fuzzer_init(FuzzerState* fuzzer, unsigned int seed, int max_ops);
-void fuzzer_free(FuzzerState* fuzzer);
-void fuzzer_log_op(FuzzerState* fuzzer, const char* format, ...);
-void fuzzer_dump_log(const FuzzerState* fuzzer);
-int fuzzer_rand_int(FuzzerState* fuzzer, int min, int max);
-
-// Shared Fuzz Runners
-void run_bst_fuzz(FuzzerState* fuzzer, int ops);
-void run_avl_fuzz(FuzzerState* fuzzer, int ops);
-void run_trie_fuzz(FuzzerState* fuzzer, int ops);
-
-void run_binomial_fuzz(FuzzerState* fuzzer, int ops);
-void run_fibonacci_fuzz(FuzzerState* fuzzer, int ops);
-void run_minmax_fuzz(FuzzerState* fuzzer, int ops);
-void run_leftist_fuzz(FuzzerState* fuzzer, int ops);
-void run_skew_fuzz(FuzzerState* fuzzer, int ops);
-void run_dary_fuzz(FuzzerState* fuzzer, int ops);
-void run_treap_fuzz(FuzzerState* fuzzer, int ops);
-
-void run_unweighted_graph_fuzz(FuzzerState* fuzzer, int num_nodes, int num_edges);
-void run_weighted_graph_fuzz(FuzzerState* fuzzer, int num_nodes, int num_edges);
-
-void run_sudoku_fuzz(FuzzerState* fuzzer, int runs);
-void run_maze_fuzz(FuzzerState* fuzzer, int runs);
-
-void run_cache_fuzz(FuzzerState* fuzzer, int ops);
-void run_hashing_fuzz(FuzzerState* fuzzer, int ops);
-void run_string_fuzz(FuzzerState* fuzzer, int ops);
 
 void fuzzer_demo(void);
 

--- a/fuzzy_tests/advanced_heaps/test_heaps_fuzz.c
+++ b/fuzzy_tests/advanced_heaps/test_heaps_fuzz.c
@@ -10,13 +10,13 @@ int main(void)
     printf("Starting Heap Fuzzing with seed: %u\n", seed);
 
     fuzzer_init(&fuzzer, seed, 2100);
-    run_binomial_fuzz(&fuzzer, 300);
-    run_fibonacci_fuzz(&fuzzer, 300);
-    run_minmax_fuzz(&fuzzer, 300);
-    run_leftist_fuzz(&fuzzer, 300);
-    run_skew_fuzz(&fuzzer, 300);
-    run_dary_fuzz(&fuzzer, 300);
-    run_treap_fuzz(&fuzzer, 300);
+    run_binomial_fuzz(&fuzzer, fuzzer_get_iterations(300));
+    run_fibonacci_fuzz(&fuzzer, fuzzer_get_iterations(300));
+    run_minmax_fuzz(&fuzzer, fuzzer_get_iterations(300));
+    run_leftist_fuzz(&fuzzer, fuzzer_get_iterations(300));
+    run_skew_fuzz(&fuzzer, fuzzer_get_iterations(300));
+    run_dary_fuzz(&fuzzer, fuzzer_get_iterations(300));
+    run_treap_fuzz(&fuzzer, fuzzer_get_iterations(300));
     fuzzer_free(&fuzzer);
 
     printf("Heap Fuzzing completed successfully!\n");

--- a/fuzzy_tests/advanced_sorting_algorithms/test_advanced_sorting_fuzz.c
+++ b/fuzzy_tests/advanced_sorting_algorithms/test_advanced_sorting_fuzz.c
@@ -23,7 +23,7 @@ void test_advanced_sorting_fuzz(void)
     FuzzerState state;
     fuzzer_init(&state, 1337, 1000);
 
-    int num_iterations = 300;
+    int num_iterations = fuzzer_get_iterations(300);
     int max_len = 100;
 
     for (int iter = 0; iter < num_iterations; iter++)

--- a/fuzzy_tests/backtracking/test_backtracking_fuzz.c
+++ b/fuzzy_tests/backtracking/test_backtracking_fuzz.c
@@ -34,8 +34,8 @@ int main(void)
     }
 
     // Sudoku
-    run_sudoku_fuzz(&fuzzer, 300);
-    run_maze_fuzz(&fuzzer, 300);
+    run_sudoku_fuzz(&fuzzer, fuzzer_get_iterations(300));
+    run_maze_fuzz(&fuzzer, fuzzer_get_iterations(300));
     fuzzer_free(&fuzzer);
     printf("Backtracking Fuzzing completed successfully!\n");
     return 0;

--- a/fuzzy_tests/bit_manipulation/test_bits_fuzz.c
+++ b/fuzzy_tests/bit_manipulation/test_bits_fuzz.c
@@ -1,15 +1,15 @@
+#include "../../features/fuzzy_tester/fuzzer.h"
+
 #include "bit_manipulation.h"
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <time.h>
 
-#define FUZZ_ITERATIONS 300
-
 /* --- set_bit tests --- */
-void test_set_bit_fuzz(void)
+void test_set_bit_fuzz(int iterations)
 {
-    for (int i = 0; i < FUZZ_ITERATIONS; ++i)
+    for (int i = 0; i < iterations; ++i)
     {
         int num = rand();
         if (rand() % 2 == 0)
@@ -34,9 +34,9 @@ void test_set_bit_fuzz(void)
 }
 
 /* --- clear_bit tests --- */
-void test_clear_bit_fuzz(void)
+void test_clear_bit_fuzz(int iterations)
 {
-    for (int i = 0; i < FUZZ_ITERATIONS; ++i)
+    for (int i = 0; i < iterations; ++i)
     {
         int num = rand();
         if (rand() % 2 == 0)
@@ -60,9 +60,9 @@ void test_clear_bit_fuzz(void)
 }
 
 /* --- toggle_bit tests --- */
-void test_toggle_bit_fuzz(void)
+void test_toggle_bit_fuzz(int iterations)
 {
-    for (int i = 0; i < FUZZ_ITERATIONS; ++i)
+    for (int i = 0; i < iterations; ++i)
     {
         int num = rand();
         if (rand() % 2 == 0)
@@ -89,9 +89,9 @@ void test_toggle_bit_fuzz(void)
 }
 
 /* --- check_bit tests --- */
-void test_check_bit_fuzz(void)
+void test_check_bit_fuzz(int iterations)
 {
-    for (int i = 0; i < FUZZ_ITERATIONS; ++i)
+    for (int i = 0; i < iterations; ++i)
     {
         int num = rand();
         if (rand() % 2 == 0)
@@ -114,9 +114,9 @@ void test_check_bit_fuzz(void)
 }
 
 /* --- count_set_bits tests --- */
-void test_count_set_bits_fuzz(void)
+void test_count_set_bits_fuzz(int iterations)
 {
-    for (int i = 0; i < FUZZ_ITERATIONS; ++i)
+    for (int i = 0; i < iterations; ++i)
     {
         int num = rand();
         if (rand() % 2 == 0)
@@ -144,7 +144,7 @@ void test_count_set_bits_fuzz(void)
 }
 
 /* --- is_power_of_two tests --- */
-void test_is_power_of_two_fuzz(void)
+void test_is_power_of_two_fuzz(int iterations)
 {
     // Fuzz with random powers of 2
     for (int i = 0; i < 31; ++i)
@@ -154,7 +154,7 @@ void test_is_power_of_two_fuzz(void)
     }
 
     // Fuzz with random numbers, verify they are not power of 2 unless they actually are
-    for (int i = 0; i < FUZZ_ITERATIONS; ++i)
+    for (int i = 0; i < iterations; ++i)
     {
         int num = rand();
         if (rand() % 2 == 0)
@@ -178,9 +178,9 @@ void test_is_power_of_two_fuzz(void)
 }
 
 /* --- find_unique tests --- */
-void test_find_unique_fuzz(void)
+void test_find_unique_fuzz(int iterations)
 {
-    for (int iter = 0; iter < FUZZ_ITERATIONS; ++iter)
+    for (int iter = 0; iter < iterations; ++iter)
     {
         int pairs = rand() % 50 + 1; // 1 to 50 pairs
         int n = pairs * 2 + 1;
@@ -229,14 +229,15 @@ void test_find_unique_fuzz(void)
 int main(void)
 {
     srand((unsigned int)time(NULL));
+    int iterations = fuzzer_get_iterations(300);
 
-    test_set_bit_fuzz();
-    test_clear_bit_fuzz();
-    test_toggle_bit_fuzz();
-    test_check_bit_fuzz();
-    test_count_set_bits_fuzz();
-    test_is_power_of_two_fuzz();
-    test_find_unique_fuzz();
+    test_set_bit_fuzz(iterations);
+    test_clear_bit_fuzz(iterations);
+    test_toggle_bit_fuzz(iterations);
+    test_check_bit_fuzz(iterations);
+    test_count_set_bits_fuzz(iterations);
+    test_is_power_of_two_fuzz(iterations);
+    test_find_unique_fuzz(iterations);
 
     printf("All Bit Manipulation Fuzz Tests Passed!\n");
 

--- a/fuzzy_tests/cache_simulator/test_cache_hashing_fuzz.c
+++ b/fuzzy_tests/cache_simulator/test_cache_hashing_fuzz.c
@@ -10,8 +10,8 @@ int main(void)
     printf("Starting Cache & Hashing Fuzzing with seed: %u\n", seed);
 
     fuzzer_init(&fuzzer, seed, 600);
-    run_cache_fuzz(&fuzzer, 300);
-    run_hashing_fuzz(&fuzzer, 300);
+    run_cache_fuzz(&fuzzer, fuzzer_get_iterations(300));
+    run_hashing_fuzz(&fuzzer, fuzzer_get_iterations(300));
     fuzzer_free(&fuzzer);
 
     printf("Cache & Hashing Fuzzing completed successfully!\n");

--- a/fuzzy_tests/compression/test_compression_fuzz.c
+++ b/fuzzy_tests/compression/test_compression_fuzz.c
@@ -1,11 +1,11 @@
+#include "../../features/fuzzy_tester/fuzzer.h"
+
 #include "compression.h"
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
-
-#define FUZZ_ITERATIONS 300
 
 // Generate lengths with a distribution weighted towards smaller strings to
 // keep tests fast, but occasionally generate very large ones (10000+ chars).
@@ -58,9 +58,9 @@ static void generate_random_string_no_digits(char* str, int len)
     str[len] = '\0';
 }
 
-static void test_rle_fuzz(void)
+static void test_rle_fuzz(int iterations)
 {
-    for (int i = 0; i < FUZZ_ITERATIONS; ++i)
+    for (int i = 0; i < iterations; ++i)
     {
         int len = get_fuzz_length(10000);
         char* input = malloc((size_t)(len + 1));
@@ -107,9 +107,9 @@ static void test_rle_fuzz(void)
     printf("RLE fuzz tests passed\n");
 }
 
-static void test_huffman_fuzz(void)
+static void test_huffman_fuzz(int iterations)
 {
-    for (int i = 0; i < FUZZ_ITERATIONS; ++i)
+    for (int i = 0; i < iterations; ++i)
     {
         int len = get_fuzz_length(10000);
         if (len == 0)
@@ -160,9 +160,9 @@ static void test_huffman_fuzz(void)
     printf("Huffman fuzz tests passed\n");
 }
 
-static void test_lzw_fuzz(void)
+static void test_lzw_fuzz(int iterations)
 {
-    for (int i = 0; i < FUZZ_ITERATIONS; ++i)
+    for (int i = 0; i < iterations; ++i)
     {
         int len = get_fuzz_length(400); // LZW in this repo has dictionary reset bugs > 500 chars
         if (len == 0)
@@ -195,9 +195,9 @@ static void test_lzw_fuzz(void)
     printf("LZW fuzz tests passed\n");
 }
 
-static void test_bwt_mtf_fuzz(void)
+static void test_bwt_mtf_fuzz(int iterations)
 {
-    for (int i = 0; i < FUZZ_ITERATIONS; ++i)
+    for (int i = 0; i < iterations; ++i)
     {
         // BWT forward is currently O(N^2 log N), limit max length to prevent timeouts
         int len = get_fuzz_length(1500);
@@ -246,11 +246,12 @@ static void test_bwt_mtf_fuzz(void)
 int main(void)
 {
     srand((unsigned int)time(NULL));
+    int iterations = fuzzer_get_iterations(300);
 
-    test_rle_fuzz();
-    test_huffman_fuzz();
-    test_lzw_fuzz();
-    test_bwt_mtf_fuzz();
+    test_rle_fuzz(iterations);
+    test_huffman_fuzz(iterations);
+    test_lzw_fuzz(iterations);
+    test_bwt_mtf_fuzz(iterations);
 
     printf("All compression fuzz tests passed\n");
     return 0;

--- a/fuzzy_tests/dynamic_programming/test_dp_fuzz.c
+++ b/fuzzy_tests/dynamic_programming/test_dp_fuzz.c
@@ -177,8 +177,8 @@ void run_dp_fuzz(FuzzerState* fuzzer, int ops)
 int main(void)
 {
     FuzzerState fuzzer;
-    fuzzer_init(&fuzzer, 42, 300);
-    run_dp_fuzz(&fuzzer, 300);
+    fuzzer_init(&fuzzer, 42, fuzzer_get_iterations(300));
+    run_dp_fuzz(&fuzzer, fuzzer_get_iterations(300));
     fuzzer_free(&fuzzer);
     return 0;
 }

--- a/fuzzy_tests/graph_traversals/test_graphs_fuzz.c
+++ b/fuzzy_tests/graph_traversals/test_graphs_fuzz.c
@@ -14,8 +14,8 @@ int main(void)
     printf("Starting Graph Fuzzing with seed: %u\n", seed);
 
     fuzzer_init(&fuzzer, seed, 600);
-    run_unweighted_graph_fuzz(&fuzzer, 300, 80);
-    run_weighted_graph_fuzz(&fuzzer, 300, 80);
+    run_unweighted_graph_fuzz(&fuzzer, fuzzer_get_iterations(300), 80);
+    run_weighted_graph_fuzz(&fuzzer, fuzzer_get_iterations(300), 80);
     fuzzer_free(&fuzzer);
 
     printf("Graph Fuzzing completed successfully!\n");

--- a/fuzzy_tests/searching_algorithms/test_search_fuzz.c
+++ b/fuzzy_tests/searching_algorithms/test_search_fuzz.c
@@ -1,10 +1,10 @@
+#include "../../features/fuzzy_tester/fuzzer.h"
+
 #include "../../src/searching_algorithms/searching_algorithms.h"
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <time.h>
-
-#define FUZZ_ITERATIONS 300
 
 // Helper function for qsort
 static int compare_ints(const void* a, const void* b)
@@ -80,9 +80,9 @@ static void test_negative_search(int* arr, int len, int target)
     assert(jump_search(arr, target, len) == -1);
 }
 
-static void test_searching_fuzz(void)
+static void test_searching_fuzz(int iterations)
 {
-    for (int i = 0; i < FUZZ_ITERATIONS; ++i)
+    for (int i = 0; i < iterations; ++i)
     {
         int len = get_fuzz_length(10000);
 
@@ -154,8 +154,9 @@ static void test_searching_fuzz(void)
 int main(void)
 {
     srand((unsigned int)time(NULL));
+    int iterations = fuzzer_get_iterations(300);
 
-    test_searching_fuzz();
+    test_searching_fuzz(iterations);
 
     return 0;
 }

--- a/fuzzy_tests/sorting_algorithms_n2/test_sorting_n2_fuzz.c
+++ b/fuzzy_tests/sorting_algorithms_n2/test_sorting_n2_fuzz.c
@@ -36,7 +36,7 @@ static void test_fuzz_n2_sorting(unsigned int seed, int num_runs)
         }
         else
         {
-            n = fuzzer_rand_int(&fuzzer, 2, 300);
+            n = fuzzer_rand_int(&fuzzer, 2, fuzzer_get_iterations(300));
         }
 
         int min_val, max_val;
@@ -127,7 +127,7 @@ int main(void)
     unsigned int seed = (unsigned int)time(NULL);
     printf("Starting O(N^2) Sorting Fuzz Tests with seed: %u\n", seed);
 
-    test_fuzz_n2_sorting(seed, 300);
+    test_fuzz_n2_sorting(seed, fuzzer_get_iterations(300));
 
     printf("All O(N^2) Sorting Fuzz Tests passed successfully!\n");
     return 0;

--- a/fuzzy_tests/string_algorithms/test_string_fuzz.c
+++ b/fuzzy_tests/string_algorithms/test_string_fuzz.c
@@ -97,11 +97,11 @@ int main(void)
 {
     FuzzerState fuzzer;
 
-    // Initialize the fuzzer with a fixed seed and 300 operations
-    fuzzer_init(&fuzzer, 12345, 300);
+    // Initialize the fuzzer with a fixed seed and fuzzer_get_iterations(300) operations
+    fuzzer_init(&fuzzer, 12345, fuzzer_get_iterations(300));
 
     // Run our string algorithms fuzzer
-    run_string_fuzz(&fuzzer, 300);
+    run_string_fuzz(&fuzzer, fuzzer_get_iterations(300));
 
     // Clean up allocated fuzzer memory
     fuzzer_free(&fuzzer);

--- a/fuzzy_tests/trees/test_trees_fuzz.c
+++ b/fuzzy_tests/trees/test_trees_fuzz.c
@@ -12,17 +12,17 @@ int main(void)
 
     printf("--- Running BST Fuzz Tests ---\n");
     fuzzer_init(&fuzzer, seed, 900);
-    run_bst_fuzz(&fuzzer, 300);
+    run_bst_fuzz(&fuzzer, fuzzer_get_iterations(300));
     fuzzer_free(&fuzzer);
 
     printf("\n--- Running AVL Fuzz Tests ---\n");
     fuzzer_init(&fuzzer, seed, 900);
-    run_avl_fuzz(&fuzzer, 300);
+    run_avl_fuzz(&fuzzer, fuzzer_get_iterations(300));
     fuzzer_free(&fuzzer);
 
     printf("\n--- Running Trie Fuzz Tests ---\n");
     fuzzer_init(&fuzzer, seed, 900);
-    run_trie_fuzz(&fuzzer, 300);
+    run_trie_fuzz(&fuzzer, fuzzer_get_iterations(300));
     fuzzer_free(&fuzzer);
 
     printf("Tree Fuzzing completed successfully!\n");


### PR DESCRIPTION
closes #1338
## Description
Fixed the heavy performance bottleneck encountered during the Valgrind memory check phase of the CI pipeline. The fuzzer testing infrastructure has been updated to dynamically scale down iterations to prevent GitHub Actions timeouts without losing rigorous edge-case coverage on standard tests.

### Changes Made:
- **Centralized Logic**: Introduced a helper function `fuzzer_get_iterations(int default_iterations)` in `features/fuzzy_tester/fuzzer.c`. This checks for the `VALGRIND_MODE` environment variable and returns `20` if enabled, or retains the `default_iterations` (`300`) if not.
- **Dynamic Fuzzy Testing**: Replaced all hardcoded `300` iteration targets across the `.c` files in `fuzzy_tests/` with `fuzzer_get_iterations(300)`. This allows test capacities (e.g. `FUZZ_ITERATIONS`) to safely adapt to the environment at runtime.
- **CI Workflow Update**: Configured the memory check step in `.github/workflows/ci.yml` to automatically inject `VALGRIND_MODE=1`.

### Verification:
- Tests successfully format and pass.
- Verified that Valgrind execution time drops to a few seconds, while local and standard CI test steps successfully maintain standard fuzzing configurations (300 iterations).
